### PR TITLE
update:point-to-dev-community-resources

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggest_faucet.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_faucet.yaml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Before submitting this suggestion, be sure to read the [listing of current Faucets](https://docs.optimism.io/tools/faucets).
+        Before submitting this suggestion, be sure to read the [listing of current Faucets](https://github.com/ethereum-optimism/developers/blob/main/community/tools/faucets.md).
   - type: markdown
     id: project_info
     attributes:

--- a/.github/ISSUE_TEMPLATE/suggest_rpc_provider.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_rpc_provider.yaml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Before submitting this suggestion, be sure to read the [listing of current RPC Providers](https://docs.optimism.io/tools/rpc-providers).
+        Before submitting this suggestion, be sure to read the [listing of current RPC and Node Providers](https://github.com/ethereum-optimism/developers/blob/main/community/tools/node-providers.md).
   - type: markdown
     id: project_info
     attributes:

--- a/pages/builders/tools/block-explorers.mdx
+++ b/pages/builders/tools/block-explorers.mdx
@@ -4,9 +4,15 @@ lang: en-US
 description: Learn about different block explorers you can use to interact with contracts and view transaction history for OP Mainnet and OP Sepolia.
 ---
 
+import { Callout } from 'nextra/components'
+
 # Block Explorers
 
 This reference guide lists different block explorers you can use to interact with contract source code and view transaction history for OP Mainnet and OP Sepolia.
+
+<Callout type="info">
+Please visit the community [Block Explorers page](https://github.com/ethereum-optimism/developers/blob/main/community/tools/block-explorers.md) for a listing of third-party block explorers being used or built by the Optimism developer community.
+</Callout>
 
 ## Blockscout
 

--- a/pages/builders/tools/faucets.mdx
+++ b/pages/builders/tools/faucets.mdx
@@ -31,6 +31,10 @@ The Superchain Faucet is a great place to start if you're looking for testnet ET
 | [Infura Faucet](https://www.infura.io/faucet/sepolia)      | Sepolia             |
 | [QuickNode Faucet](https://faucet.quicknode.com/optimism/) | Sepolia, OP Sepolia |
 
+<Callout type="info">
+Please visit the community [Testnet Faucets page](https://github.com/ethereum-optimism/developers/blob/main/community/tools/faucets.md) for a listing of third-party faucets being used or built by the Optimism developer community.
+</Callout>
+
 ## Bridge from Sepolia
 
 If you have testnet ETH on Sepolia, you can bridge it to OP Sepolia (and vice versa) using the [Optimism Bridge UI](https://app.optimism.io/bridge) or this collection of [Superchain Testnet Tools](https://www.superchain.tools/).

--- a/pages/builders/tools/rpc-providers.mdx
+++ b/pages/builders/tools/rpc-providers.mdx
@@ -4,9 +4,15 @@ lang: en-US
 description: Learn about different RPC and node providers to help you connect to an Optimism node.
 ---
 
+import { Callout } from 'nextra/components'
+
 # RPC & Node Providers
 
 This reference guide lists different RPC and node providers to help you connect to an Optimism node.
+
+<Callout type="info">
+Please visit the community [Node Providers page](https://github.com/ethereum-optimism/developers/blob/main/community/tools/node-providers.md) for a listing of third-party node providers being used by the Optimism developer community.
+</Callout>
 
 ## Ankr
 

--- a/pages/builders/tools/rpc-providers.mdx
+++ b/pages/builders/tools/rpc-providers.mdx
@@ -177,7 +177,3 @@ With the option to upgrade to a premium plan for additional features, we allow y
 *   OP Mainnet
 *   OP Sepolia
 
-## Don't see your company here?
-
-We try to keep this list up to date as we find out about more infrastructure providers who maintain OP Mainnet (and testnet) nodes.
-If you're a node provider and you'd like to be included in this list, please message us in our [developer support forum](https://github.com/ethereum-optimism/developers/discussions) or [make a PR](https://github.com/ethereum-optimism/community-hub/pulls).

--- a/pages/connect/contribute/docs-contribute.mdx
+++ b/pages/connect/contribute/docs-contribute.mdx
@@ -23,14 +23,18 @@ Optimism Docs (docs.optimism.io) is an open-source project, and we welcome your 
     add a new FAQ (question+answer set) to an [existing page](/chain/security/faq#security-model-faq), create a new FAQ page, or update an existing FAQ question/answer set.
 *   [Add or update a troubleshooting item](https://github.com/ethereum-optimism/docs/issues/new?assignees=\&labels=documentation%2Ctroubleshooting%2Ccommunity-request\&projects=\&template=suggest_troubleshooting_item.yaml\&title=Suggest+a+troubleshooting+item):
     add a new troubleshooting item (problem+solution set) to an [existing page](/builders/chain-operators/management/troubleshooting), create a new troubleshooting page, or update an existing troubleshooting problem/solution set.
-*   [Add an oracle to the developer tools](https://github.com/ethereum-optimism/docs/issues/new?assignees=\&labels=documentation%2Coracle%2Ccommunity-request\&projects=\&template=suggest_oracle.yaml\&title=Suggest+an+Oracle/):
-    add a new oracle to the [Oracles page](/builders/tools/oracles) or update an existing oracle.
-*   [Add a faucet to the developer tools](https://github.com/ethereum-optimism/docs/issues/new?assignees=\&labels=documentation%2Cfaucet%2Ccommunity-request\&projects=\&template=suggest_faucet.yaml\&title=Suggest+a+Faucet):
-    add a new faucet to the [Faucets page](/builders/tools/faucets) or update an existing faucet.
-*   [Add an RPC provider](https://github.com/ethereum-optimism/docs/issues/new?assignees=\&labels=documentation%2Crpc-provider%2Ccommunity-request\&projects=\&template=suggest_rpc_provider.yaml\&title=Suggest+an+RPC+provider):
-    add an RPC or Node provider to our [RPC developer tools listing](/builders/tools/rpc-providers).
 *   [Add a glossary term](https://github.com/ethereum-optimism/docs/issues/new?assignees=\&labels=glossary%2Cdocumentation%2Ccommunity-request\&projects=\&template=suggest_glossary_term.yaml\&title=Suggest+a+glossary+term):
     help us continue to expand the Optimism [glossary](/connect/resources/glossary).
+*   [Add a faucet to the developer community](https://github.com/ethereum-optimism/developers/tree/main/community):
+    add a new faucet to the [Faucets page](https://github.com/ethereum-optimism/developers/blob/main/community/tools/faucets.md) or update an existing faucet.
+*   [Add an oracle to the developer community](https://github.com/ethereum-optimism/developers/tree/main/community):
+    add a new oracle to the [Oracles page](https://github.com/ethereum-optimism/developers/blob/main/community/tools/oracles.md) or update an existing oracle.
+*   [Add a node provider to the developer community](https://github.com/ethereum-optimism/developers/tree/main/community)
+    add an RPC or Node provider to our [Node providers listing](https://github.com/ethereum-optimism/developers/blob/main/community/tools/node-providers.md) or update an existing node provider.
+*   [Add a block explorer to the developer community](https://github.com/ethereum-optimism/developers/tree/main/community):
+    add a new block explorer to the [Block Explorers page](https://github.com/ethereum-optimism/developers/blob/main/community/tools/block-explorers.md) or update an existing block explorer.
+*   [Add a blockchain indexer to the developer community](https://github.com/ethereum-optimism/developers/tree/main/community):
+    add a new blockchain indexer to the [Blockchain Indexers page](https://github.com/ethereum-optimism/developers/blob/main/community/tools/blockchain-indexers.md) or update an existing blockchain indexer.
 *   [Work on an open issue](https://github.com/ethereum-optimism/docs/issues): start with items we've already identified as needing attention, which range from general guides to tutorials and quickstarts.
 *   [Create new content](https://github.com/ethereum-optimism/docs/issues/new): create new content to add to the technical docs.
     Review the [style guide](style-guide) and follow the PR process outlined in the [contributor guidelines](https://github.com/ethereum-optimism/docs/blob/main/CONTRIBUTING.md) to get started.


### PR DESCRIPTION
- update links on docs contribute
- update links within git templates
- add callouts to respective pages, pointing to dev community resources

