### PR TITLE
fix: update eth amount in bridge tutorial

### DIFF
--- a/pages/builders/dapp-developers/tutorials/cross-dom-bridge-eth.mdx
+++ b/pages/builders/dapp-developers/tutorials/cross-dom-bridge-eth.mdx
@@ -163,7 +163,7 @@ Create an instance of the `CrossChainMessenger` class:
 Now you can deposit your ETH into the Standard Bridge contract.
 You'll deposit a small amount of ETH just to demonstrate the process.
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-eth.js#L24-L25 hash=ce11a2dabfed5f70016f2c82eae9262c
+```js file=<rootDir>/public/tutorials/cross-dom-bridge-eth.js#L24-L25 hash=8bd6fdfe984274e8ec2368dc735118b4
 ```
 
 {<h3>Wait for the deposit to be relayed</h3>}
@@ -201,7 +201,7 @@ Now you're going to repeat the process in reverse to bridge some ETH from L2 to 
 
 The first step to withdrawing ETH from L2 to L1 is to start the withdrawal on L2.
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-eth.js#L37-L38 hash=562c1ad81362ab4014cd182a44f09364
+```js file=<rootDir>/public/tutorials/cross-dom-bridge-eth.js#L37-L38 hash=e9880eb7e7e95253637b5b88a4772074
 ```
 
 {<h3>Check your balance on L2</h3>}

--- a/public/tutorials/cross-dom-bridge-eth.js
+++ b/public/tutorials/cross-dom-bridge-eth.js
@@ -21,7 +21,7 @@ const messenger = new optimism.CrossChainMessenger({
 })
 
 console.log('Depositing ETH...')
-tx = await messenger.depositETH(ethers.utils.parseEther('0.01'))
+tx = await messenger.depositETH(ethers.utils.parseEther('0.006942'))
 await tx.wait()
 
 console.log('Waiting for deposit to be relayed...')
@@ -34,7 +34,7 @@ console.log('L2 balance:')
 console.log((await l2Wallet.getBalance()).toString())
 
 console.log('Withdrawing ETH...')
-const withdrawal = await messenger.withdrawETH(ethers.utils.parseEther('0.01'))
+const withdrawal = await messenger.withdrawETH(ethers.utils.parseEther('0.004269'))
 await withdrawal.wait()
 
 console.log('L2 balance:')


### PR DESCRIPTION
Updates the ETH amount used in the bridge tutorial. More recognizable and makes sure the second amount is LESS than the first amount because that would cause issues if the user has no OP Sepolia ETH.