### PR TITLE
fix broken link

### DIFF
--- a/pages/builders/dapp-developers/bridging/messaging.mdx
+++ b/pages/builders/dapp-developers/bridging/messaging.mdx
@@ -13,7 +13,7 @@ This page explains how bridging works, how to use it, and what to watch out for.
 
 <Callout type="info">
   This is a high-level overview of the bridging process.
-  For a step-by-step tutorial on how to send data between L1 and L2, check out the [Solidity tutorial](cross-dom-solidity).
+  For a step-by-step tutorial on how to send data between L1 and L2, check out the [Solidity tutorial](/builders/dapp-developers/tutorials/cross-dom-solidity).
 </Callout>
 
 ## Understanding Contract Calls


### PR DESCRIPTION

**Description**

link for Solidity tutorial is broken,correct link is docs.optimism.io/builders/dapp-developers/tutorials/cross-dom-solidity


