### PR TITLE
Change --beta.op-networks flag to --op-networks

### DIFF
--- a/pages/node-operators/node-operator-guide.mdx
+++ b/pages/node-operators/node-operator-guide.mdx
@@ -91,7 +91,7 @@ CLI Flag Requirements
 
 - `op-node` requires: `--network=op-sepolia`
 - do not set: `--rollup.historicalrpc` or `rollup.historicalrpctimeout`
-- `op-geth` requires: `--beta.op-network=op-sepolia`
+- `op-geth` requires: `--op-network=op-sepolia`
 
 
 </Callout>


### PR DESCRIPTION
This flag is no longer in beta. It will still exist for a period of time, but will likely eventually be removed.

