### PR TITLE
feat: remove network variable from dapp overview

### DIFF
--- a/pages/builders/dapp-developers/overview.mdx
+++ b/pages/builders/dapp-developers/overview.mdx
@@ -4,44 +4,42 @@ lang: en-US
 description: Learn about deploying contracts, cross-chain messaging, and tutorials to help you build applications for Optimism.
 ---
 
-import { network } from '@/utils/networks'
-
 # Dapp Developer Overview
 
-This document provides an overview of tools and resources to help you build applications for {network.mainnet.l2.name}. It points you to guides on basic contract deployment, cross-chain messaging, and [Dapp developer tutorials](#dapp-developer-tutorials).
-If you're looking for third-party tools that make building apps on {network.mainnet.l2.name} easier, check out the [Developer Tools](/builders/tools/overview) section.
+This document provides an overview of tools and resources to help you build applications for OP Mainnet. It points you to guides on basic contract deployment, cross-chain messaging, and [Dapp developer tutorials](#dapp-developer-tutorials).
+If you're looking for third-party tools that make building apps on OP Mainnet easier, check out the [Developer Tools](/builders/tools/overview) section.
 
 ## Getting Started
 
-If you're brand new to {network.mainnet.l2.name}, try starting with the guide on [deploying a basic contract](/chain/getting-started).
+If you're brand new to OP Mainnet, try starting with the guide on [deploying a basic contract](/chain/getting-started).
 It'll get you familiar with the core steps required to get a contract deployed to the network.
-Luckily, {network.mainnet.l2.name} is [EVM equivalent](https://medium.com/ethereum-optimism/introducing-evm-equivalence-5c2021deb306), so it's similar to deploying a contract to {network.mainnet.l1.name} with a [few small differences](/chain/differences).
+Luckily, OP Mainnet is [EVM equivalent](https://medium.com/ethereum-optimism/introducing-evm-equivalence-5c2021deb306), so it's similar to deploying a contract to Ethereum with a [few small differences](/chain/differences).
 
-You might also want to check out the [testing on OP Networks guide](/chain/testing/testing-dapps) and the tutorial on [running a local development environment](/chain/testing/dev-node) to help you feel totally confident in your {network.mainnet.l2.name} deployment.
+You might also want to check out the [testing on OP Networks guide](/chain/testing/testing-dapps) and the tutorial on [running a local development environment](/chain/testing/dev-node) to help you feel totally confident in your OP Mainnet deployment.
 
 ## Cross-Chain Messaging
 
 Looking to explore cross-chain messaging? Here are some detailed guides for that.
-If you want to bridge a token from {network.mainnet.l1.name} to {network.mainnet.l2.name} (or vice versa!), you should check out the [Standard Token Bridge](bridging/standard-bridge).
+If you want to bridge a token from Ethereum to OP Mainnet (or vice versa!), you should check out the [Standard Token Bridge](bridging/standard-bridge).
 The Standard Token Bridge makes the process of moving tokens between chains as easy as possible.
 
 If you're looking for something more advanced, take a look at the guide on [sending data between L1 and L2](bridging/messaging).
 Contracts on one chain can trigger contract functions on the other chain, it's pretty cool!
-The Standard Token Bridge for {network.mainnet.l2.name} even uses this same message-passing infrastructure under the hood.
+The Standard Token Bridge for OP Mainnet even uses this same message-passing infrastructure under the hood.
 
 ## Dapp Developer Tutorials
 
-If you're a bit more familiar with {network.mainnet.l2.name} and {network.mainnet.l1.name}, you can try walking through one of the tutorials put together by the Optimism community.
+If you're a bit more familiar with OP Mainnet and Ethereum, you can try walking through one of the tutorials put together by the Optimism community.
 They'll help you get a headstart when building your first Optimistic project.
 
-| Tutorial Name                                                                                                                          | Description                                                                                                                                                                                                | Difficulty Level |
-| -------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| [Writing Your First Contract on Optimism](tutorials/first-contract)                                                                    | Learn how to write your first contact on Optimism using MetaMask browser extension as a wallet.                                                                                                            | 🟢 Easy          |
-| [Using {network.mainnet.l2.name} System Contracts](tutorials/system-contracts)                                                         | Learn how to work with {network.mainnet.l2.name} contracts directly from other contracts *and* how to work with contracts from the client side.                                                            | 🟢 Easy          |
-| [Bridging ETH with the Optimism SDK](tutorials/cross-dom-bridge-eth)                                                                   | Learn how to use the Optimism SDK to transfer ETH between Layer 1 ({network.mainnet.l1.name} or {network.testnet.l1.name}) and Layer 2 ({network.mainnet.l2.name} or {network.testnet.l2.name}).           | 🟢 Easy          |
-| [Bridging ERC-20 tokens with the Optimism SDK](tutorials/cross-dom-bridge-erc20)                                                       | Learn how to use the Optimism SDK to transfer ERC-20 tokens between Layer 1 ({network.mainnet.l1.name} or {network.testnet.l1.name}) and Layer 2 ({network.mainnet.l2.name} or {network.testnet.l2.name}). | 🟢 Easy          |
-| [Bridging your Standard ERC-20 token to {network.mainnet.l2.name} using the Standard Bridge](tutorials/standard-bridge-standard-token) | Learn how to bridge your standard ERC-20 token to {network.mainnet.l2.name} using the standard bridge.                                                                                                     | 🟡 Medium        |
-| [Bridging your Custom ERC-20 token to {network.mainnet.l2.name} using the Standard Bridge](tutorials/standard-bridge-custom-token)     | Learn how to bridge your custom ERC-20 token to {network.mainnet.l2.name} using the standard bridge.                                                                                                       | 🟡 Medium        |
+| Tutorial Name                                                                                                           | Description                                                                                                                               | Difficulty Level |
+| ----------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| [Writing Your First Contract on Optimism](tutorials/first-contract)                                                     | Learn how to write your first contact on Optimism using MetaMask browser extension as a wallet.                                           | 🟢 Easy          |
+| [Using OP Mainnet System Contracts](tutorials/system-contracts)                                                         | Learn how to work with OP Mainnet contracts directly from other contracts *and* how to work with contracts from the client side.          | 🟢 Easy          |
+| [Bridging ETH with the Optimism SDK](tutorials/cross-dom-bridge-eth)                                                    | Learn how to use the Optimism SDK to transfer ETH between Layer 1 (Ethereum or Sepolia) and Layer 2 (OP Mainnet or OP Sepolia).           | 🟢 Easy          |
+| [Bridging ERC-20 tokens with the Optimism SDK](tutorials/cross-dom-bridge-erc20)                                        | Learn how to use the Optimism SDK to transfer ERC-20 tokens between Layer 1 (Ethereum or Sepolia) and Layer 2 (OP Mainnet or OP Sepolia). | 🟢 Easy          |
+| [Bridging your Standard ERC-20 token to OP Mainnet using the Standard Bridge](tutorials/standard-bridge-standard-token) | Learn how to bridge your standard ERC-20 token to OP Mainnet using the standard bridge.                                                   | 🟡 Medium        |
+| [Bridging your Custom ERC-20 token to OP Mainnet using the Standard Bridge](tutorials/standard-bridge-custom-token)     | Learn how to bridge your custom ERC-20 token to OP Mainnet using the standard bridge.                                                     | 🟡 Medium        |
 
 You can also [suggest a new tutorial](https://github.com/ethereum-optimism/docs/issues/new?assignees=\&labels=tutorial%2Cdocumentation%2Ccommunity-request\&projects=\&template=suggest_tutorial.yaml\&title=%5BTUTORIAL%5D+Add+PR+title) if you have something specific in mind. We'd love to grow this list!
 


### PR DESCRIPTION
Removes the "network" variable from the dapp developer overview page. A bug in Nextra causes issues when putting variables inside frontmatter and headers. Will explore adding this back in later.

