### PR TITLE
Add Chainstack to RPC providers

### DIFF
--- a/pages/builders/tools/connect/rpc-providers.mdx
+++ b/pages/builders/tools/connect/rpc-providers.mdx
@@ -38,6 +38,17 @@ Moreover, Ankr offers access to developer tooling on OP Mainnet (and testnets) l
 *   OP Mainnet
 *   OP Sepolia
 
+## Chainstack
+
+### Description and Pricing
+
+[Chainstack](https://chainstack.com/build-better-with-optimism/) provides global & regional load-balanced nodes that are full & archive with debug & trace APIs. For the free tier, the Developer plan is available and you can sign up with GitHub account or other social logins. Chainstack also has special discounts available.
+
+### Supported Networks
+
+*   OP Mainnet
+*   OP Sepolia
+
 ## dRPC
 
 ### Description and Pricing

--- a/words.txt
+++ b/words.txt
@@ -45,6 +45,7 @@ Celestia
 Chainlink
 Chainlink's
 chainlist
+Chainstack
 chaosnet
 Clabby
 codebases


### PR DESCRIPTION
**Description**

Adding Chainstack to the node provider list as it seems to meet the inclusion criteria.

**Tests**

NA

**Additional context**

Chainstack's been an OP node provider for a 1.5 years as of today. We are also providing the free OP nodes as one of the default options in ethers. See here https://github.com/ethers-io/ethers.js/pull/4762

**Metadata**

NA
