### PR TITLE
fix: exclude archive.org from linkcheck

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -32,4 +32,5 @@ exclude = [
     'https://mainnet-sequencer.optimism.io',
     'https://sepolia.optimism.io',
     'https://sepolia-sequencer.optimism.io',
+    'https://archive.org',
 ]


### PR DESCRIPTION
Excludes archive.org from lychee link checking. For whatever reason archive.org is really flaky.
