### PR TITLE
fix: update with canyon data

### DIFF
--- a/pages/chain/differences.mdx
+++ b/pages/chain/differences.mdx
@@ -19,7 +19,6 @@ However, there are some minor differences between the behavior of Ethereum and O
 | `PREVRANDAO` | `block.prevrandao`  | Set **pseudorandomly** for each block by the Sequencer as opposed to the stronger guarantees provided by [RANDAO](https://eips.ethereum.org/EIPS/eip-4399) on Ethereum.                                                                                 |
 | `ORIGIN`     | `tx.origin`         | If the transaction is an L1 ⇒ L2 transaction triggered by a smart contract on L1, then `tx.origin` is set to the [aliased address](#address-aliasing) of the address that triggered the L1 ⇒ L2 transaction. Otherwise, this opcode behaves normally.   |
 | `CALLER`     | `msg.sender`        | If the transaction is an L1 ⇒ L2 transaction triggered by a smart contract on L1, and this is the first call frame (rather than an internal transaction from one contract to another), the same [address aliasing](#address-aliasing) behavior applies. |
-| `PUSH0`      | -                   | Currently not supported by OP Mainnet. Support to be introduced as part of the [Canyon hardfork](https://web.archive.org/web/20231207231718/https://blog.oplabs.co/canyon-hardfork/).                                                                   |
 
 ### Address Aliasing
 
@@ -66,7 +65,7 @@ The EIP-1559 parameters used by OP Mainnet differ from those used by Ethereum as
 | Block gas limit                       |   30,000,000 gas |                 30,000,000 gas |
 | Block gas target                      |    5,000,000 gas |                 15,000,000 gas |
 | EIP-1559 elasticity multiplier        |                6 |                              2 |
-| EIP-1559 denominator                  |               50 |                              8 |
+| EIP-1559 denominator                  |              250 |                              8 |
 | Maximum base fee increase (per block) |              10% |                          12.5% |
 | Maximum base fee decrease (per block) |               2% |                          12.5% |
 | Block time in seconds                 |                2 |                             12 |

--- a/pages/stack/differences.mdx
+++ b/pages/stack/differences.mdx
@@ -19,7 +19,6 @@ However, there are some minor differences between the behavior of Ethereum and O
 | `PREVRANDAO` | `block.prevrandao`  | Set **pseudorandomly** for each block by the Sequencer as opposed to the stronger guarantees provided by [RANDAO](https://eips.ethereum.org/EIPS/eip-4399) on Ethereum.                                                                                 |
 | `ORIGIN`     | `tx.origin`         | If the transaction is an L1 ⇒ L2 transaction triggered by a smart contract on L1, then `tx.origin` is set to the [aliased address](#address-aliasing) of the address that triggered the L1 ⇒ L2 transaction. Otherwise, this opcode behaves normally.   |
 | `CALLER`     | `msg.sender`        | If the transaction is an L1 ⇒ L2 transaction triggered by a smart contract on L1, and this is the first call frame (rather than an internal transaction from one contract to another), the same [address aliasing](#address-aliasing) behavior applies. |
-| `PUSH0`      | -                   | Currently not supported by the OP Stack. Support to be introduced as part of the [Canyon hardfork](https://web.archive.org/web/20231207231718/https://blog.oplabs.co/canyon-hardfork/).                                                                 |
 
 ### Address Aliasing
 


### PR DESCRIPTION
Now that Canyon is live, this updates the docs accordingly. Updated EIP-1559 denominator was pulled from https://gov.optimism.io/t/final-upgrade-proposal-2-canyon-network-upgrade/7088