### PR TITLE
Fixed Broken Link and Added Internal Reference Links for p2p.static

### DIFF
--- a/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
+++ b/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
@@ -669,7 +669,7 @@ You can add the following options to the `op-node` command to enable peer-to-pee
   --p2p.listen.udp=9003 \
 ```
 
-You can alternatively also remove the `--p2p.static` option but you may see failed requests from other chains using the same chain ID.
+You can alternatively also remove the [--p2p.static](/builders/node-operators/management/configuration#p2pstatic) option but you may see failed requests from other chains using the same chain ID.
 </Callout>
 
 </Steps>

--- a/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
+++ b/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
@@ -669,7 +669,7 @@ You can add the following options to the `op-node` command to enable peer-to-pee
   --p2p.listen.udp=9003 \
 ```
 
-You can alternatively also remove the [--p2p.static](/builders/node-operators/management/configuration#p2pstatic) option but you may see failed requests from other chains using the same chain ID.
+You can alternatively also remove the [--p2p.static](/builders/node-operators/management/configuration#p2pstatic) option, but you may see failed requests from other chains using the same chain ID.
 </Callout>
 
 </Steps>

--- a/pages/builders/node-operators/json-rpc.mdx
+++ b/pages/builders/node-operators/json-rpc.mdx
@@ -13,7 +13,7 @@ There are several OP Mainnet components with an RPC API, which are reviewed in t
 
 <Callout type="warning">
   Use [`eth_gasPrice`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_gasprice) instead of `rollup_gasPrices` for the L2 gas price.
-  For the L1 gas price, you can call the [`GasPriceOracle`'s `l1BaseFee` function](https://optimistic.etherscan.io/address/0x420000000000000000000000000000000000000F#readContract#F5).
+  For the L1 gas price, you can call the [`GasPriceOracle`'s `l1BaseFee` function](https://optimistic.etherscan.io/address/0x420000000000000000000000000000000000000F#readProxyContract#F11).
   If you want to estimate the cost of a transaction, you can [use the SDK](/builders/app-developers/tutorials/sdk-estimate-costs).
 </Callout>
 

--- a/pages/builders/node-operators/management/configuration.mdx
+++ b/pages/builders/node-operators/management/configuration.mdx
@@ -756,15 +756,15 @@ Hex-encoded private key for signing off on p2p application messages as sequencer
 
 ###### p2p.static
 
-Comma-separated multiaddr-format peer list. Static connections to make and
+Comma-separated multiaddr-format(an unsigned address, containing: IP, TCP port, [PeerID](/builders/node-operators/json-rpc#opp2p_self)) peer list. Static connections to make and
 maintain, these peers will be regarded as trusted. Addresses of the local peer
 are ignored. Duplicate/Alternative addresses for the same peer all apply, but
 only a single connection per peer is maintained.
 
 <Tabs items={['Syntax', 'Example', 'Environment Variable']}>
   <Tabs.Tab>`--p2p.static=<value>`</Tabs.Tab>
-  <Tabs.Tab>`--p2p.static=[PeerListHere]`</Tabs.Tab>
-  <Tabs.Tab>`OP_NODE_P2P_STATIC=[PeerListHere]`</Tabs.Tab>
+  <Tabs.Tab>`--p2p.static=/ip4/127.0.0.1/tcp/9222/p2p/16Uiu2HAm2y6DXp6THWHCyquczNUh8gVAm4spo6hjP3Ns1dGRiAdE`</Tabs.Tab>
+  <Tabs.Tab>`OP_NODE_P2P_STATIC=/ip4/127.0.0.1/tcp/9222/p2p/16Uiu2HAm2y6DXp6THWHCyquczNUh8gVAm4spo6hjP3Ns1dGRiAdE`</Tabs.Tab>
 </Tabs>
 
 ###### p2p.sync.req-resp


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

1. Fixed a broken link.
2. Added a link to "--p2p.static" in the "create-l2-rollup" section to provide guidance on its configuration.
3. Included an example in the "node-operators/management/configuration#p2pstatic" section.
4. Provided a link to a location within the documentation explaining how to obtain a peerID.

**Tests**



**Additional context**


Adding additional replica nodes for the op stack chain is a common requirement.

**Metadata**

- Fixes #[Link to Issue]
