### PR TITLE
Update glossary.mdx

### DIFF
--- a/pages/connect/resources/glossary.mdx
+++ b/pages/connect/resources/glossary.mdx
@@ -238,7 +238,7 @@ the modular, open source, MIT-licensed development stack that powers the OP Main
 
 #### OP Stack Fork
 
-Layer 2 blockchain that has been built using the MIT-licensed OP Stack, but is not governed by Optimism's governance or contributing sequencer revenue back to the Collective (and therefore is not on track to become part of the Superchain). This means OP Stack Chains won't necessarily share security or interoperability with OP Chains in the Superchain.
+Layer 2 blockchain that has been built using the MIT-licensed OP Stack, but is not governed by Optimism's governance or contributing sequencer revenue back to the Collective (and therefore is not on track to become part of the Superchain). This means OP Stack Forks won't necessarily share security or interoperability with OP Chains in the Superchain.
 
 #### Plasma Chain
 


### PR DESCRIPTION
For OP Stack Fork definition, fixing this line:

> This means OP Stack Chains won't necessarily share security or interoperability with OP Chains in the Superchain.

To say:

> This means OP Stack Forks won't necessarily share security or interoperability with OP Chains in the Superchain.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->


**Additional context**

For clarity, we are no longer referring to "OP Stack Chains" especially when referring to forks that are not in the Superchain. There are OP Stack Forks, and there are OP Chains.
