### PR TITLE
removing old specs reference

### DIFF
--- a/pages/chain/testing/dev-node.mdx
+++ b/pages/chain/testing/dev-node.mdx
@@ -33,10 +33,6 @@ If you don't fall into one of the above categories, you can probably get away wi
 If you don't know whether or not you should be using the development environment, feel free to hop into the [developer support forum](https://github.com/ethereum-optimism/developers/discussions).
 Someone nice will help you out!
 
-## Before You Begin
-
-The Optimism monorepo includes [a devnode setup you can use](https://github.com/ethereum-optimism/optimism/blob/65ec61dde94ffa93342728d324fecf474d228e1f/specs/meta/devnet.md).
-
 ## Installation
 
 First, make sure these components are installed.
@@ -69,6 +65,12 @@ Other OSes or versions may use different tools.
   cd optimism
   ```
 
+  ### Install dependencies
+
+  ```sh
+  pnpm install
+  ```
+  
   ### Install Foundry using monorepo tooling
 
   The following command will install Foundry if you don't already have it on your system.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

- The specs link was out of date and not needed anymore. 
- Added a missing step to install dependencies

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
