### PR TITLE
feat: no smartquotes plugin

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -1,5 +1,8 @@
-{
-  "plugins": [
+import remarkLintNoSmartQuotes from './utils/plugins/remark/remark-lint-no-smart-quotes.mjs'
+
+export default {
+  plugins: [
+    remarkLintNoSmartQuotes,
     "remark-gfm",
     "remark-frontmatter",
     "remark-preset-lint-consistent",
@@ -18,7 +21,7 @@
     [
       "remark-lint-frontmatter-schema",
       {
-        "schemas": {
+        schemas: {
           "./utils/schemas/page.schema.yaml": [
             "./pages/**/*.mdx"
           ]
@@ -27,3 +30,4 @@
     ]
   ]
 }
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ You can now start changing content and see the website updated live each time yo
 
 To prevent building issues upstream, you should build the content locally before submitting a pull request: stop or delete the terminal server if it's running, then run `pnpm dev`.
 
-- If no issues are reported (”client” and “server compiled successfully”), go ahead and submit the pull request. 
+- If no issues are reported ("client"and "server compiled successfully"), go ahead and submit the pull request. 
 - If some issues are reported (e.g., broken links), please use information reported by the terminal to fix issues. You can run `pnpm fix` to automatically fix most linting issues.
 - Try another `pnpm dev` and repeat until no issues are reported.
 
@@ -71,9 +71,9 @@ To submit your contribution for review:
 1. Create a new [pull request on GitHub](https://github.com/ethereum-optimism/docs/issues/new/choose).
 2. Select a PR type from the list or choose **Open a blank isssue** at the bottom of the page.
 3. Complete the form as requested. For blank PR issues, please provide a clear title and accurate description/context.
-4. Click the “Create pull request” button to create the pull request effectively.
+4. Click the "Create pull request"button to create the pull request effectively.
     
->If your pull request is not ready for review yet, choose the “[Create draft pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)” in the dropdown. The Optimism documentation team will review your pull request only when you mark it as “[Ready for review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request)”.
+>If your pull request is not ready for review yet, choose the "[Create draft pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)"in the dropdown. The Optimism documentation team will review your pull request only when you mark it as "[Ready for review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request)".
    
 5. Add GitHub labels for the pull request. Add `documentation` to all pull requests in this repo **AND** additional labels based on the type of update or request.
      - `tutorial`, `faq`, or `troubleshooting` for specific content types, 
@@ -85,7 +85,7 @@ To submit your contribution for review:
 **Warning**
 Approved pull requests are usually merged immediately into the `main` branch, automatically triggering a deployment on docs.optimism.io. Please add the `flag:merge-pending-release` label if the pull request content should only be released publicly in sync with a product release.
 
-That’s it! 🥳 Once the pull request is [reviewed and approved](#review-and-management-of-pull-requests), the Optimism Documentation team will merge it, and the content will be live on [docs.optimism.io](http://docs.optimism.io) a few minutes later. 🚀
+That's it! 🥳 Once the pull request is [reviewed and approved](#review-and-management-of-pull-requests), the Optimism Documentation team will merge it, and the content will be live on [docs.optimism.io](http://docs.optimism.io) a few minutes later. 🚀
 
 ## Review and Management of Pull Requests
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "remark-lint-unordered-list-marker-style": "^3.1.2",
     "remark-preset-lint-consistent": "^5.1.2",
     "remark-preset-lint-recommended": "^6.1.3",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "unified-lint-rule": "^2.1.2",
+    "unist-util-visit": "^5.0.0"
   },
   "pnpm": {
     "patchedDependencies": {

--- a/pages/builders/chain-operators/configuration.mdx
+++ b/pages/builders/chain-operators/configuration.mdx
@@ -8,12 +8,12 @@ import { Callout } from 'nextra/components'
 
 # Chain Configuration
 
-The OP Stack is a flexible platform with various configuration values that you can tweak to fit your specific needs. If you’re looking to fine-tune your OP Stack chain deployment, look no further.
+The OP Stack is a flexible platform with various configuration values that you can tweak to fit your specific needs. If you're looking to fine-tune your OP Stack chain deployment, look no further.
 
 <Callout type="warning">
   Work in Progress
 
-  OP Stack configuration is an active work in progress and will likely evolve significantly as time goes on. If something isn’t working about your configuration, check back with this page to see if anything has changed.
+  OP Stack configuration is an active work in progress and will likely evolve significantly as time goes on. If something isn't working about your configuration, check back with this page to see if anything has changed.
 </Callout>
 
 ## New Blockchain Configuration

--- a/pages/builders/chain-operators/hacks/derivation.mdx
+++ b/pages/builders/chain-operators/hacks/derivation.mdx
@@ -30,11 +30,11 @@ Modifying the Derivation layer can have unintended consequences. For example, re
 
 ### EVM Event-Triggered Transactions
 
-The default Rollup configuration of the OP Stack includes “deposited” transactions that are triggered whenever a specific event is emitted by the `OptimismPortal` contract on L1. Using the same principle, an OP Stack chain can derive transactions from events emitted by *any* contract on an EVM-based DA. Refer to [attributes.go](https://github.com/ethereum-optimism/optimism/blob/e468b66efedc5f47f4e04dc1acc803d4db2ce383/op-node/rollup/derive/attributes.go#L70) to understand how deposited transactions are derived and how custom transactions can be created.
+The default Rollup configuration of the OP Stack includes "deposited"transactions that are triggered whenever a specific event is emitted by the `OptimismPortal` contract on L1. Using the same principle, an OP Stack chain can derive transactions from events emitted by *any* contract on an EVM-based DA. Refer to [attributes.go](https://github.com/ethereum-optimism/optimism/blob/e468b66efedc5f47f4e04dc1acc803d4db2ce383/op-node/rollup/derive/attributes.go#L70) to understand how deposited transactions are derived and how custom transactions can be created.
 
 ### EVM Block-Triggered Transactions
 
-Like with events, transactions on an OP Stack chain can be triggered whenever a new block is published on an EVM-based DA. The default Rollup configuration of the OP Stack already includes a block-triggered transaction in the form of [the “L1 info” transaction](https://github.com/ethereum-optimism/optimism/blob/e468b66efedc5f47f4e04dc1acc803d4db2ce383/op-node/rollup/derive/attributes.go#L103) that relays information like the latest block hash, timestamp, and base fee into L2. The Getting Started guide demonstrates the addition of a new block-triggered transaction in the form of a new transaction that reports the amount of gas burned via the base fee on L1.
+Like with events, transactions on an OP Stack chain can be triggered whenever a new block is published on an EVM-based DA. The default Rollup configuration of the OP Stack already includes a block-triggered transaction in the form of [the "L1 info"transaction](https://github.com/ethereum-optimism/optimism/blob/e468b66efedc5f47f4e04dc1acc803d4db2ce383/op-node/rollup/derive/attributes.go#L103) that relays information like the latest block hash, timestamp, and base fee into L2. The Getting Started guide demonstrates the addition of a new block-triggered transaction in the form of a new transaction that reports the amount of gas burned via the base fee on L1.
 
 ### And much, much more…
 

--- a/pages/builders/chain-operators/hacks/execution.mdx
+++ b/pages/builders/chain-operators/hacks/execution.mdx
@@ -9,11 +9,9 @@ import { Callout } from 'nextra/components'
 # Execution Hacks
 
 <Callout type="warning">
+  OP Stack Hacks are explicitly things that you can do with the OP Stack that are *not* currently intended for production use.
 
-OP Stack Hacks are explicitly things that you can do with the OP Stack that are *not* currently intended for production use.
-
-OP Stack Hacks are not for the faint of heart. You will not be able to receive significant developer support for OP Stack Hacks — be prepared to get your hands dirty and to work without support.
-
+  OP Stack Hacks are not for the faint of heart. You will not be able to receive significant developer support for OP Stack Hacks — be prepared to get your hands dirty and to work without support.
 </Callout>
 
 ## Overview
@@ -32,9 +30,9 @@ As with modifications to the Derivation Layer, modifications to the Execution La
 
 ### EVM Tweaks
 
-The default Execution Layer module is the EVM. It’s possible to modify the EVM in many different ways like adding new precompiles or inserting predeployed smart contracts into the genesis state. Precompiles can help make common smart contract operations cheaper and can therefore further reduce the cost of execution for your specific use-case. These modifications should be made directly to [the execution client](https://github.com/ethereum-optimism/op-geth). 
+The default Execution Layer module is the EVM. It's possible to modify the EVM in many different ways like adding new precompiles or inserting predeployed smart contracts into the genesis state. Precompiles can help make common smart contract operations cheaper and can therefore further reduce the cost of execution for your specific use-case. These modifications should be made directly to [the execution client](https://github.com/ethereum-optimism/op-geth).
 
-It’s also possible to create alternative execution client implementations to improve the security properties of your chain. Note that if you modify the EVM, you must apply the same modifications to every execution client that you would like to support.
+It's also possible to create alternative execution client implementations to improve the security properties of your chain. Note that if you modify the EVM, you must apply the same modifications to every execution client that you would like to support.
 
 ### Alternative VMs
 

--- a/pages/builders/chain-operators/hacks/featured-hacks.mdx
+++ b/pages/builders/chain-operators/hacks/featured-hacks.mdx
@@ -50,7 +50,7 @@ OPCraft was an OP Stack chain that ran a modified EVM as the backend for a fully
 
 ### Description
 
-Ticking Optimism is a proof-of-concept implementation of an OP Stack chain that calls a `tick` function every block. By using the OP Stack, Ticking Optimism avoids the need for off-chain infrastructure to execute a function on a regular basis. Ticking Conway is a system that uses Ticking Optimism to build [Conway’s Game of Life](https://conwaylife.com/) onchain.
+Ticking Optimism is a proof-of-concept implementation of an OP Stack chain that calls a `tick` function every block. By using the OP Stack, Ticking Optimism avoids the need for off-chain infrastructure to execute a function on a regular basis. Ticking Conway is a system that uses Ticking Optimism to build [Conway's Game of Life](https://conwaylife.com/) onchain.
 
 ### OP Stack Configuration
 

--- a/pages/builders/chain-operators/hacks/overview.mdx
+++ b/pages/builders/chain-operators/hacks/overview.mdx
@@ -8,9 +8,9 @@ import { Callout } from 'nextra/components'
 
 # Introduction to OP Stack Hacks
 
-Welcome to OP Stack Hacks, the **highly experimental** region of the OP Stack docs. OP Stack Hacks are an unofficial guide for messing around with the OP Stack. Here you’ll find information about ways that the OP Stack can be modified in interesting ways.
+Welcome to OP Stack Hacks, the **highly experimental** region of the OP Stack docs. OP Stack Hacks are an unofficial guide for messing around with the OP Stack. Here you'll find information about ways that the OP Stack can be modified in interesting ways.
 
-OP Stack Hacks create blockchains that aren’t exactly OP Stack, and may be insecure. Hacked OP Stack chains can break key invariants that are required to interoperate with [the Optimism Superchain](/stack/explainer). **Developers of chains that wish to interoperate with [the Optimism Superchain](/stack/explainer) should *not* include any hacks**. When in doubt, stick with the official components within [the current release of the OP Stack](/stack/getting-started#the-op-stack-today).
+OP Stack Hacks create blockchains that aren't exactly OP Stack, and may be insecure. Hacked OP Stack chains can break key invariants that are required to interoperate with [the Optimism Superchain](/stack/explainer). **Developers of chains that wish to interoperate with [the Optimism Superchain](/stack/explainer) should *not* include any hacks**. When in doubt, stick with the official components within [the current release of the OP Stack](/stack/getting-started#the-op-stack-today).
 
 <Callout type="warning">
   OP Stack Hacks are explicitly things that you can do with the OP Stack that are *not* currently intended for production use.

--- a/pages/builders/chain-operators/hacks/settlement.mdx
+++ b/pages/builders/chain-operators/hacks/settlement.mdx
@@ -24,7 +24,7 @@ The default Settlement Layer module is currently the Attestation Proof Optimisti
 
 ## Security
 
-Modifications to the Settlement Layer can strongly impact the security of common mechanisms like user withdrawals. A decreased withdrawal delay can, for instance, open the door to gas spam attacks that make challenges exceedingly expensive. It is generally not recommended to modify the Settlement Layer unless you know what you’re doing.
+Modifications to the Settlement Layer can strongly impact the security of common mechanisms like user withdrawals. A decreased withdrawal delay can, for instance, open the door to gas spam attacks that make challenges exceedingly expensive. It is generally not recommended to modify the Settlement Layer unless you know what you're doing.
 
 ## Modding
 

--- a/pages/builders/chain-operators/tutorials/adding-derivation-attributes.mdx
+++ b/pages/builders/chain-operators/tutorials/adding-derivation-attributes.mdx
@@ -16,17 +16,17 @@ import { Callout, Steps } from 'nextra/components'
 
 ## Overview
 
-In this tutorial, we’ll modify the Bedrock Rollup. Although there are many ways to modify the OP Stack, we’re going to spend this tutorial modifying the Derivation function. Specifically, we’re going to update the Derivation function to track the amount of ETH being burned on L1! Who’s gonna tell [ultrasound.money](http://ultrasound.money) that they should replace their backend with an OP Stack chain?
+In this tutorial, we'll modify the Bedrock Rollup. Although there are many ways to modify the OP Stack, we're going to spend this tutorial modifying the Derivation function. Specifically, we're going to update the Derivation function to track the amount of ETH being burned on L1! Who's gonna tell [ultrasound.money](http://ultrasound.money) that they should replace their backend with an OP Stack chain?
 
 ## Getting the idea
 
-Let’s quickly recap what we’re about to do. The `op-node` is responsible for generating the Engine API payloads that trigger `op-geth` to produce blocks and transactions. The `op-node` already generates a “system transaction” for every L1 block that relays information about the current L1 state to the L2 chain. We’re going to modify the `op-node` to add a new system transaction that reports the total burn amount (the base fee multiplied by the gas used) in each block.
+Let's quickly recap what we're about to do. The `op-node` is responsible for generating the Engine API payloads that trigger `op-geth` to produce blocks and transactions. The `op-node` already generates a "system transaction"for every L1 block that relays information about the current L1 state to the L2 chain. We're going to modify the `op-node` to add a new system transaction that reports the total burn amount (the base fee multiplied by the gas used) in each block.
 
-Although it might sound like a lot, the whole process only involves deploying a single smart contract, adding one new file to `op-node`, and modifying one existing file inside `op-node`. It’ll be painless. Let’s go!
+Although it might sound like a lot, the whole process only involves deploying a single smart contract, adding one new file to `op-node`, and modifying one existing file inside `op-node`. It'll be painless. Let's go!
 
 ## Deploy the burn contract
 
-We’re going to use a smart contract on our Rollup to store the reports that the `op-node` makes about the L1 burn. Here’s the code for our smart contract:
+We're going to use a smart contract on our Rollup to store the reports that the `op-node` makes about the L1 burn. Here's the code for our smart contract:
 
 ```solidity
 // SPDX-License-Identifier: MIT
@@ -76,186 +76,187 @@ contract L1Burn {
 }
 ```
 
-Deploy this smart contract to your L2 (using any tool you find convenient). Make a note of the address that the contract is deployed to because you’ll need it in a minute. Simple!
+Deploy this smart contract to your L2 (using any tool you find convenient). Make a note of the address that the contract is deployed to because you'll need it in a minute. Simple!
 
 ## Add the burn transaction
 
-Now we need to add logic to the `op-node` to automatically submit a burn report whenever an L1 block is produced. Since this transaction is very similar to the system transaction that reports other L1 block info (found in [l1\_block\_info.go](https://github.com/ethereum-optimism/optimism/blob/c9cd1215b76111888e25ee27a49a0bc0c4eeb0f8/op-node/rollup/derive/l1_block_info.go)), we’ll use that transaction as a jumping-off point.
+Now we need to add logic to the `op-node` to automatically submit a burn report whenever an L1 block is produced. Since this transaction is very similar to the system transaction that reports other L1 block info (found in [l1\_block\_info.go](https://github.com/ethereum-optimism/optimism/blob/c9cd1215b76111888e25ee27a49a0bc0c4eeb0f8/op-node/rollup/derive/l1_block_info.go)), we'll use that transaction as a jumping-off point.
+
 <Steps>
+  ### Navigate to the `op-node` package:
 
-### Navigate to the `op-node` package:
+  ```bash
+  cd ~/optimism/op-node
+  ```
 
-    ```bash
-    cd ~/optimism/op-node
-    ```
+  ### Inside of the folder `rollup/derive`, create a new file called `l1_burn_info.go`:
 
-### Inside of the folder `rollup/derive`, create a new file called `l1_burn_info.go`:
+  ```bash
+  touch rollup/derive/l1_burn_info.go
+  ```
 
-    ```bash
-    touch rollup/derive/l1_burn_info.go
-    ```
+  ### Paste the following into `l1_burn_info.go`, and make sure to replace `YOUR_BURN_CONTRACT_HERE` with the address of the `L1Burn` contract you just deployed.
 
-### Paste the following into `l1_burn_info.go`, and make sure to replace `YOUR_BURN_CONTRACT_HERE` with the address of the `L1Burn` contract you just deployed.
+  ```go
+  package derive
 
-    ```go
-    package derive
+  import (
+      "bytes"
+      "encoding/binary"
+      "fmt"
+      "math/big"
 
-    import (
-        "bytes"
-        "encoding/binary"
-        "fmt"
-        "math/big"
+      "github.com/ethereum/go-ethereum/common"
+      "github.com/ethereum/go-ethereum/core/types"
+      "github.com/ethereum/go-ethereum/crypto"
 
-        "github.com/ethereum/go-ethereum/common"
-        "github.com/ethereum/go-ethereum/core/types"
-        "github.com/ethereum/go-ethereum/crypto"
+      "github.com/ethereum-optimism/optimism/op-node/eth"
+  )
 
-        "github.com/ethereum-optimism/optimism/op-node/eth"
-    )
+  const (
+      L1BurnFuncSignature = "report(uint64,uint64)"
+      L1BurnArguments     = 2
+      L1BurnLen           = 4 + 32*L1BurnArguments
+  )
 
-    const (
-        L1BurnFuncSignature = "report(uint64,uint64)"
-        L1BurnArguments     = 2
-        L1BurnLen           = 4 + 32*L1BurnArguments
-    )
+  var (
+      L1BurnFuncBytes4 = crypto.Keccak256([]byte(L1BurnFuncSignature))[:4]
+      L1BurnAddress    = common.HexToAddress("YOUR_BURN_CONTRACT_HERE")
+  )
 
-    var (
-        L1BurnFuncBytes4 = crypto.Keccak256([]byte(L1BurnFuncSignature))[:4]
-        L1BurnAddress    = common.HexToAddress("YOUR_BURN_CONTRACT_HERE")
-    )
+  type L1BurnInfo struct {
+      Number uint64
+      Burn   uint64
+  }
 
-    type L1BurnInfo struct {
-        Number uint64
-        Burn   uint64
-    }
+  func (info *L1BurnInfo) MarshalBinary() ([]byte, error) {
+      data := make([]byte, L1BurnLen)
+      offset := 0
+      copy(data[offset:4], L1BurnFuncBytes4)
+      offset += 4
+      binary.BigEndian.PutUint64(data[offset+24:offset+32], info.Number)
+      offset += 32
+      binary.BigEndian.PutUint64(data[offset+24:offset+32], info.Burn)
+      return data, nil
+  }
 
-    func (info *L1BurnInfo) MarshalBinary() ([]byte, error) {
-        data := make([]byte, L1BurnLen)
-        offset := 0
-        copy(data[offset:4], L1BurnFuncBytes4)
-        offset += 4
-        binary.BigEndian.PutUint64(data[offset+24:offset+32], info.Number)
-        offset += 32
-        binary.BigEndian.PutUint64(data[offset+24:offset+32], info.Burn)
-        return data, nil
-    }
+  func (info *L1BurnInfo) UnmarshalBinary(data []byte) error {
+      if len(data) != L1InfoLen {
+          return fmt.Errorf("data is unexpected length: %d", len(data))
+      }
+      var padding [24]byte
+      offset := 4
+      info.Number = binary.BigEndian.Uint64(data[offset+24 : offset+32])
+      if !bytes.Equal(data[offset:offset+24], padding[:]) {
+          return fmt.Errorf("l1 burn tx number exceeds uint64 bounds: %x", data[offset:offset+32])
+      }
+      offset += 32
+      info.Burn = binary.BigEndian.Uint64(data[offset+24 : offset+32])
+      if !bytes.Equal(data[offset:offset+24], padding[:]) {
+          return fmt.Errorf("l1 burn tx burn exceeds uint64 bounds: %x", data[offset:offset+32])
+      }
+      return nil
+  }
 
-    func (info *L1BurnInfo) UnmarshalBinary(data []byte) error {
-        if len(data) != L1InfoLen {
-            return fmt.Errorf("data is unexpected length: %d", len(data))
-        }
-        var padding [24]byte
-        offset := 4
-        info.Number = binary.BigEndian.Uint64(data[offset+24 : offset+32])
-        if !bytes.Equal(data[offset:offset+24], padding[:]) {
-            return fmt.Errorf("l1 burn tx number exceeds uint64 bounds: %x", data[offset:offset+32])
-        }
-        offset += 32
-        info.Burn = binary.BigEndian.Uint64(data[offset+24 : offset+32])
-        if !bytes.Equal(data[offset:offset+24], padding[:]) {
-            return fmt.Errorf("l1 burn tx burn exceeds uint64 bounds: %x", data[offset:offset+32])
-        }
-        return nil
-    }
+  func L1BurnDepositTxData(data []byte) (L1BurnInfo, error) {
+      var info L1BurnInfo
+      err := info.UnmarshalBinary(data)
+      return info, err
+  }
 
-    func L1BurnDepositTxData(data []byte) (L1BurnInfo, error) {
-        var info L1BurnInfo
-        err := info.UnmarshalBinary(data)
-        return info, err
-    }
+  func L1BurnDeposit(seqNumber uint64, block eth.BlockInfo, sysCfg eth.SystemConfig) (*types.DepositTx, error) {
+      infoDat := L1BurnInfo{
+          Number: block.NumberU64(),
+          Burn:   block.BaseFee().Uint64() * block.GasUsed(),
+      }
+      data, err := infoDat.MarshalBinary()
+      if err != nil {
+          return nil, err
+      }
+      source := L1InfoDepositSource{
+          L1BlockHash: block.Hash(),
+          SeqNumber:   seqNumber,
+      }
+      return &types.DepositTx{
+          SourceHash:          source.SourceHash(),
+          From:                L1InfoDepositerAddress,
+          To:                  &L1BurnAddress,
+          Mint:                nil,
+          Value:               big.NewInt(0),
+          Gas:                 150_000_000,
+          IsSystemTransaction: true,
+          Data:                data,
+      }, nil
+  }
 
-    func L1BurnDeposit(seqNumber uint64, block eth.BlockInfo, sysCfg eth.SystemConfig) (*types.DepositTx, error) {
-        infoDat := L1BurnInfo{
-            Number: block.NumberU64(),
-            Burn:   block.BaseFee().Uint64() * block.GasUsed(),
-        }
-        data, err := infoDat.MarshalBinary()
-        if err != nil {
-            return nil, err
-        }
-        source := L1InfoDepositSource{
-            L1BlockHash: block.Hash(),
-            SeqNumber:   seqNumber,
-        }
-        return &types.DepositTx{
-            SourceHash:          source.SourceHash(),
-            From:                L1InfoDepositerAddress,
-            To:                  &L1BurnAddress,
-            Mint:                nil,
-            Value:               big.NewInt(0),
-            Gas:                 150_000_000,
-            IsSystemTransaction: true,
-            Data:                data,
-        }, nil
-    }
+  func L1BurnDepositBytes(seqNumber uint64, l1Info eth.BlockInfo, sysCfg eth.SystemConfig) ([]byte, error) {
+      dep, err := L1BurnDeposit(seqNumber, l1Info, sysCfg)
+      if err != nil {
+          return nil, fmt.Errorf("failed to create L1 burn tx: %w", err)
+      }
+      l1Tx := types.NewTx(dep)
+      opaqueL1Tx, err := l1Tx.MarshalBinary()
+      if err != nil {
+          return nil, fmt.Errorf("failed to encode L1 burn tx: %w", err)
+      }
+      return opaqueL1Tx, nil
+  }
+  ```
 
-    func L1BurnDepositBytes(seqNumber uint64, l1Info eth.BlockInfo, sysCfg eth.SystemConfig) ([]byte, error) {
-        dep, err := L1BurnDeposit(seqNumber, l1Info, sysCfg)
-        if err != nil {
-            return nil, fmt.Errorf("failed to create L1 burn tx: %w", err)
-        }
-        l1Tx := types.NewTx(dep)
-        opaqueL1Tx, err := l1Tx.MarshalBinary()
-        if err != nil {
-            return nil, fmt.Errorf("failed to encode L1 burn tx: %w", err)
-        }
-        return opaqueL1Tx, nil
-    }
-    ```
-
-    Feel free to take a look at this file if you’re interested. It’s relatively simple, mainly just defining a new transaction type and describing how the transaction should be encoded.
+  Feel free to take a look at this file if you're interested. It's relatively simple, mainly just defining a new transaction type and describing how the transaction should be encoded.
 </Steps>
 
 ## Insert the burn transactions
 
-Finally, we’ll need to update `~/optimism/op-node/rollup/derive/attributes.go` to insert the new burn transaction into every block. You’ll need to make the following changes:
+Finally, we'll need to update `~/optimism/op-node/rollup/derive/attributes.go` to insert the new burn transaction into every block. You'll need to make the following changes:
+
 <Steps>
-### Find these lines:
+  ### Find these lines:
 
-    ```go
-    l1InfoTx, err := L1InfoDepositBytes(seqNumber, l1Info, sysConfig)
-    if err != nil {
+  ```go
+  l1InfoTx, err := L1InfoDepositBytes(seqNumber, l1Info, sysConfig)
+  if err != nil {
+        return nil, NewCriticalError(fmt.Errorf("failed to create l1InfoTx: %w", err))
+  }
+  ```
+
+  ### After those lines, add this code fragment:
+
+  ```go
+  l1BurnTx, err := L1BurnDepositBytes(seqNumber, l1Info, sysConfig)
+  if err != nil {
           return nil, NewCriticalError(fmt.Errorf("failed to create l1InfoTx: %w", err))
-    }
-    ```
+  }
+  ```
 
-### After those lines, add this code fragment:
+  ### Immediately following, change these lines:
 
-    ```go
-    l1BurnTx, err := L1BurnDepositBytes(seqNumber, l1Info, sysConfig)
-    if err != nil {
-            return nil, NewCriticalError(fmt.Errorf("failed to create l1InfoTx: %w", err))
-    }
-    ```
+  ```go
+  txs := make([]hexutil.Bytes, 0, 1+len(depositTxs))
+  txs = append(txs, l1InfoTx)
+  ```
 
-### Immediately following, change these lines:
+  to
 
-    ```go
-    txs := make([]hexutil.Bytes, 0, 1+len(depositTxs))
-    txs = append(txs, l1InfoTx)
-    ```
+  ```go
+  txs := make([]hexutil.Bytes, 0, 2+len(depositTxs))
+  txs = append(txs, l1InfoTx)
+  txs = append(txs, l1BurnTx)
+  ```
 
-    to
-
-    ```go
-    txs := make([]hexutil.Bytes, 0, 2+len(depositTxs))
-    txs = append(txs, l1InfoTx)
-    txs = append(txs, l1BurnTx)
-    ```
-
-All we’re doing here is creating a new burn transaction after every `l1InfoTx` and inserting it into every block.
+  All we're doing here is creating a new burn transaction after every `l1InfoTx` and inserting it into every block.
 </Steps>
 
 ## Rebuild your op-node
 
-Before we can see this change take effect, you’ll need to rebuild your `op-node`:
+Before we can see this change take effect, you'll need to rebuild your `op-node`:
 
 ```bash
 cd ~/optimism/op-node
 make op-node
 ```
 
-Now start your `op-node` if it isn’t running or restart your `op-node` if it’s already running. You should see the change immediately — new blocks will contain two system transactions instead of just one!
+Now start your `op-node` if it isn't running or restart your `op-node` if it's already running. You should see the change immediately — new blocks will contain two system transactions instead of just one!
 
 ## Checking the result
 
@@ -270,6 +271,6 @@ cast call <YOUR_BURN_CONTRACT_HERE> "total()" | cast --from-wei
 
 ## Conclusion
 
-With just a few tiny changes to the `op-node`, you were just able to implement a change to the OP Stack that allows you to keep track of the L1 ETH burn on L2. With a live Cannon fault proof system, you should not only be able to track the L1 burn on L2, you should be able to *prove* the burn to contracts back on L1. You could build a trustless prediction market on the amount of ETH burned. That’s crazy!
+With just a few tiny changes to the `op-node`, you were just able to implement a change to the OP Stack that allows you to keep track of the L1 ETH burn on L2. With a live Cannon fault proof system, you should not only be able to track the L1 burn on L2, you should be able to *prove* the burn to contracts back on L1. You could build a trustless prediction market on the amount of ETH burned. That's crazy!
 
-The OP Stack is an extremely powerful platform that allows you to perform a large amount of computation trustlessly. It’s a superpower for smart contracts. Tracking the L1 burn is just one of the many, many wild things you can do with the OP Stack. If you’re looking for inspiration or you want to see what others are building on the OP Stack, check out our OP Stack Hacks page. Maybe you’ll find a project you want to work on, or maybe you’ll get the inspiration you need to build the next killer smart contract.
+The OP Stack is an extremely powerful platform that allows you to perform a large amount of computation trustlessly. It's a superpower for smart contracts. Tracking the L1 burn is just one of the many, many wild things you can do with the OP Stack. If you're looking for inspiration or you want to see what others are building on the OP Stack, check out our OP Stack Hacks page. Maybe you'll find a project you want to work on, or maybe you'll get the inspiration you need to build the next killer smart contract.

--- a/pages/builders/chain-operators/tutorials/adding-precompiles.mdx
+++ b/pages/builders/chain-operators/tutorials/adding-precompiles.mdx
@@ -14,7 +14,7 @@ import { Callout, Steps } from 'nextra/components'
   OP Stack Hacks are not for the faint of heart. You will not be able to receive significant developer support for OP Stack Hacks — be prepared to get your hands dirty and to work without support.
 </Callout>
 
-One possible use of OP Stack is to run an EVM with a new precompile for operations to speed up calculations that are not currently supported. In this tutorial, we’ll make a simple precompile that returns a constant value if it’s called with four or less bytes, or an error if it is called with more than that.
+One possible use of OP Stack is to run an EVM with a new precompile for operations to speed up calculations that are not currently supported. In this tutorial, we'll make a simple precompile that returns a constant value if it's called with four or less bytes, or an error if it is called with more than that.
 
 To create a new precompile, the file to modify is [`op-geth/core/vm/contracts.go`](https://github.com/ethereum-optimism/op-geth/blob/optimism-history/core/vm/contracts.go).
 
@@ -86,7 +86,7 @@ type PrecompiledContract interface {
 It means that for every precompile we need two functions:
 
 *   `RequiredGas` which returns the gas cost for the call. This function takes an array of bytes as input, and returns a single value, the gas cost.
-*   `Run` which runs the actual precompile. This function also takes an array of bytes, but it returns two values: the call’s output (a byte array) and an error.
+*   `Run` which runs the actual precompile. This function also takes an array of bytes, but it returns two values: the call's output (a byte array) and an error.
 
 For every fork that changes the precompiles we have a [`map`](https://www.w3schools.com/go/go_maps.php)from addresses to the `PrecompiledContract` definitions:
 

--- a/pages/builders/node-operators/tutorials/node-from-source.mdx
+++ b/pages/builders/node-operators/tutorials/node-from-source.mdx
@@ -18,7 +18,7 @@ Nodes need to process and store the transaction history of OP Mainnet or OP Sepo
 
 ### Software requirements
 
-You’ll need the following software installed to follow this tutorial:
+You'll need the following software installed to follow this tutorial:
 
 *   [Git](https://git-scm.com/)
 *   [Go](https://go.dev/)

--- a/pages/builders/tools/faucets.mdx
+++ b/pages/builders/tools/faucets.mdx
@@ -40,4 +40,4 @@ Once you have the testnet ETH on Ethereum Sepolia you can use [Superchain Testne
 ## Next Steps
 
 *   If you're new to onchain development, check out [Optimism Unleashed](https://cryptozombies.io/en/optimism) by CryptoZombies and [Superchain Builder NFT](https://blog.thirdweb.com/optimism-superchain-faucet-nft) by ThirdWeb.
-*   If you're familiar with onchain development, check out the [Optimism Ecosystem’s Contributions Dashboard](https://optimism.io/ideas/) for project ideas that the Optimism Collective is looking for.
+*   If you're familiar with onchain development, check out the [Optimism Ecosystem's Contributions Dashboard](https://optimism.io/ideas/) for project ideas that the Optimism Collective is looking for.

--- a/pages/chain/identity/about-attestations.mdx
+++ b/pages/chain/identity/about-attestations.mdx
@@ -30,7 +30,7 @@ EAS makes it easy to sign any piece of data. In addition, here are a few key ben
 ## Privacy
 
 Attestations create log entries that become part of the permanent record of the blockchain.
-Here are some best practices to avoid violating users’ privacy:
+Here are some best practices to avoid violating users' privacy:
 
 *   Obtain explicit consent from users for [personal information](https://csrc.nist.gov/glossary/term/PII), which includes a user's legal name and birthdate.
     Clearly [inform users](https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/personal-information-what-is-it/what-is-personal-information-a-guide/) what data is being collected, why it is being collected, and how it will be used.
@@ -59,5 +59,5 @@ Here are some best practices to avoid violating users’ privacy:
 
 ## Next Steps
 
-Are you inspired and don’t know what to build? We have a [project idea list](https://optimism.io/ideas).
-Do you have a good idea, but you know you’re not the right person to build it? Please open a PR on that list and suggest it.
+Are you inspired and don't know what to build? We have a [project idea list](https://optimism.io/ideas).
+Do you have a good idea, but you know you're not the right person to build it? Please open a PR on that list and suggest it.

--- a/pages/chain/security/faq.mdx
+++ b/pages/chain/security/faq.mdx
@@ -10,8 +10,8 @@ import { Callout } from 'nextra/components'
 
 OP Mainnet is a work in progress.
 Constant, iterative improvement of the security mechanisms that safeguard OP Mainnet users is a top priority.
-At the moment, **it’s important to understand that the security of OP Mainnet is dependent on a [multisig wallet](https://www.coindesk.com/tech/2020/11/10/multisignature-wallets-can-keep-your-coins-safer-if-you-use-them-right/)** managed by several anonymous individuals.
-This multisig wallet can be used to upgrade core OP Mainnet smart contracts without upgrade delays. For more information, see [Optimism’s Security Council](https://optimism.help/Token+House+Governance/Security+Council/Intro+to+Optimism's+Security+Council).
+At the moment, **it's important to understand that the security of OP Mainnet is dependent on a [multisig wallet](https://www.coindesk.com/tech/2020/11/10/multisignature-wallets-can-keep-your-coins-safer-if-you-use-them-right/)** managed by several anonymous individuals.
+This multisig wallet can be used to upgrade core OP Mainnet smart contracts without upgrade delays. For more information, see [Optimism's Security Council](https://optimism.help/Token+House+Governance/Security+Council/Intro+to+Optimism's+Security+Council).
 
 <Callout type="info">
   Please also read this [Community Notice](https://www.optimism.io/community-notice) containing important information about OP Mainnet, its security model, and the Optimism Foundation.
@@ -19,7 +19,7 @@ This multisig wallet can be used to upgrade core OP Mainnet smart contracts with
 
 Please also keep in mind that just like any other system, **the Optimism codebase may contain unknown bugs** that could lead to the loss of some or all of the assets held within the system.
 The 2222 smart contract codebase has been [audited regularly](https://github.com/ethereum-optimism/optimism/tree/v1.1.4/technical-documents/security-reviews), but **audits are not a stamp of approval** and **a completed audit does not mean that the audited codebase is free of bugs.**
-It’s important to understand that using OP Mainnet inherently exposes you to the risk of bugs within the Optimism codebase, and that you use OP Mainnet at your own risk.
+It's important to understand that using OP Mainnet inherently exposes you to the risk of bugs within the Optimism codebase, and that you use OP Mainnet at your own risk.
 
 ## Next gen fault proofs
 
@@ -45,7 +45,7 @@ You can keep up with the roadmap progress in the [Cannon repository](https://git
 ### Does OP Mainnet have fault proofs?
 
 **No**, OP Mainnet does not currently have fault proofs.
-**Fault proofs do not meaningfully improve the security of a system if that system can be upgraded within the 7 day challenge window (”fast upgrade keys”)**.
+**Fault proofs do not meaningfully improve the security of a system if that system can be upgraded within the 7 day challenge window ("fast upgrade keys")**.
 A system with fast upgrade keys, such as OP Mainnet, is fully dependent on the upgrade keys for security.
 OP Mainnet's goal is to be the first system that deploys fault proofs that can secure the system by themselves, without fast upgrade keys.
 
@@ -56,7 +56,7 @@ Members are anonymous in order to make the multisig more difficult to compromise
 
 ### How is Optimism planning to remove the multisig?
 
-Check out Optimism’s detailed [Pragmatic Path to Decentralization](https://medium.com/ethereum-optimism/our-pragmatic-path-to-decentralization-cb5805ca43c1) post for a detailed view into how the multisig may be removed in a way that makes OP Mainnet the first chain with true fault proof security.
+Check out Optimism's detailed [Pragmatic Path to Decentralization](https://medium.com/ethereum-optimism/our-pragmatic-path-to-decentralization-cb5805ca43c1) post for a detailed view into how the multisig may be removed in a way that makes OP Mainnet the first chain with true fault proof security.
 
 ### How can I help make OP Mainnet more secure?
 

--- a/pages/connect/contribute/stack-contribute.mdx
+++ b/pages/connect/contribute/stack-contribute.mdx
@@ -8,37 +8,42 @@ import { Callout } from 'nextra/components'
 
 # Contribute to the OP Stack
 
-The OP Stack is a collaborative, decentralized development stack that only gets more powerful as more people contribute. Code for the OP Stack should follow the stack’s [design principles](/stack/protocol/design-principles), which means it should be entirely open source and accessible for people to hack on, contribute to, and extend. 
+The OP Stack is a collaborative, decentralized development stack that only gets more powerful as more people contribute. Code for the OP Stack should follow the stack's [design principles](/stack/protocol/design-principles), which means it should be entirely open source and accessible for people to hack on, contribute to, and extend.
 The Optimism Collective wins when it works together. ♥️✨
 
-Whether you’re a budding chain operator, dapp developer, node operator, bounty hunter, content creator, or anything in between, the OP Stack always has something for you to contribute to. 
-Every contribution makes a difference — no contribution is too small. If you’re ready to contribute, check out one of the following contributor pathways below.
+Whether you're a budding chain operator, dapp developer, node operator, bounty hunter, content creator, or anything in between, the OP Stack always has something for you to contribute to.
+Every contribution makes a difference — no contribution is too small. If you're ready to contribute, check out one of the following contributor pathways below.
 
 ## Component Contributions
-The OP Stack is a decentralized development stack and is constantly evolving as new layers and modules are developed. Anyone can contribute components that can be considered part of the OP Stack as long as as those components fit the stack’s [design principles and goals](/stack/protocol/design-principles). 
-To start contributing components to the stack, check out some of these [useful ideas](https://github.com/ethereum-optimism/ecosystem-contributions) and get to building! And don’t forget that projects can also receive funding from the Collective via [RetroPGF](https://community.optimism.io/docs/governance/citizens-house/#how-retropgf-works).
+
+The OP Stack is a decentralized development stack and is constantly evolving as new layers and modules are developed. Anyone can contribute components that can be considered part of the OP Stack as long as as those components fit the stack's [design principles and goals](/stack/protocol/design-principles).
+To start contributing components to the stack, check out some of these [useful ideas](https://github.com/ethereum-optimism/ecosystem-contributions) and get to building! And don't forget that projects can also receive funding from the Collective via [RetroPGF](https://community.optimism.io/docs/governance/citizens-house/#how-retropgf-works).
 
 ## Codebase Contributions
-The OP Stack codebase is not a product (in the traditional sense) but rather a collection of software components that power the Optimism ecosystem. 
-If you’d like to contribute to the current release of OP Stack codebase, rather than creating new components, your contribution would be greatly appreciated. 
-**A “Release” of the OP Stack codebase is a particular set of software components that are production-ready and which fit the stack’s design principles and goals.**
+
+The OP Stack codebase is not a product (in the traditional sense) but rather a collection of software components that power the Optimism ecosystem.
+If you'd like to contribute to the current release of OP Stack codebase, rather than creating new components, your contribution would be greatly appreciated.
+**A "Release"of the OP Stack codebase is a particular set of software components that are production-ready and which fit the stack's design principles and goals.**
 
 To make your first contribution to the codebase, check out the [open issues](https://github.com/ethereum-optimism/optimism/issues) on the Optimism Monorepo.
 
 <Callout type="warning">
-Only the software components included within the current release of the OP Stack codebase are considered in the scope of the OP Stack. 
-Any usage of the OP Stack outside of the official, intended capabilities of the current release are considered [OP Stack Hacks](/builders/chain-operators/hacks/overview) — unofficial modifications that are useful for experimentation but could have unforeseen results, such as security vulnerabilities, and are likely to cause your chain to no longer be interoperable with the [Optimism Superchain](https://app.optimism.io/superchain/). 
-Developer support for OP Stack Hacks is limited — when in doubt, stick to the capabilities of the current release!
+  Only the software components included within the current release of the OP Stack codebase are considered in the scope of the OP Stack.
+  Any usage of the OP Stack outside of the official, intended capabilities of the current release are considered [OP Stack Hacks](/builders/chain-operators/hacks/overview) — unofficial modifications that are useful for experimentation but could have unforeseen results, such as security vulnerabilities, and are likely to cause your chain to no longer be interoperable with the [Optimism Superchain](https://app.optimism.io/superchain/).
+  Developer support for OP Stack Hacks is limited — when in doubt, stick to the capabilities of the current release!
 </Callout>
 
 ## Bounty Hunting
-The OP Stack needs YOU (yes you!) to help review the codebase for bugs and vulnerabilities. If you’re interested in bounty hunting, check out our [Security Policy, Vulnerability Reporting, and Bug Bounties page](../resources/security-policy).
+
+The OP Stack needs YOU (yes you!) to help review the codebase for bugs and vulnerabilities. If you're interested in bounty hunting, check out our [Security Policy, Vulnerability Reporting, and Bug Bounties page](../resources/security-policy).
 
 ## Docs Contributions
+
 Want a new tutorial? See something that could be a little clearer? Check out the [Optimism Docs Contribution page](docs-contribute) for more information on how to help. No contribution is too small!
 
 ## Community Contributions
-If you’re looking for other ways to get involved, here are a few options:
+
+If you're looking for other ways to get involved, here are a few options:
 
 *   Grab an idea from the [project ideas list](https://github.com/ethereum-optimism/ecosystem-contributions) to start building
 *   [Suggest a new idea](https://github.com/ethereum-optimism/ecosystem-contributions/issues/74) for the project ideas list

--- a/pages/connect/contribute/style-guide.mdx
+++ b/pages/connect/contribute/style-guide.mdx
@@ -93,7 +93,7 @@ See below for when to use title or sentence case.
 
 ## Accessibility
 
-When creating content, ensure the content you’re creating is accessible by a screen-reader, for visually-impaired users, and accessible via mouse or keyboard. For more information regarding accessibility guidelines, see [W3C Web Content Accessibility Guidelines 2.0](http://www.w3.org/TR/UNDERSTANDING-WCAG20/Overview.html#contents).
+When creating content, ensure the content you're creating is accessible by a screen-reader, for visually-impaired users, and accessible via mouse or keyboard. For more information regarding accessibility guidelines, see [W3C Web Content Accessibility Guidelines 2.0](http://www.w3.org/TR/UNDERSTANDING-WCAG20/Overview.html#contents).
 
 ### Alt-Text
 
@@ -162,9 +162,9 @@ We aim to use consistent organization that is also user-centered and accessible.
 *   Outline the page content according to main topics first. Those will be your headings (tagged as H2). If there are subtopics that belong under a category, display those as subheaders (tagged as H3). <br />
     <Callout type="info">
       **Example**:<br />
-      (H1) Supporting OP Mainnet in Your Wallet (H1 page title uses “ing” verb ending) <br />
-      (H2) Connect to OP Mainnet (H2 does not use “ing” verb ending) <br />
-      (H2) Locate Canonical Token Addresses (second H2 does not use “ing” verb ending) <br />
+      (H1) Supporting OP Mainnet in Your Wallet (H1 page title uses "ing"verb ending) <br />
+      (H2) Connect to OP Mainnet (H2 does not use "ing"verb ending) <br />
+      (H2) Locate Canonical Token Addresses (second H2 does not use "ing"verb ending) <br />
     </Callout>
 
 *   Use headings in a logical manner, and the site will automatically generate anchor links for H2 and H3 tags and place them in a Table of Contents (TOC) in the right column.
@@ -176,12 +176,12 @@ We aim to use consistent organization that is also user-centered and accessible.
 ### Listing Prerequisites (Before You Begin)
 
 *   Add a "Before You Begin" section at the top of the document if there are tasks a user needs to complete before continuing with the current task, e.g. installing a module, downloading a software update, etc.
-*   Use the title “Before You Begin” and format as H2. It should follow the page overview/intro section or table of contents.
+*   Use the title "Before You Begin"and format as H2. It should follow the page overview/intro section or table of contents.
 *   Include all the tasks the user needs to complete, including links to aid in usability. Use a bulleted list for more than 2 prerequisite items.
     <Callout type="info">
       **Example**:<br />
       (H2) Before You Begin <br />
-      You’ll need to enable the ApacheSolr module. Visit the [ApacheSolr](https://drupal.org/project/apachesolr) page on [Drupal.org](http://drupal.org/) for more information. <br />
+      You'll need to enable the ApacheSolr module. Visit the [ApacheSolr](https://drupal.org/project/apachesolr) page on [Drupal.org](http://drupal.org/) for more information. <br />
     </Callout>
 
 ### Callouts
@@ -216,7 +216,7 @@ We aim to use consistent organization that is also user-centered and accessible.
 
 <Callout type="info">
   js<br />
-  console.log(’hello, world’)<br />
+  console.log('hello, world')<br />
 </Callout>
 
 will render this code snippet in `javascript` with proper syntax highlighting:
@@ -229,7 +229,7 @@ console.log('hello, world')
     *   adding a filename or title to the code block
     *   adding a caption or description (shown above)
     *   adding or showing the line numbers within the code block (easily refer to a certain code lines within the documentation)
-    *   highlighting lines or strings in the code block to draw user’s attention to specific areas
+    *   highlighting lines or strings in the code block to draw user's attention to specific areas
 
 ### Images, Screenshots, & Icons
 
@@ -332,7 +332,7 @@ Content types help manage technical content by defining the purpose and common s
 Overviews provide a general introduction to a product or service and a happy path for readers on how to navigate a particular set of docs or related features; often used at the top-level of a directory, such as `/tools/overview`. When done well, overviews accomplish two essential tasks for users:
 
 1.  **organize** the related set of documentation pages to keep developers from getting overloaded by too much information, and
-2.  **establish a ‘happy path’** to direct developers to the right pages in the documentation set based on their user scenario or use case.
+2.  **establish a 'happy path'** to direct developers to the right pages in the documentation set based on their user scenario or use case.
 
 Tables work really well for overview pages, which can both organize page content and establish the happy path for specific developer use cases. Alternatively, headings (H2) can be used, organized by use case, user scenario, or directory page titles.
 
@@ -380,7 +380,7 @@ When writing tutorials or quick starts, steps should be written in parallel styl
 
 ### FAQs
 
-FAQs address common questions developers have/might ask about a product, feature, or service. FAQs should be written from the developer’s perspective. If there are more than two steps in the answer, use a numbered list. Place FAQs onto their own separate pages, whenever possible, and link to the FAQ from within the respective guide or tutorial.
+FAQs address common questions developers have/might ask about a product, feature, or service. FAQs should be written from the developer's perspective. If there are more than two steps in the answer, use a numbered list. Place FAQs onto their own separate pages, whenever possible, and link to the FAQ from within the respective guide or tutorial.
 
 To maintain consistency, FAQs should include all of these items:
 
@@ -474,7 +474,7 @@ Please use `*` instead of `-` for items in a list. This maintains consistency ac
 
 ### Punctuation
 
-*   **Ampersand (&)** Only use “&” in headings where items are grouped or in proper names. Do not use in sentences.
+*   **Ampersand (&)** Only use "&"in headings where items are grouped or in proper names. Do not use in sentences.
 
 *   **Colon (:)** Use to introduce a list or series.
 
@@ -496,4 +496,4 @@ Please use `*` instead of `-` for items in a list. This maintains consistency ac
 
     **Example**: `developer-focused product` or `company-wide holiday`
 
-*   **Slash (/)** Avoid using as the slash is reserved for file names (see above). Use "or," “and,” or “or both” instead.
+*   **Slash (/)** Avoid using as the slash is reserved for file names (see above). Use "or," "and,"or "or both"instead.

--- a/pages/connect/resources/glossary.mdx
+++ b/pages/connect/resources/glossary.mdx
@@ -160,7 +160,7 @@ This allows for greater privacy, security, and control over personal information
 
 #### Ethereum Attestation Service (EAS)
 
-An Ethereum infrastructure public good for making attestations on or off-chain about anything. 
+An Ethereum infrastructure public good for making attestations on or off-chain about anything.
 
 #### Sybil-resistance
 
@@ -230,7 +230,7 @@ An individual chain within the Optimism Superchain. All chains, regardless of th
 
 #### OP Mainnet
 
-Layer 2 blockchain powered by the OP Stack. Previously known as just “Optimism,” OP Mainnet is where it all started, and the first chain to commit to the Superchain vision.
+Layer 2 blockchain powered by the OP Stack. Previously known as just "Optimism,"OP Mainnet is where it all started, and the first chain to commit to the Superchain vision.
 
 #### OP Stack
 
@@ -238,7 +238,7 @@ the modular, open source, MIT-licensed development stack that powers the OP Main
 
 #### OP Stack Fork
 
-Layer 2 blockchain that has been built using the MIT-licensed OP Stack, but is not governed by Optimism’s governance or contributing sequencer revenue back to the Collective (and therefore is not on track to become part of the Superchain). This means OP Stack Chains won’t necessarily share security or interoperability with OP Chains in the Superchain.
+Layer 2 blockchain that has been built using the MIT-licensed OP Stack, but is not governed by Optimism's governance or contributing sequencer revenue back to the Collective (and therefore is not on track to become part of the Superchain). This means OP Stack Chains won't necessarily share security or interoperability with OP Chains in the Superchain.
 
 #### Plasma Chain
 

--- a/pages/connect/resources/security-policy.mdx
+++ b/pages/connect/resources/security-policy.mdx
@@ -58,4 +58,4 @@ Alongside this policy, maintainers also reserve the right to:
 *   Bypass this policy and publish details on a shorter timeline.
 *   Directly notify a subset of downstream users prior to making a public announcement.
 
-This policy is based the [Geth](https://geth.ethereum.org/) team’s [silent patch policy](https://geth.ethereum.org/docs/developers/geth-developer/disclosures#why-silent-patches).
+This policy is based the [Geth](https://geth.ethereum.org/) team's [silent patch policy](https://geth.ethereum.org/docs/developers/geth-developer/disclosures#why-silent-patches).

--- a/pages/stack/components.mdx
+++ b/pages/stack/components.mdx
@@ -17,7 +17,7 @@ This page sketches out the different conceptual layers of the stack as they exis
 This doesn't include all of the modules or layers that may exist in the future, but it gives a good overview of the major OP Stack components.
 
 <Callout type="warning">
-  Please note that not all of the modules described on this page already exist in a production state — these are explicitly marked as either “**in development**” or “**proposed**.”
+  Please note that not all of the modules described on this page already exist in a production state — these are explicitly marked as either "**in development**"or "**proposed**."
 </Callout>
 
 ## Major Components
@@ -39,7 +39,7 @@ Ethereum DA is currently the most widely used Data Availability module for the O
 
 ### Sequencing
 
-The Sequencing Layer determines how user transactions on an OP Stack chain are collected and published to the Data Availability Layer module(s) in use. In the default Rollup configuration of the OP Stack, Sequencing is typically handled by a single dedicated Sequencer. Rules defined in the Derivation Layer generally restrict the Sequencer’s ability to withhold transactions for more than a specific period of time. In the proposed future, Sequencing will be modular such that chains can easily select and change the mechanism that controls their current Sequencer.
+The Sequencing Layer determines how user transactions on an OP Stack chain are collected and published to the Data Availability Layer module(s) in use. In the default Rollup configuration of the OP Stack, Sequencing is typically handled by a single dedicated Sequencer. Rules defined in the Derivation Layer generally restrict the Sequencer's ability to withhold transactions for more than a specific period of time. In the proposed future, Sequencing will be modular such that chains can easily select and change the mechanism that controls their current Sequencer.
 
 #### Single Sequencer
 
@@ -79,13 +79,13 @@ The EVM is an Execution Layer module that uses the same state representation and
 
 The Settlement Layer is a mechanism on external blockchains that establish a **view** of the state of an OP Stack chain on those external chains (including other OP Stack chains). For each OP Stack chain, there may be one or more Settlement mechanisms on one or more external chains. Settlement Layer mechanisms are **read-only** and allow parties external to the blockchain to make decisions based on the state of an OP Stack chain.
 
-The term “Settlement Layer” has its origins in the fact that Settlement Layer mechanisms are often used to handle withdrawals of assets out of a blockchain. This sort of withdrawal system first involves proving the state of the target blockchain to some third-party chain and then processing a withdrawal based on that state. However, the Settlement Layer is not strictly (or even predominantly) financial and, at its core, simply allows a third-party chain to become aware of the state of the target chain.
+The term "Settlement Layer"has its origins in the fact that Settlement Layer mechanisms are often used to handle withdrawals of assets out of a blockchain. This sort of withdrawal system first involves proving the state of the target blockchain to some third-party chain and then processing a withdrawal based on that state. However, the Settlement Layer is not strictly (or even predominantly) financial and, at its core, simply allows a third-party chain to become aware of the state of the target chain.
 
 Once a transaction is published and finalized on the corresponding Data Availability layer, the transaction is also finalized on the OP Stack chain. Short of breaking the underlying Data Availability layer, it can no longer be modified or removed. It may not be accepted by the Settlement Layer yet because the Settlement Layer needs to be able to verify transaction *results*, but the transaction itself is already immutable.
 
 #### Attestation-based Fault Proof
 
-An Attestation-based Fault Proof mechanism uses an optimistic protocol to establish a view of an OP Stack chain. In optimistic settlement mechanisms generally, **Proposer** entities can propose what they believe to be the current valid state of the OP Stack chain. If these proposals are not invalidated within a certain period of time (the “challenge period”), then the proposals are assumed by the mechanism to be correct. In the Attestation Proof mechanism in particular, a proposal can be invalidated if some threshold of pre-defined parties provide attestations to a valid state that is different than the state in the proposal. This places a trust assumption on the honesty of at least a threshold number of the pre-defined participants.
+An Attestation-based Fault Proof mechanism uses an optimistic protocol to establish a view of an OP Stack chain. In optimistic settlement mechanisms generally, **Proposer** entities can propose what they believe to be the current valid state of the OP Stack chain. If these proposals are not invalidated within a certain period of time (the "challenge period"), then the proposals are assumed by the mechanism to be correct. In the Attestation Proof mechanism in particular, a proposal can be invalidated if some threshold of pre-defined parties provide attestations to a valid state that is different than the state in the proposal. This places a trust assumption on the honesty of at least a threshold number of the pre-defined participants.
 
 *   [Specifications](https://github.com/ethereum-optimism/optimism/blob/129032f15b76b0d2a940443a39433de931a97a44/specs/withdrawals.md) (called [withdrawal transactions](/builders/dapp-developers/bridging/messaging))
 *   [Source code](https://github.com/ethereum-optimism/optimism/tree/129032f15b76b0d2a940443a39433de931a97a44/packages/contracts-bedrock/contracts)

--- a/pages/stack/explainer.mdx
+++ b/pages/stack/explainer.mdx
@@ -19,7 +19,7 @@ The launch of the Superchain would merge Optimism Mainnet and other chains into 
 This is the detailed explanation. [Click here for a less technical introduction](https://app.optimism.io/superchain/).
 
 <Callout type="info">
-  Today, the Superchain is a concept and in-flight project, not a concrete reality.  This documentation represents our best current guess as to what the Superchain’s components, features, and roadmap will be. Ultimately, its actualization will depend on (and change alongside) contributions from across the entire Optimism Collective. We cannot wait to see where it goes.
+  Today, the Superchain is a concept and in-flight project, not a concrete reality.  This documentation represents our best current guess as to what the Superchain's components, features, and roadmap will be. Ultimately, its actualization will depend on (and change alongside) contributions from across the entire Optimism Collective. We cannot wait to see where it goes.
 </Callout>
 
 ## The Scalability Vision
@@ -38,11 +38,11 @@ More than a decade later this has not changed.
 
 Imagine a world where we solved the blockchain scalability problem. Imagine if transacting onchain would be as cheap as interacting with centralized backends. In this world, what would be possible?
 
-*   Developers wouldn’t need to worry about the backend infrastructure their app exists on because the chain guarantees correct execution, uptime, and [horizontal scalability](https://en.wikipedia.org/wiki/Scalability#Horizontal_\(scale_out\)_and_vertical_scaling_\(scale_up\)) of their app.
+*   Developers wouldn't need to worry about the backend infrastructure their app exists on because the chain guarantees correct execution, uptime, and [horizontal scalability](https://en.wikipedia.org/wiki/Scalability#Horizontal_\(scale_out\)_and_vertical_scaling_\(scale_up\)) of their app.
 *   Due to the shared smart contract execution environment, composability would be supercharged far beyond the capabilities of traditional REST APIs.
 *   With standardized gas markets, developers are not required to front all infrastructure costs for their users. Paying for a viral application would no longer be a barrier to entry for app devs, and more monetization strategies would be unlocked.
 
-The combination of these features would make it possible to program highly scalable web applications without having to touch the traditional backend software stack. Removing the need to worry about backends is a value proposition which extends beyond decentralization enthusiasts into regular application developers who just want to ship a product. With scalability, blockchains can go from a niche interest to becoming a core component of every developer’s toolkit.
+The combination of these features would make it possible to program highly scalable web applications without having to touch the traditional backend software stack. Removing the need to worry about backends is a value proposition which extends beyond decentralization enthusiasts into regular application developers who just want to ship a product. With scalability, blockchains can go from a niche interest to becoming a core component of every developer's toolkit.
 
 Additionally, in this world where most applications go onchain more data becomes cryptographically verifiable. This cryptographic verifiability enables users to build reputations which transfer across all of their applications. The reputation can then be used for voting, loans, and collateral—facilitating trust on the internet. Plus there is no risk of losing access because users retain ownership of their data, applications, and reputation.
 
@@ -50,9 +50,9 @@ There is no doubt that the promise of blockchains could change the internet as w
 
 ### …and the decentralized web can still be realized
 
-This hypothetical isn’t a dream, it’s a tangible vision for the future which has motivated many—including Optimism—to dedicate their lives to its pursuit. Due to these collective contributions, every year we learn more about the blockchain technology stack and get closer to realizing the vision.
+This hypothetical isn't a dream, it's a tangible vision for the future which has motivated many—including Optimism—to dedicate their lives to its pursuit. Due to these collective contributions, every year we learn more about the blockchain technology stack and get closer to realizing the vision.
 
-With the support of the industry, we think a clear picture for how to architect a truly scalable blockchain is beginning to come into view. We call it the “Superchain”. This document lays out the core technical principles underlying the Superchain architecture, as well as a set of tangible projects which, when complete, we believe will finally realize the blockchain scalability vision. It will be a multi-year (if not decade) journey. However, if we know roughly where we’re going we’ll get there a little faster.
+With the support of the industry, we think a clear picture for how to architect a truly scalable blockchain is beginning to come into view. We call it the "Superchain". This document lays out the core technical principles underlying the Superchain architecture, as well as a set of tangible projects which, when complete, we believe will finally realize the blockchain scalability vision. It will be a multi-year (if not decade) journey. However, if we know roughly where we're going we'll get there a little faster.
 
 ## Foundational Superchain Concepts
 
@@ -68,12 +68,12 @@ Horizontal blockchain scalability fundamentally requires multiple chains. This i
 
 ### …but traditional multi-chain architectures are insufficient
 
-Traditional approaches to ‘multi-chain’ architectures suffer from two fundamental problems:
+Traditional approaches to 'multi-chain' architectures suffer from two fundamental problems:
 
 1.  Each chain introduces a new security model, resulting in compounding systemic risk as new chains are introduced into the ecosystem. (related [link](https://twitter.com/VitalikButerin/status/1479501366192132099?s=20))
 2.  New chains are costly to spin up because they require new validator sets & block producers.
 
-These issues come from a lack of a single shared blockchain (an “L1” chain) which serves as a shared source of truth for all of the chains (”L2” chains) within the multi-chain system. By using the shared source of truth it is possible to: a) enforce standard security models across all chains; and b) remove the requirement that chain deployments require a new set of validators because each L2 chain uses L1 consensus.
+These issues come from a lack of a single shared blockchain (an "L1"chain) which serves as a shared source of truth for all of the chains ("L2"chains) within the multi-chain system. By using the shared source of truth it is possible to: a) enforce standard security models across all chains; and b) remove the requirement that chain deployments require a new set of validators because each L2 chain uses L1 consensus.
 
 ### Not multi-chain, not mono-chain… Superchain
 
@@ -184,7 +184,7 @@ The ability to pause the bridge in case of emergency means that in the worst cas
 
 #### Unfreezing the bridge via L1 soft fork
 
-In order to address the frozen funds, there is a potential final recovery mechanism which has been discussed by the L2 community which we call the “L1 Soft Fork Upgrade Recovery” mechanism. This mechanism enables L1 to initiate a bridge upgrade with a soft fork, bypassing all other permissions within the Superchain bridge contracts. This approach may [introduce systemic risk](https://web.archive.org/web/20231102063913/https://vitalik.ca/general/2023/05/21/dont_overload.html) to Ethereum and requires research and community buy-in before implementation. It is not required for implementing the Superchain and is being documented for research completeness. Without further research into the implications and safety, it is not an approach the team currently endorses.
+In order to address the frozen funds, there is a potential final recovery mechanism which has been discussed by the L2 community which we call the "L1 Soft Fork Upgrade Recovery"mechanism. This mechanism enables L1 to initiate a bridge upgrade with a soft fork, bypassing all other permissions within the Superchain bridge contracts. This approach may [introduce systemic risk](https://web.archive.org/web/20231102063913/https://vitalik.ca/general/2023/05/21/dont_overload.html) to Ethereum and requires research and community buy-in before implementation. It is not required for implementing the Superchain and is being documented for research completeness. Without further research into the implications and safety, it is not an approach the team currently endorses.
 
 The mechanism is as follows:
 
@@ -233,9 +233,9 @@ It is possible to replace the trusted set of chain attestors by introducing perm
 
 Fault proofs introduce a UX burden because they require waiting a challenge period in order to safely finalize. This means that, depending on your challenge period length, users need to wait a long time before their assets are migrated from one OP Chain to the next.
 
-On the other hand, validity proofs do not have this problem. Validity proofs don’t have a challenge period and therefore provide instant withdrawals from one OP Chain to the next. This is extremely important if users are expected to migrate between chains frequently, even during normal dApp execution. However, validity proofs are commonly implemented using zero-knowledge proofs (ZKPs), which are expensive and bug-prone. It will likely take years to truly productionize ZKPs enough such that they can be the primary cross-chain communication protocol.
+On the other hand, validity proofs do not have this problem. Validity proofs don't have a challenge period and therefore provide instant withdrawals from one OP Chain to the next. This is extremely important if users are expected to migrate between chains frequently, even during normal dApp execution. However, validity proofs are commonly implemented using zero-knowledge proofs (ZKPs), which are expensive and bug-prone. It will likely take years to truly productionize ZKPs enough such that they can be the primary cross-chain communication protocol.
 
-However, while ZKPs are being productionized, it is possible to achieve low latency L2 to L2 message passing using the OP Stack’s modular proof system. With modular proofs it is possible to use two proof systems for the same chain. This opens up the possibility to provide low latency bridging which trades off security while *also* providing high security high latency bridging.
+However, while ZKPs are being productionized, it is possible to achieve low latency L2 to L2 message passing using the OP Stack's modular proof system. With modular proofs it is possible to use two proof systems for the same chain. This opens up the possibility to provide low latency bridging which trades off security while *also* providing high security high latency bridging.
 
 This heterogeneous bridging system means that developers can build their applications using one of many bridge types, such as:
 
@@ -244,7 +244,7 @@ This heterogeneous bridging system means that developers can build their applica
 3.  Low security, low latency validity proof (using trusted chain attestors in place of a ZKP)
 4.  High security, low latency validity proof (once ZKPs are ready)
 
-Mixing multiple proof systems enables developers to provide low latency bridging for low value assets and high latency for high value assets. It is even possible to turn a low security asset which was instantly bridged into a high security asset by proving the asset’s validity using a high security high latency bridge. This building block enables developers to make interesting security tradeoffs such as using a high threshold attestation proof with a high security high latency fault proof fallback.
+Mixing multiple proof systems enables developers to provide low latency bridging for low value assets and high latency for high value assets. It is even possible to turn a low security asset which was instantly bridged into a high security asset by proving the asset's validity using a high security high latency bridge. This building block enables developers to make interesting security tradeoffs such as using a high threshold attestation proof with a high security high latency fault proof fallback.
 
 ### Synchronous Cross-Chain Transactions
 
@@ -320,7 +320,7 @@ With robust multi-chain dApp frameworks, it may become as easy to deploy cross-c
 
 We believe scaling blockchains will radically decentralize the internet and make it easy to create horizontally scalable, secure, and decentralized web applications. We think the Superchain release of the OP Stack could mark a major step towards realizing this vision. However, after the release it will still take an enormous amount of work to realize the scalability vision.
 
-However, with great challenge comes great opportunity! The work needed to arrive at the initial Superchain release of the OP stack, as well as the resulting ecosystem should be exciting greenfields of opportunities for developers who want to contribute. There will be an enormous amount of low hanging fruit contributions unlocked. We can’t pick it alone! The only way we can hope to achieve it is through open source contributions from folks like you! And with [retroactive public goods funding](https://medium.com/ethereum-optimism/retroactive-public-goods-funding-33c9b7d00f0c) your open source contributions may be rewarded too!
+However, with great challenge comes great opportunity! The work needed to arrive at the initial Superchain release of the OP stack, as well as the resulting ecosystem should be exciting greenfields of opportunities for developers who want to contribute. There will be an enormous amount of low hanging fruit contributions unlocked. We can't pick it alone! The only way we can hope to achieve it is through open source contributions from folks like you! And with [retroactive public goods funding](https://medium.com/ethereum-optimism/retroactive-public-goods-funding-33c9b7d00f0c) your open source contributions may be rewarded too!
 
 Exciting times ahead.
 

--- a/pages/stack/getting-started.mdx
+++ b/pages/stack/getting-started.mdx
@@ -11,7 +11,7 @@ import { Callout } from 'nextra/components'
 **The OP Stack is the standardized, shared, and open-source development stack that powers Optimism, maintained by the Optimism Collective.**
 
 <Callout type="info">
-  [Stay up to date on the Superchain and the OP Stack by subscribing to the Optimism newsletter](https://optimism.us6.list-manage.com/subscribe/post?u=9727fa8bec4011400e57cafcb&id=ca91042234&f_id=002a19e3f0).
+  [Stay up to date on the Superchain and the OP Stack by subscribing to the Optimism newsletter](https://optimism.us6.list-manage.com/subscribe/post?u=9727fa8bec4011400e57cafcb\&id=ca91042234\&f_id=002a19e3f0).
 </Callout>
 
 The OP Stack consists of the many different software components managed and maintained by the Optimism Collective that, together, form the backbone of Optimism.
@@ -25,7 +25,7 @@ With the advent of the Superchain concept, it has become increasingly important 
 As a result, the OP Stack is primarily focused around the creation of a shared, high-quality, and fully open-source system for creating new L2 blockchains.
 By coordinating on shared standards, the Optimism Collective can avoid rebuilding the same software in silos repeatedly.
 
-Although the OP Stack today significantly simplifies the process of creating L2 blockchains, it’s important to note that this does not fundamentally define what the OP Stack **is**.
+Although the OP Stack today significantly simplifies the process of creating L2 blockchains, it's important to note that this does not fundamentally define what the OP Stack **is**.
 The OP Stack is *all* of the software that powers Optimism.
 As Optimism evolves, so will the OP Stack.
 
@@ -64,8 +64,8 @@ At the end of the day, the OP Stack becomes what Optimism needs.
 
 Ready to dive into the world of the OP Stack?
 
-*   If you’re interested in learning more about the current release of the OP Stack, check out the Bedrock Release page.
-*   If you’re interested in understanding the OP Stack in more depth, start with the [Design Principles](protocol/design-principles) and [Components Overview](components).
+*   If you're interested in learning more about the current release of the OP Stack, check out the Bedrock Release page.
+*   If you're interested in understanding the OP Stack in more depth, start with the [Design Principles](protocol/design-principles) and [Components Overview](components).
 *   If you're excited to join the Superchain, launch your first Superchain-ready L2 with our [Getting Started guide](explainer) or dive directly into the OP Stack codebase to learn more.
 
-The OP Stack is the next frontier for Ethereum. You’re already here, so what are you waiting for?
+The OP Stack is the next frontier for Ethereum. You're already here, so what are you waiting for?

--- a/pages/stack/protocol/design-principles.mdx
+++ b/pages/stack/protocol/design-principles.mdx
@@ -16,56 +16,58 @@ OP Stack is built according to a strong design philosophy that stands on four ma
 It's important to understand these pillars as they heavily influence the design of Optimism as a whole.
 
 ### Simplicity
-  Optimism is designed to be as simple as possible for the featureset it provides.
-  Ideally, Optimism should be composed of the minimum number of moving parts required for a secure, scalable, and flexible L2 system.
-  This simplicity gives Optimism's design a number of significant advantages over other more complex L2 constructions.
 
-  Simplicity reduces engineering overhead, which in turn means we can spend our time working on new features instead of re-creating existing ones.
-  Optimism prefers to use existing battle-tested Ethereum code and infrastructure where possible.
-  The most visible example of this philosophy in practice is the choice to use Geth as Optimism's client software.
+Optimism is designed to be as simple as possible for the featureset it provides.
+Ideally, Optimism should be composed of the minimum number of moving parts required for a secure, scalable, and flexible L2 system.
+This simplicity gives Optimism's design a number of significant advantages over other more complex L2 constructions.
 
-  When dealing with critical infrastructure, simplicity is also security.
-  Every line of code we write is an opportunity to introduce unintentional bugs.
-  A simple protocol means there's less code to write and, as a result, less surface area for potential mistakes.
-  A clean and minimal codebase is also more accessible to external contributors and auditors.
-  All of this serves to maximize the security and correctness of the Optimism protocol.
+Simplicity reduces engineering overhead, which in turn means we can spend our time working on new features instead of re-creating existing ones.
+Optimism prefers to use existing battle-tested Ethereum code and infrastructure where possible.
+The most visible example of this philosophy in practice is the choice to use Geth as Optimism's client software.
 
-  Simplicity is also important for the long-term vision of Optimism.
-  By limiting the amount of code that we write on top of Ethereum tooling, we're able to spend most of our time working directly with existing codebases.
-  Engineering effort that goes into Optimism can also directly benefit Ethereum, and vice versa.
-  This will only become more pronounced as the Optimism protocol solidifies and existing resources can be redirected towards core Ethereum infrastructure.
+When dealing with critical infrastructure, simplicity is also security.
+Every line of code we write is an opportunity to introduce unintentional bugs.
+A simple protocol means there's less code to write and, as a result, less surface area for potential mistakes.
+A clean and minimal codebase is also more accessible to external contributors and auditors.
+All of this serves to maximize the security and correctness of the Optimism protocol.
+
+Simplicity is also important for the long-term vision of Optimism.
+By limiting the amount of code that we write on top of Ethereum tooling, we're able to spend most of our time working directly with existing codebases.
+Engineering effort that goes into Optimism can also directly benefit Ethereum, and vice versa.
+This will only become more pronounced as the Optimism protocol solidifies and existing resources can be redirected towards core Ethereum infrastructure.
 
 ### Pragmatism
-  For all its idealism, the design process behind Optimism is ultimately driven by pragmatism.
-  The core Optimism team has real-world constraints, the projects that build on Optimism have real-world needs, and the users that engage with Optimism have real-world problems.
-  Optimism's design philosophy prioritizes user and developer needs over theoretical perfection.
-  Sometimes the best solution isn't the prettiest one.
 
-  Optimism is also developed with the understanding that any core team will have limited areas of expertise.
-  Optimism is developed iteratively and strives to continuously pull feedback from users.
-  Many core Optimism features today (like [EVM Equivalence](https://medium.com/ethereum-optimism/introducing-evm-equivalence-5c2021deb306)) were only made possible by this iterative approach to protocol development.
+For all its idealism, the design process behind Optimism is ultimately driven by pragmatism.
+The core Optimism team has real-world constraints, the projects that build on Optimism have real-world needs, and the users that engage with Optimism have real-world problems.
+Optimism's design philosophy prioritizes user and developer needs over theoretical perfection.
+Sometimes the best solution isn't the prettiest one.
+
+Optimism is also developed with the understanding that any core team will have limited areas of expertise.
+Optimism is developed iteratively and strives to continuously pull feedback from users.
+Many core Optimism features today (like [EVM Equivalence](https://medium.com/ethereum-optimism/introducing-evm-equivalence-5c2021deb306)) were only made possible by this iterative approach to protocol development.
 
 ### Sustainability
 
-  Optimism is in it for the long haul.
-  Application developers need assurance that the platform they're building on will remain not only operational but competitive over long periods of time.
-  Optimism's design process is built around the idea of long-term sustainability and not taking shortcuts to scalability.
-  At the end of the day, a scalable system means nothing without the ecosystem that sustains it.
+Optimism is in it for the long haul.
+Application developers need assurance that the platform they're building on will remain not only operational but competitive over long periods of time.
+Optimism's design process is built around the idea of long-term sustainability and not taking shortcuts to scalability.
+At the end of the day, a scalable system means nothing without the ecosystem that sustains it.
 
-  Sustainability actively influences Optimism's protocol design in ways that go hand-in-hand with our philosophy of simplicity.
-  The more complex a codebase, the more difficult it is for people outside of the core development team to actively contribute.
-  By keeping our codebase simple we're able to build a bigger community of contributors who can help maintain the protocol long-term.
+Sustainability actively influences Optimism's protocol design in ways that go hand-in-hand with our philosophy of simplicity.
+The more complex a codebase, the more difficult it is for people outside of the core development team to actively contribute.
+By keeping our codebase simple we're able to build a bigger community of contributors who can help maintain the protocol long-term.
 
 ### Optimism
 
-  Of course, none of this would be possible without a sense of optimism.
-  Our optimism about the Ethereum vision keeps this project moving forward.
-  We believe in an optimistic future for Ethereum, a future where we get to redesign our relationships with the institutions that coordinate our lives.
+Of course, none of this would be possible without a sense of optimism.
+Our optimism about the Ethereum vision keeps this project moving forward.
+We believe in an optimistic future for Ethereum, a future where we get to redesign our relationships with the institutions that coordinate our lives.
 
-  Although Optimism looks like a standalone blockchain, it's ultimately designed as an extension to Ethereum.
-  We keep this in mind whenever we're creating new features or trying to simplify existing ones.
-  Optimism is as close to Ethereum as possible not only for pragmatic reasons, but because Optimism exists so that Ethereum can succeed.
-  We hope that you can see the influence of this philosophy when looking at Optimism's design.
+Although Optimism looks like a standalone blockchain, it's ultimately designed as an extension to Ethereum.
+We keep this in mind whenever we're creating new features or trying to simplify existing ones.
+Optimism is as close to Ethereum as possible not only for pragmatic reasons, but because Optimism exists so that Ethereum can succeed.
+We hope that you can see the influence of this philosophy when looking at Optimism's design.
 
 ## Design Principles for USEful Software
 
@@ -75,39 +77,39 @@ Software that follows these principles is **USE**ful software for the Optimism C
 
 ### Utility
 
-  For something to be part of the OP Stack, it should help power the Optimism Collective.
-  This condition helps guide the type of software that can be included in the stack.
-  For instance, a powerful open-source block explorer that makes it easier for users to inspect [the Superchain](https://app.optimism.io/superchain/) would be a great addition to the OP Stack.
+For something to be part of the OP Stack, it should help power the Optimism Collective.
+This condition helps guide the type of software that can be included in the stack.
+For instance, a powerful open-source block explorer that makes it easier for users to inspect [the Superchain](https://app.optimism.io/superchain/) would be a great addition to the OP Stack.
 
-  Although utility is important for inclusion in the OP Stack, you shouldn’t be afraid to experiment.
-  Do something crazy.
-  Build something that’s never been built before, even if it doesn’t have any clear utility. Make a blockchain for Emojis, or whatever. Have fun!
+Although utility is important for inclusion in the OP Stack, you shouldn't be afraid to experiment.
+Do something crazy.
+Build something that's never been built before, even if it doesn't have any clear utility. Make a blockchain for Emojis, or whatever. Have fun!
 
 ### Simplicity
 
-  Complex code does not scale.
-  Code that makes it into the OP Stack should be simple.
+Complex code does not scale.
+Code that makes it into the OP Stack should be simple.
 
-  Simplicity reduces engineering overhead, which in turn means the Collective can spend its time working on new features instead of re-creating existing ones.
-  The OP Stack prefers to use existing battle-tested code and infrastructure where possible.
-  The most visible example of this philosophy in practice is the choice to use Geth as the OP Stack’s default execution engine.
+Simplicity reduces engineering overhead, which in turn means the Collective can spend its time working on new features instead of re-creating existing ones.
+The OP Stack prefers to use existing battle-tested code and infrastructure where possible.
+The most visible example of this philosophy in practice is the choice to use Geth as the OP Stack's default execution engine.
 
-  When dealing with critical infrastructure, simplicity is also security and maintainability.
-  Every line of code written is an opportunity to introduce bugs and vulnerabilities.
-  A simple protocol means there's less code to write and, as a result, less surface area for potential mistakes.
-  A clean and minimal codebase is also more accessible to external contributors and auditors.
-  All of this serves to maximize the security and correctness of the OP Stack.
+When dealing with critical infrastructure, simplicity is also security and maintainability.
+Every line of code written is an opportunity to introduce bugs and vulnerabilities.
+A simple protocol means there's less code to write and, as a result, less surface area for potential mistakes.
+A clean and minimal codebase is also more accessible to external contributors and auditors.
+All of this serves to maximize the security and correctness of the OP Stack.
 
 ### Extensibility
 
-  Good OP Stack code is inherently open, collaborative, and extensible.
-  Collaboration allows us to break out of siloed development.
-  Collaboration allows us spend more time building on top of one another's work and less time rebuilding the same components over and over again.
-  Collaboration is how we win, *together*.
+Good OP Stack code is inherently open, collaborative, and extensible.
+Collaboration allows us to break out of siloed development.
+Collaboration allows us spend more time building on top of one another's work and less time rebuilding the same components over and over again.
+Collaboration is how we win, *together*.
 
-  Extensible code should be designed with the mindset that others will want to build with and on top of that code.
-  In practice, this means that the code should be open source (under a permissive license), expose clean APIs, and generally be modular such that another developer can relatively easily extend the functionality of the code.
-  Extensibility is a key design principle that unlocks the superpower of collaboration within the Optimism Collective ecosystem.
+Extensible code should be designed with the mindset that others will want to build with and on top of that code.
+In practice, this means that the code should be open source (under a permissive license), expose clean APIs, and generally be modular such that another developer can relatively easily extend the functionality of the code.
+Extensibility is a key design principle that unlocks the superpower of collaboration within the Optimism Collective ecosystem.
 
 ## Contributing to the OP Stack
 

--- a/pages/stack/security/faq.mdx
+++ b/pages/stack/security/faq.mdx
@@ -8,10 +8,10 @@ import { Callout } from 'nextra/components'
 
 # OP Stack Security FAQs
 
-<Callout type="warning"> 
-Work in Progress 🚧
-The OP Stack is a work in progress. Constantly pushing to improve the overall security and decentralization of the OP Stack is a top priority. 
-Please also read this [Community Notice](https://www.optimism.io/community-notice) containing important information about OP Mainnet, its security model, and the Optimism Foundation.
+<Callout type="warning">
+  Work in Progress 🚧
+  The OP Stack is a work in progress. Constantly pushing to improve the overall security and decentralization of the OP Stack is a top priority.
+  Please also read this [Community Notice](https://www.optimism.io/community-notice) containing important information about OP Mainnet, its security model, and the Optimism Foundation.
 </Callout>
 
 ## Security in the decentralized context
@@ -24,17 +24,17 @@ The OP Stack is a decentralized development stack that powers Optimism. Componen
 
 The security model of an OP Stack based blockchain depends on the modules used for its components. Because of the flexibility and permissionless nature of the OP Stack, it is always possible for someone to maliciously or in error set up a chain which does not make use of core security features, but uses other components of OP Stack. **The goal of the OP Stack is to provide safe defaults.**
 
-Please also keep in mind that just like any other system, **the OP Stack (or chains built using the OP Stack) may contain unknown bugs**  that could lead to the loss of some or all of the assets held within an OP Stack based system. 
+Please also keep in mind that just like any other system, **the OP Stack (or chains built using the OP Stack) may contain unknown bugs**  that could lead to the loss of some or all of the assets held within an OP Stack based system.
 Many components of the OP Stack codebase have been [audited](https://github.com/ethereum-optimism/optimism/tree/129032f15b76b0d2a940443a39433de931a97a44/technical-documents/security-reviews), but successful audits do not remove all potential risk from an emerging technology, and a completed audit does not mean that the codebase is completely free of bugs.
-It’s important to understand that using the OP Stack inherently exposes you to the risk of bugs within the OP Stack codebase.
+It's important to understand that using the OP Stack inherently exposes you to the risk of bugs within the OP Stack codebase.
 
 ### Is the OP Stack safe to modify?
 
-As with anything, modify the OP Stack at your own risk. There is no guarantee that modifications to the stack will be safe. If you aren’t entirely sure about what you’re doing, stick with the safer defaults that the OP Stack provides. At the moment, the OP Stack is not particularly amenable to modifications and **you should not expect any technical support for modifications that fall outside of the standard Rollup configuration of the stack**.
+As with anything, modify the OP Stack at your own risk. There is no guarantee that modifications to the stack will be safe. If you aren't entirely sure about what you're doing, stick with the safer defaults that the OP Stack provides. At the moment, the OP Stack is not particularly amenable to modifications and **you should not expect any technical support for modifications that fall outside of the standard Rollup configuration of the stack**.
 
 ### Can I use fault proofs?
 
-**Not yet.** The OP Stack does not currently have a fault proof system. **Note that fault proofs do not meaningfully improve the security of a system if that system can be upgraded within the 7 day challenge window (”fast upgrade keys”)**. A system with fast upgrade keys is fully dependent on the upgrade keys for security. 
+**Not yet.** The OP Stack does not currently have a fault proof system. **Note that fault proofs do not meaningfully improve the security of a system if that system can be upgraded within the 7 day challenge window ("fast upgrade keys")**. A system with fast upgrade keys is fully dependent on the upgrade keys for security.
 
 Fault proofs are a key milestone and top priority for the OP Stack. In the meantime, the OP Stack can be shipped with several other excellent security options for systems that want to improve security before fault proofs are available in production.
 
@@ -42,7 +42,7 @@ Fault proofs are a key milestone and top priority for the OP Stack. In the meant
 
 One of the easiest ways to help secure the OP Stack is to look for bugs and vulnerabilities. [Optimism Mainnet, a user of the OP Stack, has one of the biggest bug bounties (ever)](https://immunefi.com/bounty/optimism/). You can earn up to $2,000,042 by finding critical bugs in the Optimism Mainnet codebase (and by extension the OP Stack).
 
-Don’t forget that the OP Stack is a decentralized development stack. Anyone can start to contribute to the OP Stack by building software that follows [the stack’s design principles](/stack/protocol/design-principles). You can always help make the OP Stack more secure by building components, like alternative client or proof implementations, that users of the OP Stack can take advantage of.
+Don't forget that the OP Stack is a decentralized development stack. Anyone can start to contribute to the OP Stack by building software that follows [the stack's design principles](/stack/protocol/design-principles). You can always help make the OP Stack more secure by building components, like alternative client or proof implementations, that users of the OP Stack can take advantage of.
 
 ### Where do I report bugs?
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,12 @@ devDependencies:
   typescript:
     specifier: ^5.2.2
     version: 5.3.2
+  unified-lint-rule:
+    specifier: ^2.1.2
+    version: 2.1.2
+  unist-util-visit:
+    specifier: ^5.0.0
+    version: 5.0.0
 
 packages:
 

--- a/utils/plugins/remark/remark-lint-no-smart-quotes.mjs
+++ b/utils/plugins/remark/remark-lint-no-smart-quotes.mjs
@@ -1,0 +1,36 @@
+import { visit } from 'unist-util-visit'
+import { lintRule } from 'unified-lint-rule'
+
+const remarkLintNoSmartQuotes = lintRule(
+  {
+    url: 'https://github.com/ethereum-optimism/docs',
+    origin: 'remark-lint:no-smart-quotes'
+  },
+  (tree, file) => {
+    visit(tree, 'text', (node) => {
+      const smartQuotesRegex = /[“”‘’]/g
+      const replacements = {
+        '“': '"',
+        '”': '"',
+        '‘': "'",
+        '’': "'"
+      }
+
+      let match
+      while ((match = smartQuotesRegex.exec(node.value)) !== null) {
+        file.message(
+          `Smart quote found: ${match[0]} at index ${match.index}`,
+          node
+        )
+
+        node.value = node.value.substring(0, match.index) + replacements[match[0]] + node.value.substring(match.index + 1)
+        file.messages[file.messages.length - 1].fix = {
+          range: [node.position.start.offset, node.position.end.offset],
+          text: node.value
+        }
+      }
+    })
+  }
+)
+
+export default remarkLintNoSmartQuotes


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR introduces remarkLintNoSmartQuotes, a new linting rule for the Ethereum Optimism documentation. The purpose of this rule is to identify and replace smart quotes (“, ”, ‘, ’) in text nodes with their standard ASCII counterparts (", '). This ensures consistency in quote usage throughout the documentation, aligning with the common markdown standards. The rule is implemented using unist-util-visit to traverse the markdown abstract syntax tree and perform the necessary replacements.

**Tests**

Currently, this PR does not include specific tests for the remarkLintNoSmartQuotes rule. This is mainly due to the straightforward nature of the implementation, which relies on established libraries (unist-util-visit and unified-lint-rule). However, I am open to feedback on the necessity of adding tests for this specific rule and willing to work on them if deemed necessary.

**Additional context**

n/a
**Metadata**

- Fixes an annoying issue!
