### PR TITLE
Fix artifacts in 'Create L2 Rollup' tutorial

### DIFF
--- a/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
+++ b/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
@@ -475,12 +475,6 @@ If the same `IMPL_SALT` is used to deploy the same contracts twice, the second d
 **You can generate a new `IMPL_SALT` by running `direnv allow` anywhere in the Optimism Monorepo.**
 </Callout>
 
-{<h3>Generate contract artifacts</h3>}
-
-```bash
-forge script scripts/Deploy.s.sol:Deploy --sig 'sync()' --rpc-url $L1_RPC_URL
-```
-
 </Steps>
 
 ## Generate the L2 config files
@@ -508,7 +502,7 @@ Now you'll generate the `genesis.json` and `rollup.json` files within the `op-no
 ```bash
 go run cmd/main.go genesis l2 \
   --deploy-config ../packages/contracts-bedrock/deploy-config/getting-started.json \
-  --deployment-dir ../packages/contracts-bedrock/deployments/getting-started/ \
+  --deployment-dir ../packages/contracts-bedrock/deployments/sepolia/ \
   --outfile.l2 genesis.json \
   --outfile.rollup rollup.json \
   --l1-rpc $L1_RPC_URL

--- a/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
+++ b/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
@@ -502,7 +502,7 @@ Now you'll generate the `genesis.json` and `rollup.json` files within the `op-no
 ```bash
 go run cmd/main.go genesis l2 \
   --deploy-config ../packages/contracts-bedrock/deploy-config/getting-started.json \
-  --deployment-dir ../packages/contracts-bedrock/deployments/sepolia/ \
+  --l1-deployments ../packages/contracts-bedrock/deployments/getting-started/.deploy \
   --outfile.l2 genesis.json \
   --outfile.rollup rollup.json \
   --l1-rpc $L1_RPC_URL


### PR DESCRIPTION
Fix the instructions in the tutorial so users don't run into the issue described in https://github.com/ethereum-optimism/optimism/issues/10114, using the instructions from https://github.com/ethereum-optimism/developers/discussions/354#discussioncomment-9140745. I've tested this against the `tutorials/chain` branch and it is working. https://github.com/ethereum-optimism/docs/issues/627