### PR TITLE
fix: minor cleanup to snapshots page

### DIFF
--- a/pages/builders/node-operators/management/snapshots.mdx
+++ b/pages/builders/node-operators/management/snapshots.mdx
@@ -25,15 +25,20 @@ Migrated OP Mainnet databases can be generated manually or pre-migrated database
 </Callout>
 
 <Callout type="info">
-  We recommend using [aria2](https://aria2.github.io/) to download. This can help by parallelizing the download.
+  Using [aria2](https://aria2.github.io/) to download snapshots can significantly speed up the download process.
 </Callout>
 
-### OP Mainnet
+### OP Mainnet (Full Node)
 
-| Snapshot Date             | Size  | Download Link                                                                                                                                                                                                                                             | sha256sum                                                                                          |
-| ------------------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| 2024-01-03 (archive node) | 3.2TB | [Mirror 1](https://datadirs.optimism.io/mainnet-2024-01-03.tar.zst)                                                                                                                                                                                       | <span className="shasum">`89fe570a1be92079108b7db4413f6e0be213a791c0d8ff195f890cd92a6f1f7a`</span> |
-| 2023-06-06                | 325GB | [Mirror 1](https://datadirs.optimism.io/mainnet-bedrock.tar.zst) <br /> [Mirror 2](https://op.datadirs.xyz/mainnet-bedrock.tar.zst) <br /> [Mirror 3 (torrent)](magnet:?xt=urn:btih:0eea90fa3da8cd88bfa34c70ccef64f5e643c4c1\&dn=mainnet-bedrock.tar.zst) | <span className="shasum">`ec4baf47e309a14ffbd586dc85376833de640c0f2a8d7355cb8a9e64c38bfcd1`</span> |
+| Snapshot Date | Size  | Download Link                                                                                                                                                                                                                                             | sha256sum                                                                                          |
+| ------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| 2023-06-06    | 325GB | [Mirror 1](https://datadirs.optimism.io/mainnet-bedrock.tar.zst) <br /> [Mirror 2](https://op.datadirs.xyz/mainnet-bedrock.tar.zst) <br /> [Mirror 3 (torrent)](magnet:?xt=urn:btih:0eea90fa3da8cd88bfa34c70ccef64f5e643c4c1\&dn=mainnet-bedrock.tar.zst) | <span className="shasum">`ec4baf47e309a14ffbd586dc85376833de640c0f2a8d7355cb8a9e64c38bfcd1`</span> |
+
+### OP Mainnet (Archive Node)
+
+| Snapshot Date | Size  | Download Link                                                       | sha256sum                                                                                          |
+| ------------- | ----- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| 2024-01-03    | 3.2TB | [Mirror 1](https://datadirs.optimism.io/mainnet-2024-01-03.tar.zst) | <span className="shasum">`89fe570a1be92079108b7db4413f6e0be213a791c0d8ff195f890cd92a6f1f7a`</span> |
 
 ### OP Mainnet (Legacy)
 

--- a/styles/global.css
+++ b/styles/global.css
@@ -37,6 +37,7 @@ footer {
   display: none;
 }
 
+/* Make shasums actually legible */
 span.shasum {
   display: block;
   max-width: 300px;
@@ -48,6 +49,8 @@ span.shasum {
   background-color: var(--op-neutral-700) !important;
 }
 span.shasum code {
+  padding-left: 0;
+  padding-right: 0;
   border: none;
   background-color: transparent !important;
 }


### PR DESCRIPTION
Very minor cleanup to the snapshots page. Biggest change here is splitting up the full node and archive node snapshots so people don't accidentally download the wrong one.