### PR TITLE
feat: add token list search section

### DIFF
--- a/pages/builders/dapp-developers/bridging/standard-bridge.mdx
+++ b/pages/builders/dapp-developers/bridging/standard-bridge.mdx
@@ -206,6 +206,31 @@ Consider checking this list to make sure that you're not using the wrong bridged
 Developers who are creating their own bridged tokens should consider [adding their token](https://github.com/ethereum-optimism/ethereum-optimism.github.io#adding-a-token-to-the-list) to the Superchain Token List.
 Tokens on the Superchain Token List will automatically appear on certain tools like the [Optimism Bridge UI](https://app.optimism.io/bridge).
 
+### Searching the Token List
+
+You should strongly consider using the Superchain Token List to verify that you're using the correct bridged representation of a token when bridging a native token.
+Doing so can help you avoid accidentally bridging to the wrong token and locking up your native token permanently.
+
+You can easily find the bridged representation of a token for OP Mainnet on the [Bridged Token Addresses](/chain/tokenlist#op-mainnet) page.
+If you want to find the bridged representation of a token for another chain, use the following steps.
+
+<Steps>
+
+{<h3>Find the token you want to bridge</h3>}
+
+The Superchain Token List is organized by the token's address and native blockchain.
+[Search the token list](https://github.com/ethereum-optimism/ethereum-optimism.github.io/blob/master/optimism.tokenlist.json) for the token you want to bridge to confirm that it's included in the list.
+Make sure that the chain ID in the entry matches the chain ID of the blockchain you're bridging from.
+Retrieve the token's name and symbol from the list.
+
+{<h3>Find the bridged representation of the token</h3>}
+
+Once you've found the token you want to bridge, look for the token's name and symbol in the list.
+Find the entry that matches the name and symbol of the token you want to bridge and where the chain ID matches the chain ID of the blockchain you're bridging to.
+The address of this entry is the address of the bridged representation of the token you want to bridge.
+
+</Steps>
+
 ## Special Considerations
 
 ### USDC


### PR DESCRIPTION
Adds a section to the standard bridge docs that explains how to search the token list properly. We should probably just make a tool for this eventually but this is a good start.