### PR TITLE
fix: remove unnecessary RPC callout

### DIFF
--- a/pages/op-networks.mdx
+++ b/pages/op-networks.mdx
@@ -2,11 +2,6 @@ import { Callout } from 'nextra/components'
 
 # OP Networks and Public RPC Endpoints
 
-<Callout type="warning">
-Some API calls, such as those in the [personal namespace](https://geth.ethereum.org/docs/rpc/ns-personal) make no sense in a shared environment.
-Such RPCs are either totally unsupported, or will return nonsensical values.
-</Callout>
-
 ## OP Mainnet
 
 | Parameter | Value |

--- a/pages/tools/rpc-providers.mdx
+++ b/pages/tools/rpc-providers.mdx
@@ -1,11 +1,4 @@
-import { Callout } from 'nextra/components'
-
 # RPC & Node Providers
-
-<Callout type="warning">
-Some API calls, such as those in the [personal namespace](https://geth.ethereum.org/docs/rpc/ns-personal) make no sense in a shared environment.
-Such RPCs are either totally unsupported, or will return nonsensical values.
-</Callout>
 
 ## Ankr
 


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Removes a Callout from the RPC pages that wasn't necessary. This is not unique to OP Mainnet, this is just a fact that is generally true for all public RPCs.
