### PR TITLE
modify admin account suggest balance when deploy your own testnet

### DIFF
--- a/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
+++ b/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
@@ -305,7 +305,7 @@ The exact amount of ETH required depends on the L1 network being used.
 
 It's recommended to fund the addresses with the following amounts when using Sepolia:
 
-*   `Admin` — 0.2 Sepolia ETH
+*   `Admin` — 0.5 Sepolia ETH
 *   `Proposer` — 0.2 Sepolia ETH
 *   `Batcher` — 0.1 Sepolia ETH
 


### PR DESCRIPTION
Cost as follows when deploying rollup testnet on sepolia:

ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.
Total Paid: 0.337178127660167352 ETH (34101896 gas * avg 10.038510876 gwei)
