### PR TITLE
Require op-node 1.5.1 for mainnet

### DIFF
--- a/pages/builders/node-operators/releases.mdx
+++ b/pages/builders/node-operators/releases.mdx
@@ -21,7 +21,7 @@ These are the minimal required versions for the `op-node` and `op-geth` by netwo
 
 | Network    | op-node                                                                     | op-geth                                                                              |
 | ---------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| OP Mainnet | [v1.5.0](https://github.com/ethereum-optimism/optimism/releases/tag/v1.5.0) | [v1.101305.3](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101305.3) |
+| OP Mainnet | [v1.5.1](https://github.com/ethereum-optimism/optimism/releases/tag/v1.5.1) | [v1.101305.3](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101305.3) |
 | OP Sepolia | [v1.5.1](https://github.com/ethereum-optimism/optimism/releases/tag/v1.5.1) | [v1.101308.0](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101308.0) |
 | OP Goerli  | [v1.5.0](https://github.com/ethereum-optimism/optimism/releases/tag/v1.5.0) | [v1.101305.3](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101305.3) |
 


### PR DESCRIPTION
1.5.1 fixes the receipt cache issue which is plaguing many users.