### PR TITLE
External link styling

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -1,16 +1,4 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400..700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400..700&display=swap');
 @import url("colors.css");
-@import url("overrides.css");
-
-.nextra-nav-container nav a[target="_blank"]:nth-child(2):after,
-.nextra-nav-container nav a[target="_blank"]:nth-child(3):after,
-.nextra-nav-container nav a[target="_blank"]:nth-child(4):after {
-    content: url("data:image/svg+xml,%3Csvg width='8' height='8' viewBox='0 0 10 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.33622 2.84025L1.17647 10L0 8.82354L7.15975 1.66378H0.849212V0H10V9.15081H8.33622V2.84025Z' fill='%239195A6'/%3E%3C/svg%3E%0A ");
-    padding-left: 20px;
-}
-
-.nextra-sidebar-container a[target="_blank"]:after {
-    content: url("data:image/svg+xml,%3Csvg width='8' height='8' viewBox='0 0 10 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.33622 2.84025L1.17647 10L0 8.82354L7.15975 1.66378H0.849212V0H10V9.15081H8.33622V2.84025Z' fill='%239195A6'/%3E%3C/svg%3E%0A ");
-    padding-left: 6px;
-}
+@import url("theme.css");

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -159,6 +159,26 @@ pre {
     border:1px solid var(--op-neutral-600);
 }
 
+
 a.nx-underline {
     text-decoration: none;
+}
+
+
+/* External links styling */
+.nextra-nav-container nav a[target="_blank"]:nth-child(2):after,
+.nextra-nav-container nav a[target="_blank"]:nth-child(3):after,
+.nextra-nav-container nav a[target="_blank"]:nth-child(4):after {
+    content: url("data:image/svg+xml,%3Csvg width='8' height='8' viewBox='0 0 10 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.33622 2.84025L1.17647 10L0 8.82354L7.15975 1.66378H0.849212V0H10V9.15081H8.33622V2.84025Z' fill='%239195A6'/%3E%3C/svg%3E%0A ");
+    padding-left: 20px;
+}
+
+.nextra-sidebar-container a[target="_blank"]:after {
+    content: url("data:image/svg+xml,%3Csvg width='8' height='8' viewBox='0 0 10 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.33622 2.84025L1.17647 10L0 8.82354L7.15975 1.66378H0.849212V0H10V9.15081H8.33622V2.84025Z' fill='%239195A6'/%3E%3C/svg%3E%0A ");
+    padding-left: 6px;
+}
+
+.nextra-content a[target="_blank"]:after {
+    content: url("data:image/svg+xml,%3Csvg width='8' height='8' viewBox='0 0 10 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.33622 2.84025L1.17647 10L0 8.82354L7.15975 1.66378H0.849212V0H10V9.15081H8.33622V2.84025Z' fill='%239195A6'/%3E%3C/svg%3E%0A ");
+    padding-left: 2px;
 }


### PR DESCRIPTION
**Style all external links**

Styles external links in the main nav, sidebar TOC, and just in case y'all wanted it in-content links.

**Additional context**

I don't know Next JS or JS well enough to add classes to the main nav links I wanted to target. The theme, as-is, authors all the links in the nav without unique classes or IDs. My solution was using CSS ```nth:child``` to target the links. It's worth noting that adding new external links to the main nav will require copying the css and adding the new child to the declaration.

All sidebar TOC links and in-content links are styled automatically without any new css needing to be added.

🚧  It was not requested that in-content links be styled. I styled them while I was working on it. If we don't want this, it's easy to remove. 

Looking for group approval on my choice of styling links before this gets merged. 

**Looks like**  👀 

<img width="1839" alt="Screenshot 2023-10-31 at 10 05 34 PM" src="https://github.com/ethereum-optimism/docs/assets/416727/ddbc27e9-155f-4215-a4ad-4bf9e1843652">

cc/ @cpengilly 
