### PR TITLE
Security Council Multisig has 13 owners not 12

### DIFF
--- a/pages/chain/security/faq.mdx
+++ b/pages/chain/security/faq.mdx
@@ -21,7 +21,7 @@ OP Mainnet and the OP Stack in general **may also contain unknown bugs that coul
 ## OP Mainnet Multisig
 
 The security of OP Mainnet is currently dependent on a multisig managed jointly by the [Optimism Security Council](https://gov.optimism.io/t/intro-to-optimisms-security-council/6885) and the Optimism Foundation.
-This multisig is a [2-of-2 nested multisig](https://etherscan.io/address/0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A) which is in turn governed by a [4-of-12 multisig](https://etherscan.io/address/0xc2819DC788505Aac350142A7A707BF9D03E3Bd03) managed by the Optimism Security Council and a [5-of-7 multisig](https://etherscan.io/address/0x847B5c174615B1B7fDF770882256e2D3E95b9D92) managed by the Optimism Foundation.
+This multisig is a [2-of-2 nested multisig](https://etherscan.io/address/0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A) which is in turn governed by a [4-of-13 multisig](https://etherscan.io/address/0xc2819DC788505Aac350142A7A707BF9D03E3Bd03) managed by the Optimism Security Council and a [5-of-7 multisig](https://etherscan.io/address/0x847B5c174615B1B7fDF770882256e2D3E95b9D92) managed by the Optimism Foundation.
 
 This multisig can be used to upgrade core OP Mainnet smart contracts **without upgrade delays** to allow for quick responses to potential security concerns.
 All upgrades to the OP Mainnet system must be approved by both component multisigs and either can veto an upgrade.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Small update based on my onchain analysis of the security council Gnosis safe: https://etherscan.io/address/0xc2819DC788505Aac350142A7A707BF9D03E3Bd03#readProxyContract

<img width="443" alt="Screenshot 2024-03-13 at 14 06 35" src="https://github.com/ethereum-optimism/docs/assets/15608778/0e2293eb-8e12-427c-97b0-3f288b2ce590">

The contract actually has 13 owners on mainnet.


**Tests**

N/A

**Additional context**

N/A

**Metadata**

N/A
