### PR TITLE
docs: pre-image URL

### DIFF
--- a/pages/stack/protocol/fault-proofs/overview.mdx
+++ b/pages/stack/protocol/fault-proofs/overview.mdx
@@ -38,7 +38,7 @@ The FPP is a combination of `op-node` and `op-geth`, so it has both the consensu
 
 The FPP is designed so that it can be run in a deterministic way such that two invocations with the same input data will result in not only the same output, but the same program execution trace. This allows it to be run in an onchain VM as part of the dispute resolution process.
 
-All data is retrieved via the Preimage Oracle API. The preimages could be provided via the FPVM when onchain or by a native "host" implementation that can download the required data from nodes via JSON-RPC requests. The native host implementation is also provided by `op-program` but doesn't run as part of the onchain execution.  Basically op-program has two halves: the "client" Fault Proof Program part covered in this section and the "host" part used to fetch required preimages.
+All data is retrieved via the [Preimage Oracle API](https://specs.optimism.io/experimental/fault-proof/index.html#pre-image-oracle). The preimages could be provided via the FPVM when onchain or by a native "host" implementation that can download the required data from nodes via JSON-RPC requests. The native host implementation is also provided by `op-program` but doesn't run as part of the onchain execution.  Basically, `op-program` has two halves: the "client" Fault Proof Program part covered in this section and the "host" part used to fetch required preimages.
 
 ## Fault Proof Virtual Machine
 


### PR DESCRIPTION
**Description**

Adds a link to the spec for the Preimage Oracle API.

**Additional context**

https://specs.optimism.io/experimental/fault-proof/index.html#pre-image-oracle