### PR TITLE
Update withdrawal-flow.mdx

### DIFF
--- a/pages/stack/protocol/withdrawal-flow.mdx
+++ b/pages/stack/protocol/withdrawal-flow.mdx
@@ -57,7 +57,7 @@ Typically this is done [by the SDK](https://sdk.optimism.io/classes/crosschainme
 
 ### Offchain processing
 
-1.  A user calls the SDK's [`CrossDomainMessenger.proveMessage()`](https://github.com/ethereum-optimism/optimism/blob/62c7f3b05a70027b30054d4c8974f44000606fb7/packages/sdk/src/cross-chain-messenger.ts#L1452-L1471) with the hash of the L1 message.
+1.  A user calls the SDK's [`CrossDomainMessenger.proveMessage()`](https://github.com/ethereum-optimism/optimism/blob/62c7f3b05a70027b30054d4c8974f44000606fb7/packages/sdk/src/cross-chain-messenger.ts#L1452-L1471) with the hash of the L2 message.
     This function calls [`CrossDomainMessenger.populateTransaction.proveMessage()`](https://github.com/ethereum-optimism/optimism/blob/62c7f3b05a70027b30054d4c8974f44000606fb7/packages/sdk/src/cross-chain-messenger.ts#L1746-L1798).
 
 2.  To get from the L2 transaction hash to the raw withdrawal fields, the SDK uses [`toLowLevelMessage`](https://github.com/ethereum-optimism/optimism/blob/62c7f3b05a70027b30054d4c8974f44000606fb7/packages/sdk/src/cross-chain-messenger.ts#L368-L450).


### PR DESCRIPTION
**Description**
I believe that the transaction hash that is passed into the `proveMessage()` is the corresponding L2 transaction. I don't think there is any L1 transactions corresponding to this withdraw yet.
