### PR TITLE
fix: change the minimum version of make

### DIFF
--- a/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
+++ b/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
@@ -79,7 +79,7 @@ You'll be using the [`op-proposer` implementation](https://github.com/ethereum-o
 | [node](https://nodejs.org/en/)                                | `^20`    | `node --version`      |
 | [pnpm](https://pnpm.io/installation)                          | `^8`     | `pnpm --version`      |
 | [foundry](https://github.com/foundry-rs/foundry#installation) | `^0.2.0` | `forge --version`     |
-| [make](https://linux.die.net/man/1/make)                      | `^4`     | `make --version`      |
+| [make](https://linux.die.net/man/1/make)                      | `^3`     | `make --version`      |
 | [jq](https://github.com/jqlang/jq)                            | `^1.6`   | `jq --version`        |
 | [direnv](https://direnv.net)                                  | `^2`     | `direnv --version`    |
 


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Change the minimum version of make to reflect what the `./packages/contracts-bedrock/scripts/getting-started/versions.sh` script expects.

**Tests**

No tests are required

