### PR TITLE
feat: add dynamic network info

### DIFF
--- a/components/network.tsx
+++ b/components/network.tsx
@@ -1,0 +1,12 @@
+const networks = {
+  op: {
+    name: 'OP Mainnet',
+    testnet: 'OP Goerli',
+    explorer: 'https://optimistic.etherscan.io',
+    testexplorer: 'https://goerli-optimistic.etherscan.io',
+  }
+}
+
+export const Network = ({ k }) => {
+  return <span>{networks.op[k]}</span>
+}

--- a/pages/differences.mdx
+++ b/pages/differences.mdx
@@ -1,9 +1,10 @@
 import { Callout } from 'nextra/components'
+import { Network } from '@/components/Network'
 
-# Differences between Ethereum and OP Mainnet
+# Differences between Ethereum and <Network k="name" />
 
-It's important to note that there are various minor discrepancies between the behavior of OP Mainnet and Ethereum.
-You should be aware of these descrepancies when building apps on top of OP Mainnet.
+It's important to note that there are various minor discrepancies between the behavior of <Network k="name" /> and Ethereum.
+You should be aware of these descrepancies when building apps on top of <Network k="name" />.
 
 ## Opcode Differences
 
@@ -20,7 +21,7 @@ You should be aware of these descrepancies when building apps on top of OP Mainn
 <Callout type="info"> 
 `tx.origin == msg.sender`:
 On L1 Ethereum `tx.origin` is equal to `msg.sender` only when the smart contract was called directly from an externally owned account (EOA).
-However, on OP Mainnet `tx.origin` is the origin *on OP Mainnet*.
+However, on <Network k="name" /> `tx.origin` is the origin *on <Network k="name" />*.
 It could be an EOA.
 However, in the case of messages from L1, it is possible for a message from a smart contract on L1 to appear on L2 with `tx.origin == msg.sender`.
 This is unlikely to make a significant difference, because an L1 smart contract cannot directly manipulate the L2 state.
@@ -30,7 +31,7 @@ However, there could be edge cases we did not think about where this matters.
 ### Accessing L1 information
 
 If you need the equivalent information from the latest L1 block, you can get it from [the `L1Block` contract](https://github.com/ethereum-optimism/optimism/blob/65ec61dde94ffa93342728d324fecf474d228e1f/packages/contracts-bedrock/contracts/L2/L1Block.sol).
-This contract is a predeploy at address [`0x4200000000000000000000000000000000000015`](https://goerli-optimism.etherscan.io/address/0x4200000000000000000000000000000000000015).
+This contract is a predeploy at address [`0x4200000000000000000000000000000000000015`](https://optimism.etherscan.io/address/0x4200000000000000000000000000000000000015).
 You can use [the getter functions](https://docs.soliditylang.org/en/v0.8.12/contracts.html#getter-functions) to get these parameters:
 
 - `number`: The latest L1 block number known to L2
@@ -56,17 +57,13 @@ The value of `tx.origin` is determined as follows:
 | L1 user (Externally Owned Account) | The user's address (same as in Ethereum)   |
 | L1 contract (using `CanonicalTransactionChain.enqueue`) | `L1_contract_address + 0x1111000000000000000000000000000000001111` |
 
-
 The value of `msg.sender` at the top-level (the very first contract being called) is always equal to `tx.origin`.
 Therefore, if the value of `tx.origin` is affected by the rules defined above, the top-level value of `msg.sender` will also be impacted.
 
 Note that in general, [`tx.origin` should *not* be used for authorization](https://docs.soliditylang.org/en/latest/security-considerations.html#tx-origin). 
 However, that is a separate issue from address aliasing because address aliasing also affects `msg.sender`.
 
-
-
 #### Why is address aliasing an issue?
-
 
 The problem with two identical source addresses (the L1 contract and the L2 contract) is that we extend trust based on the address.
 It is possible that we will want to trust one of the contracts, but not the other.
@@ -92,7 +89,7 @@ It is possible that we will want to trust one of the contracts, but not the othe
    This transaction transfers 1000 DAI from Nimrod's address to Helena Hacker's address.
    If this transaction were to come from the same address as Hackswap on L2, it would be able to transfer the 1000 DAI because of the allowance Nimrod *had* to give Hackswap in the previous step to swap tokens.
    
-   Nimrod, despite his naivete, is protected because OP Mainnet modified the transaction's `tx.origin` (which is also the initial `msg.sender`).
+   Nimrod, despite his naivete, is protected because <Network k="name" /> modified the transaction's `tx.origin` (which is also the initial `msg.sender`).
    That transaction comes from a *different* address, one that does not have the allowance.
 
 **Note:** It is simple to create two different contracts on the same address in different chains. 
@@ -100,13 +97,11 @@ But it is nearly impossible to create two that are different by a specified amou
 
 </details>
 
-
-
 ## Transactions
 
 ### Transaction costs
 
-[Transaction costs on OP Mainnet](/transaction-fees/overview) include an [L2 execution fee](/transaction-fees/overview#the-l2-execution-fee) and an [L1 data fee](/transaction-fees/overview#the-l1-data-fee). 
+[Transaction costs on <Network k="name" />](/transaction-fees/overview) include an [L2 execution fee](/transaction-fees/overview#the-l2-execution-fee) and an [L1 data fee](/transaction-fees/overview#the-l1-data-fee). 
 
 #### EIP-1559
 
@@ -117,7 +112,7 @@ The L2 execution fee is calculated using [EIP-1559](https://notes.ethereum.org/@
 
 The EIP-1559 parameters are different:
 
-  | Parameter | OP Mainnet value | Ethereum value (for reference) |
+  | Parameter | <Network k="name" /> value | Ethereum value (for reference) |
   | - | -: | -: |
   | Block gas limit | 30,000,000 gas | 30,000,000 gas
   | Block gas target | 5,000,000 gas | 15,000,000 gas
@@ -127,8 +122,6 @@ The EIP-1559 parameters are different:
   | Maximum base fee decrease (per block) | 2% | 12.5%
   | Block time in seconds | 2 | 12
 
-
-
 ### Transaction pool (a.k.a. mempool)
 
 As in L1 Ethereum, transactions are stored in a pool until they can be included in a block.
@@ -137,11 +130,9 @@ To submit transactions, you will need to configure `op-geth` to forward transact
 
 The sequencer processes transactions in the mempool in order of their base and priority fees.
 
-
 ## Blocks
 
-There are several differences in the way blocks are produced between L1 Ethereum and OP Mainnet.
-
+There are several differences in the way blocks are produced between L1 Ethereum and <Network k="name" />.
 
 | Parameter           | L1 Ethereum | Optimism Bedrock |
 | - | -: | -: |
@@ -154,18 +145,16 @@ There are several differences in the way blocks are produced between L1 Ethereum
 
 **Note:** The L1 Ethereum parameter values are taken from [ethereum.org](https://ethereum.org/en/developers/docs/blocks/#block-time).
 
-
 ## Network specifications
 
 ### JSON-RPC differences
 
-OP Mainnet uses the same [JSON-RPC API](https://eth.wiki/json-rpc/API) as Ethereum.
-Some additional OP Mainnet specific methods have been introduced.
+<Network k="name" /> uses the same [JSON-RPC API](https://eth.wiki/json-rpc/API) as Ethereum.
+Some additional <Network k="name" /> specific methods have been introduced.
 See the full list of [custom JSON-RPC methods](/node-operators/json-rpc) for more information.
-
 
 ## Contract addresses
 
-The addresses in which various infrastructure contracts are installed are different between L1 Ethereum and OP Mainnet.
+The addresses in which various infrastructure contracts are installed are different between L1 Ethereum and <Network k="name" />.
 For example, [WETH9](https://github.com/gnosis/canonical-weth/blob/master/contracts/WETH9.sol) is installed on L1 Ethereum on [address `0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2`](https://etherscan.io/address/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2). 
-On OP Mainnet the same contract is installed on [address `0x4200000000000000000000000000000000000006`](https://explorer.optimism.io/address/0x4200000000000000000000000000000000000006).
+On <Network k="name" /> the same contract is installed on [address `0x4200000000000000000000000000000000000006`](https://explorer.optimism.io/address/0x4200000000000000000000000000000000000006).

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,11 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "paths": {
+      "@/components/*": ["components/*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Introduces a new Network component which can be used to dynamically load network information like the network name, testnet name, chain ID, etc. Shows off how this works in the differences page. Once pages are more stable we should rework them to use this Network component so that they can be made generic.
