### PR TITLE
removing outdated genesis file and generalized the instructions

### DIFF
--- a/pages/builders/node-operators/management/configuration.mdx
+++ b/pages/builders/node-operators/management/configuration.mdx
@@ -29,7 +29,7 @@ To configure your node, you will need to do the following:
 `op-geth` stores its state in a database that requires initialization. 
 Depending on the network you're running, initialization is done one of three ways:
 
-1.  **With a Genesis File:** This is for deployments that are not migrated from a legacy network (i.e. OP Sepolia). In this case, you'll use the [genesis file](https://networks.optimism.io/op-sepolia/genesis.json) and initialize the data directory via `geth init`.
+1.  **With a Genesis File:** This is for deployments that are not migrated from a legacy network (i.e. OP Sepolia). In this case, you'll use a genesis file and initialize the data directory via `geth init`.
 2.  **With a Data Directory:** This is used for networks that are migrated from a legacy network. This currently **only** includes OP Mainnet. In this case, you'll download a preconfigured data directory and extract it. No further initialization is necessary in this case, because the data directory contains the network's genesis information. This method can be bypassed if you utilize [snap sync](/builders/node-operators/management/snap-sync).
 3.  **With network flags:** This initializes the genesis information and chain configuration from the [superchain-registry](https://github.com/ethereum-optimism/superchain-registry).
 
@@ -47,7 +47,7 @@ to initialize the data directory:
 ```bash
 #!/bin/sh
 FILE=/$DATADIR/genesis.json
-OP_GETH_GENESIS_URL=https://networks.optimism.io/op-sepolia/genesis.json
+OP_GETH_GENESIS_URL=<<insert op-geth url to the genesis file>>
 
 if [ ! -s $FILE ]; then
   apk add curl


### PR DESCRIPTION
fixes https://github.com/ethereum-optimism/docs/issues/441

- removes outdated genesis file
- generalizes instructions
- op-sepolia should use the network flags (option 3)
