### PR TITLE
Update Foundry install steps and dev account section for `dev-node` page

### DIFF
--- a/pages/chain/testing/dev-node.mdx
+++ b/pages/chain/testing/dev-node.mdx
@@ -117,7 +117,7 @@ Other OSes or versions may use different tools.
     By default, the same 10 dev accounts that are pre-funded using Anvil or HardHat are also pre-funded on both L1 and L2:
 
     <Callout>
-        These private keys are common knowledge, you shoult **not** use them on any network other than this dev network.
+        These private keys are common knowledge, you should **not** use them on any network other than this dev network.
         Using these private keys on mainnet, or even a testnet, will most likely result **in a loss of funds**.
     </Callout>
 

--- a/pages/chain/testing/dev-node.mdx
+++ b/pages/chain/testing/dev-node.mdx
@@ -28,7 +28,7 @@ We generally recommend using the local development environment if your applicati
 
 However, not everyone will need to use the local development environment.
 OP Mainnet is [EVM equivalent](https://web.archive.org/web/20231127160757/https://medium.com/ethereum-optimism/introducing-evm-equivalence-5c2021deb306), which means that OP Mainnet looks almost exactly like Ethereum under the hood.
-If you don't fall into one of the above categories, you can probably get away with simply relying on existing testing tools like Truffle or Hardhat.
+If you don't fall into one of the above categories, you can probably get away with simply relying on existing testing tools like Foundry or Hardhat.
 If you don't know whether or not you should be using the development environment, feel free to hop into the [developer support forum](https://github.com/ethereum-optimism/developers/discussions).
 Someone nice will help you out!
 
@@ -43,13 +43,10 @@ Note that the command line directions were verified under Ubuntu 22.04 LTS.
 Other OSes or versions may use different tools.
 
 <Steps>
-  ### Install the command line utilities `make` `jq` and `foundry`
+  ### Install the command line utilities `make` and `jq`
 
   ```sh
   sudo apt install -y make jq
-  curl -L https://foundry.paradigm.xyz | bash
-  . ~/.bashrc
-  foundryup
   ```
 
   ### Install [Go programming language](https://go.dev/)
@@ -69,6 +66,26 @@ Other OSes or versions may use different tools.
   ```sh
   git clone https://github.com/ethereum-optimism/optimism.git
   cd optimism
+  ```
+
+  ### Install Foundry using monorepo tooling
+
+  The following command will install Foundry if you don't already have it on your system.
+
+  ```sh
+  pnpm install:foundry
+  ```
+
+  If you do already have Foundry installed, make sure to run the following to verify your installed version will work with the monorepo tooling as expected.
+
+  ```sh
+  pnpm check:foundry
+  ```
+
+  If you need to, you can run the following to update Foundry to the expected version.
+
+  ```sh
+  pnpm update:foundry
   ```
 </Steps>
 
@@ -94,7 +111,22 @@ Other OSes or versions may use different tools.
     | L2 chain ID                         |         10 |     901 |
     | Time between L1 blocks (in seconds) |         12 |       3 |
 
-*   Test ETH:
+*   Pre-Funded Dev Accounts
 
-    *   Address: `0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266`
-    *   Private key: `ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80`
+    By default, the same 10 dev accounts that are prefunded using Anvil or HardHat are also prefunded on both L1 and L2:
+
+    | Address                                    | Private Key                                                        | Balance    |
+    | ------------------------------------------ | -----------------------------------------------------------------: | ---------: |
+    | 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 | 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 | 10,000 ETH |
+    | 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 | 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d | 10,000 ETH |
+    | 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC | 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a | 10,000 ETH |
+    | 0x90F79bf6EB2c4f870365E785982E1f101E93b906 | 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6 | 10,000 ETH |
+    | 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65 | 0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a | 10,000 ETH |
+    | 0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc | 0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba | 10,000 ETH |
+    | 0x976EA74026E726554dB657fA54763abd0C3a0aa9 | 0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e | 10,000 ETH |
+    | 0x14dC79964da2C08b23698B3D3cc7Ca32193d9955 | 0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356 | 10,000 ETH |
+    | 0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f | 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97 | 10,000 ETH |
+    | 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720 | 0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6 | 10,000 ETH |
+
+    * Mnemonic: `test test test test test test test test test test test junk`
+    * Derivation path: `m/44'/60'/0'/0/`

--- a/pages/chain/testing/dev-node.mdx
+++ b/pages/chain/testing/dev-node.mdx
@@ -113,7 +113,7 @@ Other OSes or versions may use different tools.
 
 *   Pre-Funded Dev Accounts
 
-    By default, the same 10 dev accounts that are prefunded using Anvil or HardHat are also prefunded on both L1 and L2:
+    By default, the same 10 dev accounts that are pre-funded using Anvil or HardHat are also pre-funded on both L1 and L2:
 
     | Address                                    | Private Key                                                        | Balance    |
     | ------------------------------------------ | -----------------------------------------------------------------: | ---------: |
@@ -128,5 +128,5 @@ Other OSes or versions may use different tools.
     | 0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f | 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97 | 10,000 ETH |
     | 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720 | 0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6 | 10,000 ETH |
 
-    * Mnemonic: `test test test test test test test test test test test junk`
-    * Derivation path: `m/44'/60'/0'/0/`
+    *   Mnemonic: `test test test test test test test test test test test junk`
+    *   Derivation path: `m/44'/60'/0'/0/`

--- a/pages/chain/testing/dev-node.mdx
+++ b/pages/chain/testing/dev-node.mdx
@@ -5,6 +5,7 @@ description: Learn how to setup and run a local development environment of the e
 ---
 
 import { Steps } from 'nextra/components'
+import { Callout } from 'nextra/components'
 
 # Running a Local Development Environment
 
@@ -114,6 +115,11 @@ Other OSes or versions may use different tools.
 *   Pre-Funded Dev Accounts
 
     By default, the same 10 dev accounts that are pre-funded using Anvil or HardHat are also pre-funded on both L1 and L2:
+
+    <Callout>
+        These private keys are common knowledge, you shoult **not** use them on any network other than this dev network.
+        Using these private keys on mainnet, or even a testnet, will most likely result **in a loss of funds**.
+    </Callout>
 
     | Address                                    | Private Key                                                        | Balance    |
     | ------------------------------------------ | -----------------------------------------------------------------: | ---------: |


### PR DESCRIPTION
- Replaced Foundry installation step with dedicated step that makes use of monorepo `pnpm` commands
- Update dev accounts section to include all dev accounts, their private keys, balances, mnemonic, and derivation path