### PR TITLE
feat: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @cpengilly @OPMattie @sbvegan @zainbacchus @K-Ho @annieke @smartcontracts


### PR DESCRIPTION
Adds a placeholder codeowners file. Currently makes codeowners global but will eventually edit this so that people own specific sub-folders rather than owning the entire repository.