### PR TITLE
Update create-l2-rollup.mdx fix sync() issue

### DIFF
--- a/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
+++ b/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
@@ -101,6 +101,8 @@ You may experience unexpected errors on older versions of Node.js.
 #### `foundry`
 
 It's recommended to use the scripts in the monorepo's `package.json` for managing `foundry` to ensure you're always working with the correct version. This approach simplifies the installation, update, and version checking process. Make sure to clone the monorepo locally before proceeding.
+
+for forge , please use https://github.com/foundry-rs/foundry/releases/tag/nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a, latest version of forge will cause address Lowercase issue and fail the sync() method 
 #### `direnv`
 
 Parts of this tutorial use [`direnv`](https://direnv.net) as a way of loading environment variables from `.envrc` files into your shell.


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
for branch tutorials/chain , if using the latest forge version , it will failed to run  
`forge script scripts/Deploy.s.sol:Deploy --sig 'sync()' --rpc-url $L1_RPC_URL`

with error info 
`"Deploy Tx not found"`

the root cause is the contract address is lower in  : broadcast/Deploy.s.sol/11155111/run-latest.json

but its not lowercase in deployments/getting-started/.deploy


**Tests**

sync success 

**Additional context**

bug of  https://docs.optimism.io/builders/chain-operators/tutorials/create-l2-rollup 

by the way , anyone please fix the doc if its outdated
**Metadata**

- Fixes #[Link to Issue]
