### PR TITLE
Correction to 1559 parameters doc - maximum base fee increases/decreases

### DIFF
--- a/pages/chain/differences.mdx
+++ b/pages/chain/differences.mdx
@@ -66,8 +66,8 @@ The EIP-1559 parameters used by OP Mainnet differ from those used by Ethereum as
 | Block gas target                      |    5,000,000 gas |                 15,000,000 gas |
 | EIP-1559 elasticity multiplier        |                6 |                              2 |
 | EIP-1559 denominator                  |              250 |                              8 |
-| Maximum base fee increase (per block) |              10% |                          12.5% |
-| Maximum base fee decrease (per block) |               2% |                          12.5% |
+| Maximum base fee increase (per block) |               2% |                          12.5% |
+| Maximum base fee decrease (per block) |             0.4% |                          12.5% |
 | Block time in seconds                 |                2 |                             12 |
 
 ### Mempool Rules


### PR DESCRIPTION
Updating the docs for maximum base fee increase/decrease per block to reflect the new 1559 values implemented in canyon

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The current documentation for the 1559 parameters is outdated with the canyon fork - the elasticity multiplier and denominator were updated, but the max base fee increase/decrease were not.

**Tests**

Pulled the correct values from this blog ("Parameter Revisions in the Canyon Hard Fork"): https://mirror.xyz/hashigo%F0%9F%94%B4.eth/sZ42ZTmmEzC99gTQ7djtkec6AOXcoJNxgLO6wpHfDXA

Also calculated them myself to verify the accuracy.

