### PR TITLE
Fix: fix one typo in the tutorial

### DIFF
--- a/pages/builders/dapp-developers/tutorials/first-contract.mdx
+++ b/pages/builders/dapp-developers/tutorials/first-contract.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploying Your First Contract on OP Mainnet
 lang: en-US
-description: Learn how to write and deploy your first contact on OP Mainnet using the MetaMask browser extension.
+description: Learn how to write and deploy your first contract on OP Mainnet using the MetaMask browser extension.
 ---
 
 import { Callout, Steps } from 'nextra/components'


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

A typo is fixed in the following document:
- /pages/builders/dapp-developers/tutorials/first-contract.mdx