### PR TITLE
minor fix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Then, run `pnpm dev` to start the development server and visit localhost:3000.
 
 ## Contributions
 
-Please see the [CONTRIBUTING.md](contributing.md) page for specifics on how to write PRs, use the linter, run spellcheck, add dictionary terms, etc. You should also review the [Optimism Documentation Style Guide](/pages/connect/contribute/style-guide.mdx) for additional guidelines, especially if you are writing entirely brand new pages to the developer docs, as opposed to smaller edits and/or revisions.
+Please see the [CONTRIBUTING.md](CONTRIBUTING.md) page for specifics on how to write PRs, use the linter, run spellcheck, add dictionary terms, etc. You should also review the [Optimism Documentation Style Guide](/pages/connect/contribute/style-guide.mdx) for additional guidelines, especially if you are writing entirely brand new pages to the developer docs, as opposed to smaller edits and/or revisions.
 
 ## Project Board
 


### PR DESCRIPTION
Changes [contributing.md](https://github.com/ethereum-optimism/docs/blob/main/contributing.md) to [CONTRIBUTING.md](https://github.com/ethereum-optimism/docs/blob/main/CONTRIBUTING.md)
