### PR TITLE
fix: move sepolia into separate section

### DIFF
--- a/pages/addresses.mdx
+++ b/pages/addresses.mdx
@@ -13,7 +13,7 @@ import { L2ContractTable } from '@/components/L2ContractTable'
 
 <L2ContractTable chain="10" />
 
-## Testnet
+## Testnet (Sepolia)
 
 ### Sepolia (L1)
 
@@ -22,6 +22,8 @@ import { L2ContractTable } from '@/components/L2ContractTable'
 ### OP Sepolia (L2)
 
 <L2ContractTable chain="11155420" />
+
+## Testnet (Goerli)
 
 ### Goerli (L1)
 


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Moves the Sepolia addresses in addresses.mdx into a distinct section. A little more clear for users.