### PR TITLE
update final command `make geth` not `make op-geth`

### DIFF
--- a/pages/builders/node-operators/tutorials/node-from-source.mdx
+++ b/pages/builders/node-operators/tutorials/node-from-source.mdx
@@ -141,7 +141,7 @@ Some releases may only be required for the OP Sepolia testnet.
 Build the `op-geth` implementation of the Execution Client.
 
 ```bash
-make op-geth
+make geth
 ```
 
 </Steps>


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
In the 3rd step [here](https://docs.optimism.io/builders/node-operators/tutorials/node-from-source#build-the-execution-client) the build command is updated from `make op-geth` to `make geth`
**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
