### PR TITLE
Update the Blockscout user interface URL.

### DIFF
--- a/pages/builders/chain-operators/tools/explorer.mdx
+++ b/pages/builders/chain-operators/tools/explorer.mdx
@@ -56,7 +56,7 @@ DOCKER_REPO=blockscout-optimism docker compose -f geth.yml up
 
 ### Explorer
 
-After Blockscout is started, browse to [https://localhost:3000](https://localhost:3000) to view the user interface.
+After Blockscout is started, browse to [http://localhost](http://localhost) to view the user interface.
 Note that this URL may differ if you have changed the Blockscout configuration.
 
 ### API


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
In my testing, port 3000 cannot access the Blockscout frontend. 
According to the Blockscout documentation: 

> Unless you overrode the default configs, you will see the default port for the backend is 4000, and 3000 for the frontend. However, these are not exposed because they are running within the container. This means localhost:3000 will not work.
> Since the proxy is in place (listen 80), the whole application should default to port 80 (which is just localhost). So your instance with the new frontend should now be served on localhost. 

[Link to the documentation](https://docs.blockscout.com/for-developers/deployment/frontend-migration/all-in-one-container#id-5-check-the-proxy-configuration)

**Tests**
![测试](https://github.com/ethereum-optimism/docs/assets/86885634/c354f73b-b142-4722-aab9-c11099710fa4)

**Additional context**

**Metadata**

- Fixes #[Link to Issue]
