### PR TITLE
feat: no semicolon rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
     'plugin:mdx/recommended',
   ],
   rules: {
+    'semi': ['error', 'never']
   },
   overrides: [
     {
@@ -17,7 +18,8 @@ module.exports = {
         'mdx/code-blocks': true
       },
       rules: {
-        'no-unused-expressions': 'off'
+        'no-unused-expressions': 'off',
+        'semi': ['error', 'never']
       }
     }
   ]


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Added a rule to enforce no semicolons being used because they are lame 

**Tests**

No tests configured at this time.

**Additional context**

Doing this to get RetroPGF

**Metadata**

- Fixes #[Link to Issue]
