### PR TITLE
feat: move security policy higher

### DIFF
--- a/pages/chain/security/_meta.json
+++ b/pages/chain/security/_meta.json
@@ -1,4 +1,10 @@
 {
-    "faq": "Security FAQ",
-    "privileged-roles": "Privileged Roles"
+    "faq": "Security Model & FAQ",
+    "privileged-roles": "Privileged Roles",
+    "security-policy": "Security Policy",
+    "bug-bounty": {
+        "title": "Bug Bounty Program",
+        "href": "https://immunefi.com/bounty/optimism/",
+        "newWindow": true
+    }
 }

--- a/pages/chain/security/faq.mdx
+++ b/pages/chain/security/faq.mdx
@@ -23,7 +23,7 @@ It's important to understand that using OP Mainnet inherently exposes you to the
 
 ## Next gen fault proofs
 
-As part of the OVM 2.0 upgrade, the **Optimism fault proof mechanism had to be temporarily disabled**. This means that users of the OP Mainnet network currently need to trust the Sequencer node (run by Optimism Foundation) to publish valid state roots to Ethereum. **You can also read more about our [security model](/connect/resources/security-policy)**.
+As part of the OVM 2.0 upgrade, the **Optimism fault proof mechanism had to be temporarily disabled**. This means that users of the OP Mainnet network currently need to trust the Sequencer node (run by Optimism Foundation) to publish valid state roots to Ethereum. **You can also read more about our [security model](/chain/security/security-policy)**.
 
 We're making progress on the upgrade fault proof mechanism and we expect to productionize our work in 2023. You can keep up with developments in the [Cannon repository](https://github.com/ethereum-optimism/cannon/).
 
@@ -60,10 +60,10 @@ Check out Optimism's detailed [Pragmatic Path to Decentralization](https://mediu
 
 ### How can I help make OP Mainnet more secure?
 
-[OP Mainnet has one of the biggest bug bounties (ever)](/connect/resources/security-policy).
+[OP Mainnet has one of the biggest bug bounties (ever)](/chain/security/security-policy).
 You can earn up to $2,000,042 by finding critical bugs in the Optimism codebase.
 You can also run your own verifier node to detect network faults.
 
 ### Where do I report bugs?
 
-For details about reporting vulnerabilities and available bug bounty programs, see the [Security Policy](/connect/resources/security-policy).
+For details about reporting vulnerabilities and available bug bounty programs, see the [Security Policy](/chain/security/security-policy).

--- a/pages/chain/security/security-policy.mdx
+++ b/pages/chain/security/security-policy.mdx
@@ -11,25 +11,20 @@ import { Callout } from 'nextra/components'
 This page describes general best practices for reporting bugs and provides specific reporting guidelines for OP Stack and OP Mainnet code contained within the [ethereum-optimism](https://github.com/ethereum-optimism) GitHub organization.
 
 <Callout type="error">
-  How NOT to disclose a vulnerability
+  **Do not** disclose vulnerabilities publicly or by executing them against a production network. If you do, will you not only be putting users at risk, but you will forfeit your right to a reward. Always follow the appropriate reporting pathways as described below.
 
-  Do *not* disclose vulnerabilities publicly or by executing them against a production network. If you do, will you not only be putting users at risk, but you will forfeit your right to a reward. Always follow the appropriate reporting pathways as described below.
-
-  *   Do *not* disclose the vulnerability publicly, for example by filing a public ticket.
-  *   Do *not* test the vulnerability on a publicly available network, either the testnet or the mainnet.
+  *   **Do not** disclose the vulnerability publicly, for example by filing a public ticket.
+  *   **Do not** test the vulnerability on a publicly available network, either the testnet or the mainnet.
 </Callout>
 
 ## Optimism Bug Bounty Program
 
-Optimism takes security seriously and as such, we have a massive bug bounty program. We don't just talk about it either! We have given out one of the [largest bounty payouts ever](https://medium.com/ethereum-optimism/disclosure-fixing-a-critical-bug-in-optimisms-geth-fork-a836ebdf7c94)! You can read more about that bug [here](https://web.archive.org/web/20230104144930/https://www.saurik.com/optimism.html). Below are the various bug bounty programs we have, as well as how to reach out to us if your bug is not covered by an existing bounty.
+The Optimism Bug Bounty Program offers up to [$2,000,042](https://immunefi.com/bounty/optimism/) for critical vulnerabilities found in the OP Mainnet codebase.
+Below you can find information about the various available bug bounty programs and how to report bugs that are not covered by an existing bounty.
 
 ### Main Bounty Page
 
 Optimism has a very detailed [Bug Bounty Page on Immunefi](https://immunefi.com/bounty/optimism/). In the listing you can find all the information relating to components in scope, reporting, and the payout process.
-
-### Bedrock Audit Contest
-
-With our upcoming launch of [Bedrock](/stack/differences) we have launched a [Sherlock audit contest](https://app.sherlock.xyz/audits/contests/38).
 
 ### Unscoped Bugs
 

--- a/pages/connect/contribute/docs-contribute.mdx
+++ b/pages/connect/contribute/docs-contribute.mdx
@@ -34,7 +34,7 @@ Optimism Developer Docs (docs.optimism.io) is an open-source project, and we wel
 *   [Work on an open issue](https://github.com/ethereum-optimism/docs/issues): start with items we've already identified as needing attention, which range from general guides to tutorials and quickstarts.
 *   [Create new content](https://github.com/ethereum-optimism/docs/issues/new): create new content to add to the technical docs.
     Review the [style guide](style-guide) and follow the PR process outlined in the [contributor guidelines](https://github.com/ethereum-optimism/docs/blob/main/CONTRIBUTING.md) to get started.
-*   [Submit a bug report](https://immunefi.com/bounty/optimism/): create a report to help us improve our products and developer tooling. For more information, please read our [Security Policy](/connect/resources/security-policy).
+*   [Submit a bug report](https://immunefi.com/bounty/optimism/): create a report to help us improve our products and developer tooling. For more information, please read our [Security Policy](/chain/security/security-policy).
 *   [Contribute to the Optimism Collective](https://github.com/ethereum-optimism/ecosystem-contributions): select from several different categories where you can make an impact such as
     [foundation missions](https://github.com/ethereum-optimism/ecosystem-contributions/issues?q=is%3Aissue+is%3Aopen+label%3A%22Foundation+Mission+%28RFP%29%22) or general [contributor opportunities](https://github.com/ethereum-optimism/ecosystem-contributions/issues?q=is%3Aissue+is%3Aopen+label%3A%22Contribution+Opportunity%22).
 

--- a/pages/connect/contribute/stack-contribute.mdx
+++ b/pages/connect/contribute/stack-contribute.mdx
@@ -35,7 +35,7 @@ To make your first contribution to the codebase, check out the [open issues](htt
 
 ## Bounty Hunting
 
-The OP Stack needs YOU (yes you!) to help review the codebase for bugs and vulnerabilities. If you're interested in bounty hunting, check out our [Security Policy, Vulnerability Reporting, and Bug Bounties page](../resources/security-policy).
+The OP Stack needs YOU (yes you!) to help review the codebase for bugs and vulnerabilities. If you're interested in bounty hunting, check out our [Security Policy, Vulnerability Reporting, and Bug Bounties page](/chain/security/security-policy).
 
 ## Docs Contributions
 

--- a/pages/connect/resources/_meta.json
+++ b/pages/connect/resources/_meta.json
@@ -1,10 +1,4 @@
 {
-    "security-policy": "Security Policy",
-    "bug-bounty": {
-        "title": "Bug Bounty Program",
-        "href": "https://immunefi.com/bounty/optimism/",
-        "newWindow": true
-    },
     "changelog": {
         "title": "Changelog",
         "href": "https://github.com/ethereum-optimism/optimism/releases",

--- a/pages/stack/security/faq.mdx
+++ b/pages/stack/security/faq.mdx
@@ -46,4 +46,4 @@ Don't forget that the OP Stack is a decentralized development stack. Anyone can 
 
 ### Where do I report bugs?
 
-For details about reporting vulnerabilities and available bug bounty programs, see the [Security Policy](/connect/resources/security-policy).
+For details about reporting vulnerabilities and available bug bounty programs, see the [Security Policy](/chain/security/security-policy).


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Moves the Security Policy page to the chain/security folder to make it more visible. Also updates the title of the Security FAQ page to highlight that the page describes the security model.