### PR TITLE
removing migration system dictator

### DIFF
--- a/pages/chain/security/privileged-roles.mdx
+++ b/pages/chain/security/privileged-roles.mdx
@@ -61,16 +61,6 @@ This is the address authorized to change the settings in the [`SystemConfig`](ht
 If access to this address is lost, it would make it more difficult to modify the system configuration (not impossible, because we can upgrade the contract at the proxy).
 If access to this address is compromised, an attack can raise the gas markup and cause users to overpay for transactions.
 
-### Migration SystemDictator Controller
-
-This is the address authorized to control [`SystemDictator`](https://github.com/ethereum-optimism/optimism/blob/62c7f3b05a70027b30054d4c8974f44000606fb7/packages/contracts-bedrock/contracts/deployment/SystemDictator.sol), used for upgrades.
-It can be used to perform an upgrade, and to revert out of one until a certain stage is reached.
-
-*   **Mainnet address**: [`0xB4453CEb33d2e67FA244A24acf2E50CEF31F53cB`](https://etherscan.io/address/0xB4453CEb33d2e67FA244A24acf2E50CEF31F53cB)
-*   **Sepolia address**: [`0xfd1D2e729aE8eEe2E146c033bf4400fE75284301`](https://sepolia.etherscan.io/address/0xfd1D2e729aE8eEe2E146c033bf4400fE75284301)
-
-If access to the owner is lost, or compromised, it can prevent upgrades.
-
 ### Challenger
 
 This is the address authorized to call [`deleteL2Outputs()`](https://github.com/ethereum-optimism/optimism/blob/62c7f3b05a70027b30054d4c8974f44000606fb7/packages/contracts-bedrock/contracts/L1/L2OutputOracle.sol#L133-L167) to remove a faulty state commitment.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Removing the Migration System Dictator Controller. There is no such role or privilege on OP mainnet right now.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
