### PR TITLE
fix： Devnet Guide Update

### DIFF
--- a/pages/chain/testing/dev-node.mdx
+++ b/pages/chain/testing/dev-node.mdx
@@ -39,25 +39,29 @@ The Optimism monorepo includes [a devnode setup you can use](https://github.com/
 ## Installation
 
 First, make sure these components are installed.
-Note that the command line directions were verified under Ubuntu 20.04 LTS.
+Note that the command line directions were verified under Ubuntu 22.04 LTS.
 Other OSes or versions may use different tools.
 
 <Steps>
-  ### Install the command line utilities `make` and `jq`
+  ### Install the command line utilities `make` `jq` and `foundry`
 
   ```sh
   sudo apt install -y make jq
+  curl -L https://foundry.paradigm.xyz | bash
+  . ~/.bashrc
+  foundryup
   ```
 
   ### Install [Go programming language](https://go.dev/)
 
   ```sh
   sudo apt update
-  wget https://go.dev/dl/go1.20.linux-amd64.tar.gz
-  tar xvzf go1.20.linux-amd64.tar.gz
+  wget https://go.dev/dl/go1.21.5.linux-amd64.tar.gz
+  tar xvzf go1.21.5.linux-amd64.tar.gz
   sudo cp go/bin/go /usr/bin/go
   sudo mv go /usr/lib
   echo export GOROOT=/usr/lib/go >> ~/.bashrc
+  . ~/.bashrc
   ```
 
   ### Clone the Optimism monorepo


### PR DESCRIPTION
The optimism repo was updated, causing the documentation guidelines to outdate.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Issue 1：
../op-preimage/verifier.go:6:2: package slices is not in GOROOT (/usr/lib/go/src/slices)
**note: imported by a module that requires go 1.21**
make[2]: *** [Makefile:19: op-program-host] Error 1
make[2]: Leaving directory '/root/optimism/op-program'
make[1]: *** [Makefile:84: op-program] Error 2
make[1]: Leaving directory '/root/optimism'
make: *** [Makefile:115: pre-devnet] Error 2

Issue 2:
File "/root/optimism/bedrock-devnet/devnet/init.py", line 168, in devnet_l1_genesis
geth = subprocess.Popen([
File "/usr/lib/python3.10/subprocess.py", line 969, in init
self._execute_child(args, executable, preexec_fn, close_fds,
File "/usr/lib/python3.10/subprocess.py", line 1845, in _execute_child
raise child_exception_type(errno_num, err_msg, err_filename)
**FileNotFoundError: [Errno 2] No such file or directory: 'anvil'**
**Tests**
Tested:
```
root@simple:~# docker ps
CONTAINER ID   IMAGE                                                                COMMAND                  CREATED          STATUS          PORTS                                                                                                                                                                        NAMES
a32170cecf64   nginx:1.25-alpine                                                    "/docker-entrypoint.…"   48 minutes ago   Up 48 minutes   0.0.0.0:8080->80/tcp, :::8080->80/tcp                                                                                                                                        ops-bedrock-artifact-server-1
ca94f3c2c451   us-docker.pkg.dev/oplabs-tools-artifacts/images/op-proposer:devnet   "op-proposer"            48 minutes ago   Up 48 minutes   0.0.0.0:6062->6060/tcp, :::6062->6060/tcp, 0.0.0.0:7302->7300/tcp, :::7302->7300/tcp, 0.0.0.0:6546->8545/tcp, :::6546->8545/tcp                                              ops-bedrock-op-proposer-1
b070919ef10e   us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:devnet    "op-batcher"             48 minutes ago   Up 48 minutes   0.0.0.0:6061->6060/tcp, :::6061->6060/tcp, 0.0.0.0:7301->7300/tcp, :::7301->7300/tcp, 0.0.0.0:6545->8545/tcp, :::6545->8545/tcp                                              ops-bedrock-op-batcher-1
8fc8b08d4cc0   us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:devnet       "op-node --l1=ws://l…"   48 minutes ago   Up 48 minutes   0.0.0.0:6060->6060/tcp, :::6060->6060/tcp, 0.0.0.0:7300->7300/tcp, :::7300->7300/tcp, 0.0.0.0:9003->9003/tcp, :::9003->9003/tcp, 0.0.0.0:7545->8545/tcp, :::7545->8545/tcp   ops-bedrock-op-node-1
8b8b89a90c78   ops-bedrock-l2                                                       "/bin/sh /entrypoint…"   48 minutes ago   Up 48 minutes   8546/tcp, 30303/tcp, 30303/udp, 0.0.0.0:8060->6060/tcp, :::8060->6060/tcp, 0.0.0.0:9545->8545/tcp, :::9545->8545/tcp                                                         ops-bedrock-l2-1
6e9a7d772ee0   ops-bedrock-l1                                                       "/bin/bash /entrypoi…"   48 minutes ago   Up 48 minutes   0.0.0.0:8545-8546->8545-8546/tcp, :::8545-8546->8545-8546/tcp, 30303/tcp, 30303/udp, 0.0.0.0:7060->6060/tcp, :::7060->6060/tcp  
```
**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[https://github.com/ethereum-optimism/developers/discussions/127#discussioncomment-7870527]
