### PR TITLE
Update standard-bridge.mdx, "if the 'minting' message..." -> "if the 'unlock' message..."

### DIFF
--- a/pages/builders/app-developers/bridging/standard-bridge.mdx
+++ b/pages/builders/app-developers/bridging/standard-bridge.mdx
@@ -179,7 +179,7 @@ The process for bridging a non-native, bridged representation of a token involve
 
   {<h3>The native token is unlocked</h3>}
 
-  If the minting message is fully verified, `finalizeBridgeERC20` will [unlock and transfer tokens to the recipient](https://github.com/ethereum-optimism/optimism/blob/2e647210882d961f04055e656590d90ad98c9934/packages/contracts-bedrock/src/universal/StandardBridge.sol#L280-L281) equal to the number of tokens originally burned on the other blockchain.
+  If the unlock message is fully verified, `finalizeBridgeERC20` will [unlock and transfer tokens to the recipient](https://github.com/ethereum-optimism/optimism/blob/2e647210882d961f04055e656590d90ad98c9934/packages/contracts-bedrock/src/universal/StandardBridge.sol#L280-L281) equal to the number of tokens originally burned on the other blockchain.
 
   This completes the process of bridging native tokens.
   This process is identical in both the Ethereum to OP Mainnet and OP Mainnet to Ethereum directions.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Just a simple fix one word....

The native token is unlocked
If the '**minting**' message is fully verified, finalizeBridgeERC20 will unlock and transfer tokens to the recipient equal to the number of tokens originally burned on the other blockchain. 

->

The native token is unlocked
If the '**unlock**' message is fully verified, finalizeBridgeERC20 will unlock and transfer tokens to the recipient equal to the number of tokens originally burned on the other blockchain.

**Tests**

No tests required to fix just one word.

**Additional context**

No additional context

**Metadata**

- Fixes #[Link to Issue]
