### PR TITLE
fix: make link checker run on PR

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,9 +1,10 @@
 name: Check Links
 
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * *'  # Runs at 00:00 UTC every day
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   build-and-run-lychee:

--- a/lychee.toml
+++ b/lychee.toml
@@ -35,3 +35,6 @@ exclude = [
     'https://archive.org',
     'https://web.archive.org'
 ]
+
+# Accept these status codes
+accept = ["100..=103", "200..=299", "403..=403"]

--- a/pages/builders/tools/monitor/analytics-tools.mdx
+++ b/pages/builders/tools/monitor/analytics-tools.mdx
@@ -42,4 +42,4 @@ Here are some additional tools and resources for OP Mainnet analytics and develo
 *   DeFi Stats: [OP Mainnet's DeFiLlama Page](https://defillama.com/chain/Optimism/)
 *   L2 Usage and Comparison: [growthepie](https://www.growthepie.xyz/)
 *   OP Analytics (Incentive Tracking, Helper Functions, Public Analysis): [OP Analytics on GitHub](https://github.com/ethereum-optimism/op-analytics)
-*   Contribute to NumbaNERDs: [NumbaNERDs on Dework](https://app.dework.xyz/optimism-community/main-space-35638/overview) or [Issues on GitHub](https://github.com/ethereum-optimism/op-analytics/issues)
+*   Contribute to NumbaNERDs: [Issues on GitHub](https://github.com/ethereum-optimism/op-analytics/issues)


### PR DESCRIPTION
Makes the link checking workflow run on PR instead of on a timer since it's less error prone.

