### PR TITLE
fix: tutorial ci concurrency

### DIFF
--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 0 * * *'  # Runs at 00:00 UTC every day
 
+concurrency:
+  group: shared-tutorial-key
+  cancel-in-progress: false
+
 jobs:
   cross-dom-bridge-erc20:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Prevent tutorial CI jobs from running concurrently since this can cause a race condition when two transactions are sent with the same nonce at the same time.