### PR TITLE
feat: add solidity compatibility page

### DIFF
--- a/pages/builders/dapp-developers/contracts/_meta.json
+++ b/pages/builders/dapp-developers/contracts/_meta.json
@@ -1,4 +1,5 @@
 {
+  "compatibility": "Solidity Compatibility",
   "system-contracts": "System Contracts",
   "optimization": "Cost Optimization"
 }

--- a/pages/builders/dapp-developers/contracts/compatibility.mdx
+++ b/pages/builders/dapp-developers/contracts/compatibility.mdx
@@ -1,0 +1,24 @@
+---
+title: Solidity Compatibility
+lang: en-US
+description: Learn about the differences between OP Mainnet and Ethereum when building Solidity contracts.
+---
+
+# Solidity Compatibility
+
+OP Mainnet is designed to be [EVM equivalent](https://medium.com/ethereum-optimism/introducing-evm-equivalence-5c2021deb306), which means OP Mainnet looks exactly like Ethereum in every way possible.
+Almost all Ethereum tooling works out of the box on OP Mainnet, including the [Solidity](https://soliditylang.org/) smart contract language.
+However, there are a few minor sdifferences between OP Mainnet and Ethereum that you should be aware of when building Solidity contracts.
+
+## EVM/Opcode Differences
+
+Most smart contracts will work on OP Mainnet without any changes.
+Check out the [Differences Between Ethereum and OP Mainnet](/chain/differences#opcodes) page for a detailed list of the few differences you should know about.
+
+## Gas Differences
+
+OP Mainnet uses the same gas costs as Ethereum.
+However, OP Mainnet also charges an [L1 Data Fee](/stack/transactions/transaction-fees#l1-data-fee) for the cost of publishing an L2 transaction to L1.
+This fee is charged based on the size of a tranasction in bytes.
+As a result, smart contract optimization techniques can differ slightly on OP Mainnet.
+Refer to the [Contract Optimization guide](./optimization) for more information.


### PR DESCRIPTION
Adds a small page called "Solidity Compatibility" that basically just links out to other pages. Idea here is to clearly highlight the differences page during the dapp developer flow in a natural way.
