### PR TITLE
fix: moderate => medium difficulty

### DIFF
--- a/pages/builders/chain-operators/chain-operator-overview.mdx
+++ b/pages/builders/chain-operators/chain-operator-overview.mdx
@@ -35,7 +35,7 @@ They'll help you get a headstart deploying your first OP Stack chain.
 
 | Tutorial Name | Description | Difficulty Level | 
 | ------------- | ----------- | -----------------|
-| [Creating Your Own L2 Rollup](tutorials/create-l2-rollup) | Learn how to spin up your own OP Stack testnet chain | 🟡 Moderate |
+| [Creating Your Own L2 Rollup](tutorials/create-l2-rollup) | Learn how to spin up your own OP Stack testnet chain | 🟡 Medium |
 | [Using the OP Stack Client SDK](tutorials/sdk) | Learn how to use the OP Stack Client SDK when working with native and non-native supported chains. | 🟢 Easy |
 | [Adding Attributes to the Derivation Function](tutorials/adding-derivation-attributes) | Learn how to modify the derivation function for an OP Stack chain to track the amount of ETH being burned on L1. | 🟢 Easy |
 | [Adding a Precompile](tutorials/adding-precompiles) | Learn how to run an EVM with a new precompile for OP Stack chain operations to speed up calculations that are not currently supported. | 🟢 Easy |

--- a/pages/builders/dapp-developers/dapp-developer-overview.mdx
+++ b/pages/builders/dapp-developers/dapp-developer-overview.mdx
@@ -38,8 +38,8 @@ They'll help you get a headstart when building your first Optimistic project.
 | [Using OP Mainnet System Contracts](tutorials/system-contracts) | Learn how to work with OP Mainnet contracts directly from other contracts *and* how to work with contracts from the client side. | 🟢 Easy |
 | [Bridging ETH with the Optimism SDK](tutorials/cross-dom-bridge-eth) | Learn how to use the Optimism SDK to transfer ETH between Layer 1 (Ethereum or Goerli) and Layer 2 (OP Mainnet or OP Goerli). | 🟢 Easy |
 | [Bridging ERC-20 tokens with the Optimism SDK](tutorials/cross-dom-bridge-erc20) | Learn how to use the Optimism SDK to transfer ERC-20 tokens between Layer 1 (Ethereum or Goerli) and Layer 2 (OP Mainnet or OP Goerli). | 🟢 Easy |
-| [Bridging your Standard ERC-20 token to OP Mainnet using the Standard Bridge](tutorials/standard-bridge-standard-token) | Learn how to bridge your standard ERC-20 token to OP Mainnet using the standard bridge. | 🟡 Moderate |
-| [Bridging your Custom ERC-20 token to OP Mainnet using the Standard Bridge](tutorials/standard-bridge-custom-token) | Learn how to bridge your custom ERC-20 token to OP Mainnet using the standard bridge. | 🟡 Moderate |
+| [Bridging your Standard ERC-20 token to OP Mainnet using the Standard Bridge](tutorials/standard-bridge-standard-token) | Learn how to bridge your standard ERC-20 token to OP Mainnet using the standard bridge. | 🟡 Medium |
+| [Bridging your Custom ERC-20 token to OP Mainnet using the Standard Bridge](tutorials/standard-bridge-custom-token) | Learn how to bridge your custom ERC-20 token to OP Mainnet using the standard bridge. | 🟡 Medium |
 
 You can also [suggest a new tutorial](https://github.com/ethereum-optimism/docs/issues/new?assignees=&labels=tutorial%2Cdocumentation%2Ccommunity-request&projects=&template=suggest_tutorial.yaml&title=%5BTUTORIAL%5D+Add+PR+title) if you have something specific in mind. We'd love to grow this list! 
 

--- a/pages/builders/node-operators/node-operator-overview.mdx
+++ b/pages/builders/node-operators/node-operator-overview.mdx
@@ -46,8 +46,8 @@ They'll help you get a headstart deploying your first OP node.
 | Tutorial Name | Description | Difficulty Level | 
 | ------------- | ----------- | -----------------|
 | [Building a Node From Source](tutorials/node-from-source) | Learn how to build your own node without relying on images from Optimism. | 🟢 Easy |
-| [Running OP Mainnet from Source](tutorials/mainnet) | Learn how to run a node from source using OP Mainnet. | 🟡 Moderate |
-| [Running OP Testnet from Source](tutorials/testnet) | Learn how to run a node from source using OP Testnet. | 🟡 Moderate |
+| [Running OP Mainnet from Source](tutorials/mainnet) | Learn how to run a node from source using OP Mainnet. | 🟡 Medium |
+| [Running OP Testnet from Source](tutorials/testnet) | Learn how to run a node from source using OP Testnet. | 🟡 Medium |
 
 You can also [suggest a new tutorial](https://github.com/ethereum-optimism/docs/issues/new?assignees=&labels=tutorial%2Cdocumentation%2Ccommunity-request&projects=&template=suggest_tutorial.yaml&title=%5BTUTORIAL%5D+Add+PR+title) if you have something specific in mind. We'd love to grow this list!
 


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Changes "moderate" to "medium" in the difficulty level column for tutorials. Just looks slightly cleaner because moderate gets thrown on a separate line.