### PR TITLE
fix: incorrect link

### DIFF
--- a/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
+++ b/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
@@ -21,8 +21,8 @@ You can use this testnet to experiment and perform tests, or you can choose to m
 You don't need permission from anyone to modify or deploy the stack in any configuration you want.
 
 <Callout type="warning">
-Modifications to the OP Stack may prevent a chain from being able to benefit from aspects of the [Optimism Superchain](/op-stack/explainer).
-Make sure to check out the [Superchain Explainer](/op-stack/explainer) to learn more.
+Modifications to the OP Stack may prevent a chain from being able to benefit from aspects of the [Optimism Superchain](/stack/explainer).
+Make sure to check out the [Superchain Explainer](/stack/explainer) to learn more.
 </Callout>
 
 ## What You're Going to Deploy


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Changing the redirect links from ``op-stack/explainer`` (which throws page not found) to ``stack/explainer``.

**Tests**

Ran it locally and clicked the links to make sure they're working as expected.


**Metadata**

- Fixes #484 
