### PR TITLE
fix: move tutorials under overview always

### DIFF
--- a/pages/builders/chain-operators/_meta.json
+++ b/pages/builders/chain-operators/_meta.json
@@ -1,8 +1,8 @@
 {
     "chain-operator-overview": "Overview",
+    "tutorials": "Tutorials",
     "configuration": "Chain Configuration",
     "operations": "Rollup Operations",
-    "tutorials": "Tutorials",
     "hacks": "OP Stack Hacks",
     "explorer": "Explorer and Indexer",
     "chain-troubleshooting": "Chain Troubleshooting"

--- a/pages/builders/dapp-developers/_meta.json
+++ b/pages/builders/dapp-developers/_meta.json
@@ -1,9 +1,9 @@
 {
     "dapp-developer-overview": "Overview",
+    "tutorials": "Tutorials",
     "bridging": "Bridging Domains",
     "contracts": "Contracts",
     "creating-a-nft": "Creating an NFT",
-    "tutorials": "Tutorials",
     "testing": "Testing Your Dapp",
     "troubleshooting": "Troubleshooting Transactions"
 }

--- a/pages/builders/node-operators/_meta.json
+++ b/pages/builders/node-operators/_meta.json
@@ -1,9 +1,9 @@
 {
     "node-operator-overview": "Overview",
+    "tutorials": "Tutorials",
     "configuration": "Node Configuration",
     "data-directories": "Data Directories",
     "json-rpc": "JSON-RPC",
     "metrics": "Node Monitoring",
-    "tutorials": "Tutorials",
     "node-troubleshooting": "Node Troubleshooting"
 }


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Puts the "tutorials" section underneath the "overview" section everywhere. More consistent and easier to find.