### PR TITLE
fix: Blockscout Configuration

### DIFF
--- a/pages/builders/chain-operators/explorer.mdx
+++ b/pages/builders/chain-operators/explorer.mdx
@@ -51,7 +51,7 @@ Download and install [Docker engine](https://docs.docker.com/engine/install/#ser
     ln -s `pwd`/envs ..
     ```
 
-3.  If `op-geth` in archive mode runs on a different computer or a port that isn't 8545, edit `docker-compose-no-build-geth.yml` to set `ETHEREUM_JSONRPC_HTTP_URL` to the correct URL.
+3.  If `op-geth` in archive mode runs on a different computer or a port that isn't 8545, edit `envs/common-blockscout.env` to set `ETHEREUM_JSONRPC_HTTP_URL` to the correct URL. and If you want to access `Blockscout` on other hosts, replace `localhost` in `docker-compose/envs/common-frontend.env` with the IP address of the computer running `Blockscout`.
 
 4.  Start Blockscout
 
@@ -61,7 +61,7 @@ Download and install [Docker engine](https://docs.docker.com/engine/install/#ser
 
 ## Usage
 
-After the docker containers start, browse to http:// \< *computer running Blockscout* > :4000 to view the user interface.
+After the docker containers start, browse to http:// \< *computer running Blockscout* > to view the user interface.
 
 You can also use the [API](https://docs.blockscout.com/for-users/api)
 


### PR DESCRIPTION
Blockscout has been upgraded to a new version, and the previous port 4000 is no longer accessible. Please refer to https://docs.blockscout.com/for-developers/frontend-migration for more information.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**




**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
http://146.190.127.32/
**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[https://github.com/ethereum-optimism/docs/issues/121]
Location: https://docs.optimism.io/chain-operators/explorer

Blockscout version update may have resulted in this information being outdated