### PR TITLE
feat: add StepsHeader custom component

### DIFF
--- a/components/steps-header.tsx
+++ b/components/steps-header.tsx
@@ -1,0 +1,21 @@
+import cn from 'clsx'
+import type { ComponentProps, ReactElement } from 'react'
+
+export function StepsHeader({
+  children,
+  className,
+  ...props
+}: ComponentProps<'div'>): ReactElement {
+  return (
+    <h3
+      className={cn(
+        'nx-font-semibold nx-tracking-tight nx-text-slate-900',
+        'dark:nx-text-slate-100 nx-mt-8 nx-text-2xl',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </h3>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@eth-optimism/contracts-ts": "^0.17.0",
     "@eth-optimism/tokenlist": "^9.0.9",
     "@feelback/react": "^0.3.4",
+    "clsx": "^2.0.0",
     "next": "^13.5.6",
     "next-sitemap": "^4.2.3",
     "nextra": "latest",

--- a/pages/builders/dapp-developers/tutorials/cross-dom-bridge-eth.mdx
+++ b/pages/builders/dapp-developers/tutorials/cross-dom-bridge-eth.mdx
@@ -5,6 +5,7 @@ description: Learn how to use the Optimism SDK to transfer ETH between Layer 1 (
 ---
 
 import { Steps, Callout } from 'nextra/components'
+import { StepsHeader } from '@/components/steps-header'
 
 # Bridging ETH with the Optimism SDK
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ dependencies:
   '@feelback/react':
     specifier: ^0.3.4
     version: 0.3.4(react@18.2.0)
+  clsx:
+    specifier: ^2.0.0
+    version: 2.0.0
   next:
     specifier: ^13.5.6
     version: 13.5.6(react-dom@18.2.0)(react@18.2.0)


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Adds a new StepsHeader custom component. The Steps component uses h3 tags for each of the list items which causes the headers to show up in the sidebar. We don't want these items to show up in the sidebar. Comments of an issue in the Nextra GitHub suggest using something that looks like `{<h3>My Header</h3>}` but this is clumsy and confusing. Using a custom tag is much nicer.

Also has the side-effect of setting ourselves up for using other custom tags in the future.