### PR TITLE
Update standard-bridge-custom-token.mdx

### DIFF
--- a/pages/builders/app-developers/tutorials/standard-bridge-custom-token.mdx
+++ b/pages/builders/app-developers/tutorials/standard-bridge-custom-token.mdx
@@ -106,7 +106,7 @@ Make sure that your environment is set to "Injected Provider", your wallet is co
 Then, select the `MyCustomL2Token` contract from the deployment dropdown and deploy it with the following parameters:
 
 ```text
-_BRIDGE:      "0x4200000000000000000000000000000000000007"
+_BRIDGE:      "0x4200000000000000000000000000000000000010"
 _REMOTETOKEN: "<L1 ERC-20 address>"
 _NAME:        "My Custom L2 Token"
 _SYMBOL:      "MCL2T"


### PR DESCRIPTION
the constructor's bridge params should be L2StandardBridge.sol deployed address, not L2CrossDomainMessenger's address

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Change bridge address to L2StandardBridge address when custom L2 token deployed.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
