### PR TITLE
Change branch and command in the instruction for Blockscout launch

### DIFF
--- a/pages/builders/chain-operators/explorer.mdx
+++ b/pages/builders/chain-operators/explorer.mdx
@@ -40,7 +40,7 @@ Download and install [Docker engine](https://docs.docker.com/engine/install/#ser
 
     ```sh
     cd ~
-    git clone https://github.com/blockscout/blockscout.git
+    git clone https://github.com/blockscout/blockscout.git -b production-optimism
     cd blockscout/docker-compose
     ```
 
@@ -56,7 +56,7 @@ Download and install [Docker engine](https://docs.docker.com/engine/install/#ser
 4.  Start Blockscout
 
     ```sh
-    docker compose -f docker-compose-no-build-geth.yml up
+    DOCKER_REPO=blockscout-optimism docker compose -f geth.yml up
     ```
 
 ## Usage


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Change explorer (Blockscout) running instructions:

- change explorer port 4000 -> 80
- clone production-optimism branch
- launching command is changed: specific to OP-stack docker image is used and the name of config.yml is changed.


**Additional context**

The same changes as proped for https://github.com/ethereum-optimism/stack-docs/pull/42.

