### PR TITLE
fix: make link check workflow quiet

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Run Lychee
       run: |
         cd docs
-        lychee --config ./lychee.toml "./pages"
+        lychee --config ./lychee.toml --quiet "./pages"
 
     - name: Notify Slack on failure
       uses: ravsamhq/notify-slack-action@v2


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Adds the quiet flag to the lychee command so that the output is less verbose. Much nicer when reviewing workflow output.

