### PR TITLE
Update messaging.mdx, fix one word, "If someone is able prove..." -> "If someone is able to prove..."

### DIFF
--- a/pages/builders/app-developers/bridging/messaging.mdx
+++ b/pages/builders/app-developers/bridging/messaging.mdx
@@ -225,8 +225,8 @@ Here's where the "fault proof" comes into play.
 Whenever a transaction result is published, it's considered "pending" for a period of time known as the challenge period.
 During this period of time, anyone may re-execute the transaction *on Ethereum* in an attempt to demonstrate that the published result was incorrect.
 
-If someone is able to prove that a transaction result is faulty, then the result is scrubbed from existence and anyone can publish another result in its place (hopefully the correct one this time, financial punishments make faulty results *very* costly for their publishers).
-Once the window for a given transaction result has fully passed without a challenge the result can be considered fully valid (or else someone would've challenged it).
+If someone can prove that a transaction result is faulty, then the result is scrubbed from existence and anyone can publish another result in its place (hopefully the correct one this time, financial punishments make faulty results *very* costly for their publishers).
+Once the window for a given transaction result has fully passed without a challenge, the result can be considered fully valid (or else someone would've challenged it).
 
 Anyway, the point here is that **you don't want to be making decisions about Layer 2 transaction results from inside a smart contract on Layer 1 until this challenge period has elapsed**.
 Otherwise you might be making decisions based on an invalid transaction result.

--- a/pages/builders/app-developers/bridging/messaging.mdx
+++ b/pages/builders/app-developers/bridging/messaging.mdx
@@ -225,7 +225,7 @@ Here's where the "fault proof" comes into play.
 Whenever a transaction result is published, it's considered "pending" for a period of time known as the challenge period.
 During this period of time, anyone may re-execute the transaction *on Ethereum* in an attempt to demonstrate that the published result was incorrect.
 
-If someone is able prove that a transaction result is faulty, then the result is scrubbed from existence and anyone can publish another result in its place (hopefully the correct one this time, financial punishments make faulty results *very* costly for their publishers).
+If someone is able to prove that a transaction result is faulty, then the result is scrubbed from existence and anyone can publish another result in its place (hopefully the correct one this time, financial punishments make faulty results *very* costly for their publishers).
 Once the window for a given transaction result has fully passed without a challenge the result can be considered fully valid (or else someone would've challenged it).
 
 Anyway, the point here is that **you don't want to be making decisions about Layer 2 transaction results from inside a smart contract on Layer 1 until this challenge period has elapsed**.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

"If someone is able prove that a transaction result is faulty," 
->
"If someone is able **to** prove that a transaction result is faulty,"

**Tests**

No tests required to fix just one grammer issue

**Additional context**

No additional context

**Metadata**

- Fixes #[Link to Issue]
