### PR TITLE
fix: make sure tutorial jobs run in order

### DIFF
--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -48,6 +48,7 @@ jobs:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   cross-dom-bridge-eth:
+    needs: cross-dom-bridge-erc20
     runs-on: ubuntu-latest
 
     steps:
@@ -85,6 +86,7 @@ jobs:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   sdk-estimate-costs:
+    needs: cross-dom-bridge-eth
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Adds "needs" keywords to the tutorial workflow file so that each job runs after the previous job instead of running all at once. Should fix the last of the concurrency issues.