### PR TITLE
Add the year for Nov 11th update

### DIFF
--- a/pages/stack/protocol/overview.mdx
+++ b/pages/stack/protocol/overview.mdx
@@ -109,7 +109,7 @@ If the commitment is successfully challenged, then it is removed from the `State
 It's important to note that a successful challenge does not roll back OP Mainnet itself, only the published commitments about the state of the chain.
 The ordering of transactions and the state of OP Mainnet is unchanged by a fault proof challenge.
 
-The fault proof process is currently undergoing major redevelopment as a side-effect of the November 11th [EVM Equivalence](https://web.archive.org/web/20231127160757/https://medium.com/ethereum-optimism/introducing-evm-equivalence-5c2021deb306) update.
+The fault proof process is currently undergoing major redevelopment as a side-effect of the November 11th, 2021 [EVM Equivalence](https://web.archive.org/web/20231127160757/https://medium.com/ethereum-optimism/introducing-evm-equivalence-5c2021deb306) update.
 
 ## Next Steps
 


### PR DESCRIPTION
When we put the reason for fault proofs being unavailable as "because of the EVM update" back in 2022 it was obvious that the update was in 2021. Now it's not so clear.

So I think either add the year, or provide a better reason for cannon fault proofs not being available yet.

(I happened to see this while updating links on Lattice's redstone.xyz).