### PR TITLE
fix: --network and --op-network flags mixed up

### DIFF
--- a/pages/builders/node-operators/management/configuration.mdx
+++ b/pages/builders/node-operators/management/configuration.mdx
@@ -131,7 +131,7 @@ geth \
   --nodiscover \
   --syncmode=full \
   --maxpeers=0 \
-  --network=op-mainnet
+  --op-network=op-mainnet
 ```
 
 Consult [Geth's documentation](https://geth.ethereum.org/docs/) for more information on customizing `op-geth`'s behavior.
@@ -147,7 +147,7 @@ A minimal valid configuration that runs `op-node` looks like:
 ```bash
 op-node --l1=<ethereum mainnet RPC url> \
         --l2=<op-geth authenticated RPC url> \
-        --op-network=op-mainnet \
+        --network=op-mainnet \
         --rpc.addr=127.0.0.1 \
         --rpc.port=9545 \
         --l2.jwt-secret=<path to JWT secret>


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

The `--network` and `--op-network` flags are mixed up in the op-geth and op-node service configuration examples.

**Tests**

Not needed because this is a typo correction.

**Additional context**

None

**Metadata**

None
