### PR TITLE
fix: patch nextra children view bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   "pnpm": {
     "patchedDependencies": {
       "remark-lint-frontmatter-schema@3.15.4": "patches/remark-lint-frontmatter-schema@3.15.4.patch",
-      "remark-code-import@1.2.0": "patches/remark-code-import@1.2.0.patch"
+      "remark-code-import@1.2.0": "patches/remark-code-import@1.2.0.patch",
+      "nextra@2.13.2": "patches/nextra@2.13.2.patch"
     }
   }
 }

--- a/patches/nextra@2.13.2.patch
+++ b/patches/nextra@2.13.2.patch
@@ -1,0 +1,21 @@
+diff --git a/dist/normalize-pages.js b/dist/normalize-pages.js
+index db97af203d09cdab91be98d520efa82451b5bfc3..87b36b81df6ea55ca4326c99c927a7ed4e0b2501 100644
+--- a/dist/normalize-pages.js
++++ b/dist/normalize-pages.js
+@@ -273,8 +273,14 @@ function normalizePages({
+     }
+     if (type === "doc" && display === "children") {
+       if (docsItem.children) {
+-        directories.push(...docsItem.children);
+-        docsDirectories.push(...docsItem.children);
++        const children = docsItem.children.map((child) => {
++          return {
++            ...child,
++            name: `${docsItem.name}-${child.name}`,
++          }
++        })
++        directories.push(...children);
++        docsDirectories.push(...children);
+       }
+     } else {
+       directories.push(item);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
+  nextra@2.13.2:
+    hash: a4rp2hgojklggjmthmkiyqaek4
+    path: patches/nextra@2.13.2.patch
   remark-code-import@1.2.0:
     hash: heylvfasxh3ubj2edns2svea2m
     path: patches/remark-code-import@1.2.0.patch
@@ -30,7 +33,7 @@ dependencies:
     version: 4.2.3(next@13.5.6)
   nextra:
     specifier: latest
-    version: 2.13.2(next@13.5.6)(react-dom@18.2.0)(react@18.2.0)
+    version: 2.13.2(patch_hash=a4rp2hgojklggjmthmkiyqaek4)(next@13.5.6)(react-dom@18.2.0)(react@18.2.0)
   nextra-theme-docs:
     specifier: latest
     version: 2.13.2(next@13.5.6)(nextra@2.13.2)(react-dom@18.2.0)(react@18.2.0)
@@ -4563,14 +4566,14 @@ packages:
       next: 13.5.6(react-dom@18.2.0)(react@18.2.0)
       next-seo: 6.4.0(next@13.5.6)(react-dom@18.2.0)(react@18.2.0)
       next-themes: 0.2.1(next@13.5.6)(react-dom@18.2.0)(react@18.2.0)
-      nextra: 2.13.2(next@13.5.6)(react-dom@18.2.0)(react@18.2.0)
+      nextra: 2.13.2(patch_hash=a4rp2hgojklggjmthmkiyqaek4)(next@13.5.6)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scroll-into-view-if-needed: 3.1.0
       zod: 3.22.4
     dev: false
 
-  /nextra@2.13.2(next@13.5.6)(react-dom@18.2.0)(react@18.2.0):
+  /nextra@2.13.2(patch_hash=a4rp2hgojklggjmthmkiyqaek4)(next@13.5.6)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-pIgOSXNUqTz1laxV4ChFZOU7lzJAoDHHaBPj8L09PuxrLKqU1BU/iZtXAG6bQeKCx8EPdBsoXxEuENnL9QGnGA==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -4610,6 +4613,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+    patched: true
 
   /no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Patches a bug in Nextra that breaks things when using the "display": "children" option for multiple folders where those folders have contents with the same name.
