### PR TITLE
adding callout devs running erigon

### DIFF
--- a/pages/builders/node-operators/management/configuration.mdx
+++ b/pages/builders/node-operators/management/configuration.mdx
@@ -31,7 +31,7 @@ We'll start with `op-geth`'s configuration because it is more complex. As mentio
 1.  **With a Genesis File:** This is for OP Sepolia, and other testnets or deployments that are not migrated from a legacy network. In this case, you'll download the [genesis file](https://networks.optimism.io/op-sepolia/genesis.json) and initialize the data directory via `geth init`.
 2.  **With a Data Directory:** This is used for networks that are migrated from a legacy network. This currently **only** includes OP Mainnet. In this case, you'll download a preconfigured data directory and extract it. No further initialization is necessary in this case, because the data directory contains the network's genesis information.
 
-Regardless of how `op-geth` is initialized, you'll need to ensure that you have sufficient disk space available to store the network's data. As of this writing, the mainnet data directory is ~100GB for a full node and ~1TB for an archival node.
+Regardless of how `op-geth` is initialized, you'll need to ensure that you have sufficient disk space available to store the network's data. As of this writing, the mainnet data directory is \~100GB for a full node and \~1TB for an archival node.
 
 Instructions for each initialization method are below. If you're spinning up an OP Mainnet, use the [Initialization via Data Directory](#initialization-via-data-directory) path. If you're spinning up an OP Sepolia node, use the [Initialization via Genesis File](#initialization-via-genesis-file) path.
 
@@ -323,10 +323,11 @@ Poll interval for reloading the runtime config, useful when config events are no
 Trust the L1 RPC, sync faster at risk of malicious/buggy RPC providing bad or inconsistent L1 data. The default value is `false`.
 
 <Callout type="info">
-  If you're running an Erigon Ethereum execution client for your L1 provider you will need to include `--l1.trustrpc`. At the time of writing, 
-  Erigon doesn’t support the `eth_getProof` that we prefer to use to load L1 data for some processing in `op-node`. The trustrpc flag makes it 
-  use something else that erigon supports, but the `op-node` can’t verify for correctness.
+  If you're running an Erigon Ethereum execution client for your L1 provider you will need to include `--l1.trustrpc`. At the time of writing,
+  Erigon doesn't support the `eth_getProof` that we prefer to use to load L1 data for some processing in `op-node`. The trustrpc flag makes it
+  use something else that erigon supports, but the `op-node` can't verify for correctness.
 </Callout>
+
 <Tabs items={['Syntax', 'Example', 'Environment Variable']}>
   <Tabs.Tab>`--l1.trustrpc=<boolean>`</Tabs.Tab>
   <Tabs.Tab>`--l1.trustrpc=false`</Tabs.Tab>
@@ -1845,7 +1846,7 @@ Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail. The def
 
 ###### `ethstats`
 
-Reporting URL of an ethstats service (nodename:secret@host:port).
+Reporting URL of an ethstats service (nodename:secret\@host:port).
 
 <Tabs items={['Syntax', 'Example', 'Environment Variable']}>
   <Tabs.Tab>`--ethstats=<value>`</Tabs.Tab>

--- a/pages/builders/node-operators/management/configuration.mdx
+++ b/pages/builders/node-operators/management/configuration.mdx
@@ -322,6 +322,11 @@ Poll interval for reloading the runtime config, useful when config events are no
 
 Trust the L1 RPC, sync faster at risk of malicious/buggy RPC providing bad or inconsistent L1 data. The default value is `false`.
 
+<Callout type="info">
+  If you're running an Erigon Ethereum execution client for your L1 provider you will need to include `--l1.trustrpc`. At the time of writing, 
+  Erigon doesn’t support the `eth_getProof` that we prefer to use to load L1 data for some processing in `op-node`. The trustrpc flag makes it 
+  use something else that erigon supports, but the `op-node` can’t verify for correctness.
+</Callout>
 <Tabs items={['Syntax', 'Example', 'Environment Variable']}>
   <Tabs.Tab>`--l1.trustrpc=<boolean>`</Tabs.Tab>
   <Tabs.Tab>`--l1.trustrpc=false`</Tabs.Tab>

--- a/pages/builders/node-operators/tutorials/mainnet.mdx
+++ b/pages/builders/node-operators/tutorials/mainnet.mdx
@@ -175,7 +175,9 @@ You will need 500+ GB for this part alone.
   *   Set the `/path/to/op-geth/jwt.txt` to the path of the shared secret you generated in a previous step
 
   <Callout type="info">
-    If you're running an Erigon Ethereum execution client for your L1 provider you will need to include `--l1.trustrpc`.
+    If you're running an Erigon Ethereum execution client for your L1 provider you will need to include `--l1.trustrpc`. At the time of writing, 
+    Erigon doesn’t support the `eth_getProof` that we prefer to use to load L1 data for some processing in `op-node`. The trustrpc flag makes it 
+    use something else that erigon supports, but the `op-node` can’t verify for correctness.
   </Callout>
   ```sh
   ./bin/op-node \

--- a/pages/builders/node-operators/tutorials/mainnet.mdx
+++ b/pages/builders/node-operators/tutorials/mainnet.mdx
@@ -104,7 +104,7 @@ You will need 500+ GB for this part alone.
 <Steps>
   ### Navigate into your `op-geth` directory
 
-  ### Create a random number 
+  ### Create a random number
 
   This will be the shared secret for `op-geth` and `op-node` to communicate over the engine API authrpc.
 
@@ -135,9 +135,9 @@ You will need 500+ GB for this part alone.
 <Steps>
   ### Navigate into your `op-geth` directory
 
-  ### Start `op-geth` with the following command 
+  ### Start `op-geth` with the following command
 
-  *   Make sure you update your path to your data directory 
+  *   Make sure you update your path to your data directory
 
   ```sh
   ./build/bin/geth \
@@ -175,10 +175,11 @@ You will need 500+ GB for this part alone.
   *   Set the `/path/to/op-geth/jwt.txt` to the path of the shared secret you generated in a previous step
 
   <Callout type="info">
-    If you're running an Erigon Ethereum execution client for your L1 provider you will need to include `--l1.trustrpc`. At the time of writing, 
-    Erigon doesn’t support the `eth_getProof` that we prefer to use to load L1 data for some processing in `op-node`. The trustrpc flag makes it 
-    use something else that erigon supports, but the `op-node` can’t verify for correctness.
+    If you're running an Erigon Ethereum execution client for your L1 provider you will need to include `--l1.trustrpc`. At the time of writing,
+    Erigon doesn't support the `eth_getProof` that we prefer to use to load L1 data for some processing in `op-node`. The trustrpc flag makes it
+    use something else that erigon supports, but the `op-node` can't verify for correctness.
   </Callout>
+
   ```sh
   ./bin/op-node \
       --l1=<< L1 RPC URL >>  \

--- a/pages/builders/node-operators/tutorials/mainnet.mdx
+++ b/pages/builders/node-operators/tutorials/mainnet.mdx
@@ -174,6 +174,9 @@ You will need 500+ GB for this part alone.
   *   Set `L1 RPC KIND` to the network provider you are using (options: alchemy, quicknode, infura, parity, nethermind, debug\_geth, erigon, basic, any).
   *   Set the `/path/to/op-geth/jwt.txt` to the path of the shared secret you generated in a previous step
 
+  <Callout type="info">
+    If you're running an Erigon Ethereum execution client for your L1 provider you will need to include `--l1.trustrpc`.
+  </Callout>
   ```sh
   ./bin/op-node \
       --l1=<< L1 RPC URL >>  \

--- a/pages/builders/node-operators/tutorials/testnet.mdx
+++ b/pages/builders/node-operators/tutorials/testnet.mdx
@@ -86,8 +86,11 @@ geth init \
   *   Set the `/path/to/op-geth/jwt.txt` to the path of the shared secret you generated in a previous step
 
   <Callout type="info">
-    If you're running an Erigon Ethereum execution client for your L1 provider you will need to include `--l1.trustrpc`.
+    If you're running an Erigon Ethereum execution client for your L1 provider you will need to include `--l1.trustrpc`. At the time of writing, 
+    Erigon doesn’t support the `eth_getProof` that we prefer to use to load L1 data for some processing in `op-node`. The trustrpc flag makes it 
+    use something else that erigon supports, but the `op-node` can’t verify for correctness.
   </Callout>
+
   ```sh
   ./bin/op-node \
       --l1=<< L1 RPC URL >>  \

--- a/pages/builders/node-operators/tutorials/testnet.mdx
+++ b/pages/builders/node-operators/tutorials/testnet.mdx
@@ -85,6 +85,9 @@ geth init \
   *   Set `L1 RPC KIND` to the network provider you are using (options: alchemy, quicknode, infura, parity, nethermind, debug\_geth, erigon, basic, any).
   *   Set the `/path/to/op-geth/jwt.txt` to the path of the shared secret you generated in a previous step
 
+  <Callout type="info">
+    If you're running an Erigon Ethereum execution client for your L1 provider you will need to include `--l1.trustrpc`.
+  </Callout>
   ```sh
   ./bin/op-node \
       --l1=<< L1 RPC URL >>  \

--- a/pages/builders/node-operators/tutorials/testnet.mdx
+++ b/pages/builders/node-operators/tutorials/testnet.mdx
@@ -37,7 +37,7 @@ geth init \
 <Steps>
   ### Navigate into your `op-geth` directory
 
-  ### Create a random number 
+  ### Create a random number
 
   This will be the shared secret for `op-geth` and `op-node` to communicate over the engine API authrpc.
 
@@ -49,11 +49,11 @@ geth init \
 ## Start `op-geth`
 
 <Steps>
-  ### Navigate into your `op-geth` directory 
+  ### Navigate into your `op-geth` directory
 
-  ### Start `op-geth` with the following command 
+  ### Start `op-geth` with the following command
 
-  *   Make sure you update your path to your data directory 
+  *   Make sure you update your path to your data directory
 
   ```sh
   ./build/bin/geth \
@@ -86,9 +86,9 @@ geth init \
   *   Set the `/path/to/op-geth/jwt.txt` to the path of the shared secret you generated in a previous step
 
   <Callout type="info">
-    If you're running an Erigon Ethereum execution client for your L1 provider you will need to include `--l1.trustrpc`. At the time of writing, 
-    Erigon doesn’t support the `eth_getProof` that we prefer to use to load L1 data for some processing in `op-node`. The trustrpc flag makes it 
-    use something else that erigon supports, but the `op-node` can’t verify for correctness.
+    If you're running an Erigon Ethereum execution client for your L1 provider you will need to include `--l1.trustrpc`. At the time of writing,
+    Erigon doesn't support the `eth_getProof` that we prefer to use to load L1 data for some processing in `op-node`. The trustrpc flag makes it
+    use something else that erigon supports, but the `op-node` can't verify for correctness.
   </Callout>
 
   ```sh


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

When users are running erigon as their L1 rpc provider, they need to include `--l1.trustrpc`.

**Additional context**

This was reported here: https://github.com/ethereum-optimism/developers/discussions/126

**Metadata**

- Fixes https://github.com/ethereum-optimism/docs/issues/304
