### PR TITLE
adding activation callout

### DIFF
--- a/pages/builders/node-operators/network-upgrades/overview.mdx
+++ b/pages/builders/node-operators/network-upgrades/overview.mdx
@@ -4,7 +4,7 @@ lang: en-US
 description: Learn more about how network upgrades work and how to keep your nodes up to date.
 ---
 
-import { Steps } from 'nextra/components'
+import { Steps, Callout } from 'nextra/components'
 
 # Network Upgrade Overview
 
@@ -35,6 +35,12 @@ This section has information on how to upgrade your Mainnet and Testnet nodes fo
 </Steps>
 
 ## Activations
+
+<Callout type="info">
+  Network upgrade are activated by timestamps. Failing to upgrade your node 
+  before the timestamp will cause a chain divergence. You will need to 
+  resync your node to reconcile the chain.
+</Callout>
 
 | Upgrade                                                    | Governance Approval | OP Mainnet                                     | OP Sepolia                                     | OP Goerli                                      |
 | ---------------------------------------------------------- | ------------------- | ---------------------------------------------- | ---------------------------------------------- | ---------------------------------------------- |


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

If node operators miss the a network activation, their node will cause a chain divergence. The resolution is to resync the chain.
