### PR TITLE
Design tweaks

### DIFF
--- a/styles/theme.css
+++ b/styles/theme.css
@@ -125,7 +125,7 @@
 }
 
 code,kbd,samp,pre {
-    font-family:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace;
+    font-family:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace !important;
     font-size:1rem;
     font-weight:420;
 }

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -6,10 +6,6 @@
         font-weight: 700;
     }
 
-    .nx-leading-7 {
-        line-height: 1.6;
-    }
-
     .nx-rounded-xl {
         border-radius: 5px;
     }
@@ -179,7 +175,7 @@ h4 {
 
 /* Callouts */
 .nextra-callout svg {
-    margin-top: 2px;
+    /* margin-top: 4px; */
 }
 
 /* Customize code styles to match Optimism */

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -177,6 +177,10 @@ h4 {
     color: var(--op-neutral-300) !important;
 }
 
+/* Callouts */
+.nextra-callout svg {
+    margin-top: 2px;
+}
 
 /* Customize code styles to match Optimism */
 code,kbd,samp,pre {

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -128,9 +128,14 @@
     
 }
 
-code,kbd,samp,pre {
-    font-family:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace !important;
-    font-weight:420 !important;
+/* Main nav */
+nav a span {
+    font-weight: 600;
+}
+
+/* Links */
+a.nx-underline {
+    text-decoration: none;
 }
 
 
@@ -147,14 +152,20 @@ h4 {
     font-size: 1rem !important;
 }
 
+
 /* Override Nextra for headings in-content */
+.nextra-content h1 {
+    margin-top: 1.5rem;
+}
+
 .nextra-content h2 ~ p {
     margin-top: .5rem;
 }
 
 .nextra-content h3 ~ p {
-    margin-top: .1rem;
+    margin-top: .3rem;
 }
+
 
 /* Restyle Nextra Steps */
 .nextra-steps h3:before {
@@ -166,8 +177,11 @@ h4 {
     color: var(--op-neutral-300) !important;
 }
 
-nav a span {
-    font-weight: 600;
+
+/* Customize code styles to match Optimism */
+code,kbd,samp,pre {
+    font-family:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace !important;
+    font-weight:420 !important;
 }
 
 code {
@@ -185,11 +199,6 @@ pre {
 
 :is(html[class~=dark]) pre {
     border:1px solid var(--op-neutral-600);
-}
-
-
-a.nx-underline {
-    text-decoration: none;
 }
 
 
@@ -217,6 +226,7 @@ a.nx-underline {
 table tr {
     background-color: transparent !important;
 }
+
 
 /* Feedback Widget */
 

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -2,7 +2,10 @@
     font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
     font-weight: 440;
 
-    
+    .nx-font-semibold {
+        font-weight: 700;
+    }
+
     .nx-leading-7 {
         line-height: 1.6;
     }
@@ -122,6 +125,7 @@
     .nx-bg-primary-700\/5 {
         background-color:var(--op-neutral-100);
     }
+    
 }
 
 code,kbd,samp,pre {

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -162,6 +162,27 @@ h4 {
     margin-top: .3rem;
 }
 
+/* Set colors for common text elements */
+p, table, ol, ul {
+    color: var(--op-neutral-800);
+}
+
+:is(html[class~=dark]) p {
+    color: var(--op-neutral-200);
+}
+
+:is(html[class~=dark]) table {
+    color: var(--op-neutral-200);
+}
+
+:is(html[class~=dark]) ol {
+    color: var(--op-neutral-200);
+}
+
+:is(html[class~=dark]) ul {
+    color: var(--op-neutral-200);
+}
+
 
 /* Restyle Nextra Steps */
 .nextra-steps h3:before {

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -124,6 +124,7 @@
     
 }
 
+
 /* Main nav */
 nav a span {
     font-weight: 600;
@@ -162,6 +163,7 @@ h4 {
     margin-top: .3rem;
 }
 
+
 /* Set colors for common text elements */
 p, table, ol, ul {
     color: var(--op-neutral-800);
@@ -194,10 +196,12 @@ p, table, ol, ul {
     color: var(--op-neutral-300) !important;
 }
 
+
 /* Callouts */
 .nextra-callout svg {
     /* margin-top: 4px; */
 }
+
 
 /* Customize code styles to match Optimism */
 code,kbd,samp,pre {
@@ -243,14 +247,12 @@ pre {
 
 
 /* Tables */ 
-
 table tr {
     background-color: transparent !important;
 }
 
 
 /* Feedback Widget */
-
 .feelback-container {
     padding-top: .1em;
 }
@@ -305,7 +307,6 @@ table tr {
     margin-top: 1.5em;
 }
 
-
-  :is(html[class~=dark]) .nextra-toc .divider {
+:is(html[class~=dark]) .nextra-toc .divider {
     border-top: 1px solid var(--op-neutral-700);
 } 

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -137,6 +137,22 @@ h2 {
     border: none;
 }
 
+h3 {
+    font-size: 20px !important;
+}
+
+h4 {
+    font-size: 1rem !important;
+}
+
+.nextra-content h2 ~ p {
+    margin-top: .5rem;
+}
+
+.nextra-content h3 ~ p {
+    margin-top: .1rem;
+}
+
 nav a span {
     font-weight: 600;
 }

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -142,7 +142,7 @@ h2 {
 }
 
 h3 {
-    font-size: 20px !important;
+    font-size: 1.25rem !important;
 }
 
 h4 {
@@ -156,7 +156,7 @@ h4 {
 }
 
 .nextra-content h2 ~ p {
-    margin-top: .7rem;
+    margin-top: .3rem
 }
 
 .nextra-content h3 ~ p {

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -228,6 +228,7 @@ pre {
 
 
 /* External links styling */
+/* Style nav external links */
 .nextra-nav-container nav a[target="_blank"]:nth-child(2):after,
 .nextra-nav-container nav a[target="_blank"]:nth-child(3):after,
 .nextra-nav-container nav a[target="_blank"]:nth-child(4):after {
@@ -235,14 +236,17 @@ pre {
     padding-left: 20px;
 }
 
+/* sidebar external links */
 .nextra-sidebar-container a[target="_blank"]:after {
     content: url("data:image/svg+xml,%3Csvg width='8' height='8' viewBox='0 0 10 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.33622 2.84025L1.17647 10L0 8.82354L7.15975 1.66378H0.849212V0H10V9.15081H8.33622V2.84025Z' fill='%239195A6'/%3E%3C/svg%3E%0A ");
     padding-left: 6px;
 }
 
+/* in-content external links */
 .nextra-content a[target="_blank"]:after {
-    content: url("data:image/svg+xml,%3Csvg width='8' height='8' viewBox='0 0 10 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.33622 2.84025L1.17647 10L0 8.82354L7.15975 1.66378H0.849212V0H10V9.15081H8.33622V2.84025Z' fill='%239195A6'/%3E%3C/svg%3E%0A ");
-    padding-left: 2px;
+    content: url('data:image/svg+xml,<svg width="8" height="8" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8.33622 2.84025L1.17647 10L0 8.82354L7.15975 1.66378H0.849212V0H10V9.15081H8.33622V2.84025Z" fill="%233374DB"/></svg>');
+    padding-left: 5px;
+    margin-right: 2px;
 }
 
 

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -155,7 +155,7 @@ h4 {
 }
 
 .nextra-content h2 ~ p {
-    margin-top: .5rem;
+    margin-top: .7rem;
 }
 
 .nextra-content h3 ~ p {

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -133,6 +133,8 @@ code,kbd,samp,pre {
     font-weight:420 !important;
 }
 
+
+/* Headings */
 h2 {
     border: none;
 }
@@ -145,12 +147,23 @@ h4 {
     font-size: 1rem !important;
 }
 
+/* Override Nextra for headings in-content */
 .nextra-content h2 ~ p {
     margin-top: .5rem;
 }
 
 .nextra-content h3 ~ p {
     margin-top: .1rem;
+}
+
+/* Restyle Nextra Steps */
+.nextra-steps h3:before {
+    margin-top: -1px !important;
+    color: var(--op-neutral-600) !important;
+}
+
+:is(html[class~=dark]) .nextra-steps h3:before {
+    color: var(--op-neutral-300) !important;
 }
 
 nav a span {

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -130,8 +130,7 @@
 
 code,kbd,samp,pre {
     font-family:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace !important;
-    font-size:1rem;
-    font-weight:420;
+    font-weight:420 !important;
 }
 
 h2 {


### PR DESCRIPTION
Fixes a few smaller details and cleans up the CSS a little. The PR:

- Makes sure JetBrains Mono is used for all code
- Makes sure headings are bole
- Makes external link arrow icon blue in-content 
- Better spacing for external links in-content
- Nicer Heading spacing (more for h1, less for h2, h3). Articles flow a bit better
- fix alignment for emoji in Nextra Callouts
- Body copy is 800 color now, a little more contrast


Looks like 👀 : 

<img width="1720" alt="Screenshot 2023-11-16 at 3 12 47 PM" src="https://github.com/ethereum-optimism/docs/assets/416727/b7dcac60-61b7-4293-9801-27c2cc734f55">
