### PR TITLE
Update privileged-roles.mdx

### DIFF
--- a/pages/chain/security/privileged-roles.mdx
+++ b/pages/chain/security/privileged-roles.mdx
@@ -22,12 +22,11 @@ The L1 Proxy Admin is an address that can be used to upgrade most OP Mainnet sys
 
 ### Mitigations
 
-*   L1 Proxy Admin is a 5-of-7 [multisig](https://etherscan.io/address/0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A#readProxyContract).
-*   L1 Proxy Admin may eventually be operated by a [Security Council](https://gov.optimism.io/t/intro-to-optimisms-security-council/6885).
+*   L1 Proxy Admin owner is a 2-of-2 [multisig](https://etherscan.io/address/0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A#readProxyContract). One owner is an Optimism Foundation 5/7 [multisig](https://etherscan.io/address/0x847B5c174615B1B7fDF770882256e2D3E95b9D92#readProxyContract) and the other owner is the [Security Council](https://gov.optimism.io/t/intro-to-optimisms-security-council/6885) [multisig](https://etherscan.io/address/0xc2819DC788505Aac350142A7A707BF9D03E3Bd03#readProxyContract).
 
 ### Addresses
 
-*   **Ethereum**: [`0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A`](https://etherscan.io/address/0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A)
+*   **Ethereum**: [`0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A`](https://etherscan.io/address/0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A)
 *   **Sepolia:** [`0xfd1D2e729aE8eEe2E146c033bf4400fE75284301`](https://sepolia.etherscan.io/address/0xfd1D2e729aE8eEe2E146c033bf4400fE75284301)
 
 ## L2 Proxy Admin


### PR DESCRIPTION
The L1 proxy admin owner is no longer just the foundation, but is a 2/2 multisig with the security council. Source: https://github.com/ethereum-optimism/superchain-ops/tree/main/tasks/eth/001-security-council-phase-0