### PR TITLE
Update rpc-providers.mdx

### DIFF
--- a/pages/builders/tools/connect/rpc-providers.mdx
+++ b/pages/builders/tools/connect/rpc-providers.mdx
@@ -62,6 +62,12 @@ OP Sepolia
 *   OP Mainnet
 *   OP Sepolia
 
+## GetBlock
+
+### Description and Pricing
+
+[GetBlock](https://getblock.io/) GetBlock is a service that provides access to 50+ blockchain nodes including Optimism [Optimism nodes](https://getblock.io/nodes/op/), ensuring developers can easily connect to the OP Mainnet and testnet without the hassle of managing complex infrastructure. It offers a convenient free package and For those looking for more advanced features and enhanced capabilities, GetBlock introduces paid packages starting from $29. 
+
 ## QuickNode
 
 ### Description and Pricing


### PR DESCRIPTION
Add GetBlock service to list of RPC providers

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

GetBlock is a service that provides access to hosted blockchain nodes, including OP Mainnet and testnet without the hassle of managing complex infrastructure. 

