### PR TITLE
Update link to OP-Proposer

### DIFF
--- a/pages/stack/protocol/withdrawal-flow.mdx
+++ b/pages/stack/protocol/withdrawal-flow.mdx
@@ -47,7 +47,7 @@ Withdrawals require the user to submit three transactions:
         Note that if the gas limit is not enough, or if the L1 finalizing transaction does not have enough gas to provide that gas limit, the finalizing transaction returns a failure, it does not revert.
     *   `data` - The calldata for the withdrawal transaction
 
-4.  When `op-proposer` [proposes a new output](https://github.com/ethereum-optimism/optimism/blob/62c7f3b05a70027b30054d4c8974f44000606fb7/op-proposer/proposer/l2_output_submitter.go#L312-L320), the output proposal includes [the output root](https://github.com/ethereum-optimism/optimism/blob/62c7f3b05a70027b30054d4c8974f44000606fb7/op-proposer/proposer/l2_output_submitter.go#L316), provided as part of the block by `op-node`.
+4.  When `op-proposer` [proposes a new output](https://github.com/ethereum-optimism/optimism/blob/4a3d3fb444f50bed6a6991785ea5634e0efa07a4/op-proposer/proposer/driver.go#L311), the output proposal includes [the output root](https://github.com/ethereum-optimism/optimism/blob/62c7f3b05a70027b30054d4c8974f44000606fb7/op-proposer/proposer/l2_output_submitter.go#L316), provided as part of the block by `op-node`.
     This new output root commits to the state of the `sentMessages` mapping in the `L2ToL1MessagePasser` contract's storage on L2, and it can be used to prove the presence of a pending withdrawal within it.
 
 ## Withdrawal proving transaction


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
The link to showcase the code that proposes a new output by `op-proposer` is outdated. I simply updated the doc

**Tests**

A simple doc fix, so no test is needed

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #642
