### PR TITLE
feat: added wip callout feature

### DIFF
--- a/components/WipCallout.tsx
+++ b/components/WipCallout.tsx
@@ -1,0 +1,39 @@
+/**
+ * The WipCallout function renders a custom callout component with optional context text for
+ * displaying maintenance messages.
+ * @param {Props}  - The code snippet you provided is a React component named `WipCallout` that
+ * renders a special callout message. The component takes an optional prop `context` of type string,
+ * which can be used to customize the message displayed in the callout.
+ * @returns The WipCallout component is being returned, which is a React element representing a
+ * custom callout with a message. The message displayed depends on the value of the `context` prop
+ * passed to the component. If `context` is provided, it will display the provided context message. If
+ * `context` is not provided, it will display a default maintenance message.
+ */
+import type { ReactElement } from 'react';
+interface Props {
+  context?: string;
+}
+export function WipCallout({ context }: Props): ReactElement {
+  return (
+    <div className="custom-callouts nx-w-full nx-mt-6 nx-flex nx-justify-center nx-items-center nx-bg-white dark:nx-bg-black">
+      <div className="nx-w-full  nx-px-4 nx-text-center nx-font-medium nx-text-sm">
+        {context ? (
+          context
+        ) : (
+          <div>
+            Please do not rely on the content of this page as it is currently
+            undergoing maintenance. Code samples and solutions may not function
+            as expected. Please check back for an update or{' '}
+            <a
+              href="https://github.com/ethereum-optimism/docs/issues"
+              className="callout-link"
+            >
+              signup to help us revise this page
+            </a>
+            . We welcome your contribution! ❤️
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/messages/WipMsg.md
+++ b/messages/WipMsg.md
@@ -1,0 +1,3 @@
+Please **do not rely** on the content of this page as it is currently undergoing maintenance. **Code samples and solutions may not function as expected.** Please check back for an update or [signup to help us revise this
+page](https://github.com/ethereum-optimism/docs/labels/tutorial). We welcome
+your contribution! ❤️

--- a/notes/wip-callout.md
+++ b/notes/wip-callout.md
@@ -1,0 +1,37 @@
+## Wip Callout: Rendering Custom Maintenance Messages
+
+The WipCallout component is a React functional component designed to render custom callouts for displaying messages about the page. This feature allows you to provide users with important information, including optional context text that makes it dynamic and reusable.
+
+## Directory
+
+You can find the WipCallout component in the `/components` directory.
+
+## Behavior
+
+When imported into a page, this component renders a message at the top of the nested page. It also sticks to the top when scrolling, ensuring users don't miss the important information. To add a different message, simply pass the `context` prop with your intended message.
+
+## How to Use Wip Callout
+
+1. Import it into your `.mdx` file:
+
+```typescript
+import { WipCallout } from '@/components/WipCallout';
+```
+
+2. Use it within the file
+
+```typescript
+<WipCallout /> // with default message
+
+<WipCallout context="this tutorial is outdated" /> // with custom message
+
+// with a custom `.md` file
+import WipMsg from "@/message/WipMsg.md" //import the md file
+
+<WipCallout context={<WipMsg/>} />  // with custom message
+
+```
+
+## Maintenance
+
+Maintenance of this feature is straightforward. As a simple React component, you can find it located in the `/components` directory. Additionally, the relevant styling for this component can be found in the global CSS file at `/styles/global.css`.

--- a/pages/builders/app-developers/tutorials/cross-dom-bridge-erc20.mdx
+++ b/pages/builders/app-developers/tutorials/cross-dom-bridge-erc20.mdx
@@ -5,12 +5,19 @@ description: Learn how to use the Optimism SDK to transfer ERC-20 tokens between
 ---
 
 import { Callout, Steps } from 'nextra/components'
+import { WipCallout } from '@/components/WipCallout'
+import WipMsg from "@/message/WipMsg.md"
+
+<WipCallout />
 
 # Bridging ERC-20 Tokens to OP Mainnet With the Optimism SDK
 
 <Callout type="error">
-Please **do not rely** on the content of this page as it is currently undergoing maintenance. **Code samples and solutions may not function as expected.**  
-Please check back for an update or [signup to help us revise this page](https://github.com/ethereum-optimism/docs/labels/tutorial). We welcome your contribution! ❤️
+  Please **do not rely** on the content of this page as it is currently
+  undergoing maintenance. **Code samples and solutions may not function as
+  expected.** Please check back for an update or [signup to help us revise this
+  page](https://github.com/ethereum-optimism/docs/labels/tutorial). We welcome
+  your contribution! ❤️
 </Callout>
 
 This tutorial explains how you can use the [Optimism SDK](https://sdk.optimism.io) to bridge ERC-20 tokens from L1 (Ethereum or Sepolia) to L2 (OP Mainnet or OP Sepolia).
@@ -21,7 +28,10 @@ Behind the scenes, the Optimism SDK uses the [Standard Bridge](/builders/app-dev
 Make sure to check out the [Standard Bridge guide](/builders/app-developers/bridging/standard-bridge) if you want to learn more about how the bridge works under the hood.
 
 <Callout type="error">
-The Standard Bridge **does not** support [**fee on transfer tokens**](https://github.com/d-xo/weird-erc20#fee-on-transfer) or [**rebasing tokens**](https://github.com/d-xo/weird-erc20#balance-modifications-outside-of-transfers-rebasingairdrops) because they can cause bridge accounting errors.
+  The Standard Bridge **does not** support [**fee on transfer
+  tokens**](https://github.com/d-xo/weird-erc20#fee-on-transfer) or [**rebasing
+  tokens**](https://github.com/d-xo/weird-erc20#balance-modifications-outside-of-transfers-rebasingairdrops)
+  because they can cause bridge accounting errors.
 </Callout>
 
 ## Supported Networks
@@ -41,37 +51,37 @@ You're going to use the Optimism SDK for this tutorial.
 Since the Optimism SDK is a [Node.js](https://nodejs.org/en/) library, you'll need to create a Node.js project to use it.
 
 <Steps>
+  {<h3>Make a Project Folder</h3>}
 
-{<h3>Make a Project Folder</h3>}
+  ```bash
+  mkdir op-sample-project
+  cd op-sample-project
+  ```
 
-```bash
-mkdir op-sample-project
-cd op-sample-project
-```
+  {<h3>Initialize the Project</h3>}
 
-{<h3>Initialize the Project</h3>}
+  ```bash
+  pnpm init
+  ```
 
-```bash
-pnpm init
-```
+  {<h3>Install the Optimism SDK</h3>}
 
-{<h3>Install the Optimism SDK</h3>}
+  ```bash
+  pnpm add @eth-optimism/sdk
+  ```
 
-```bash
-pnpm add @eth-optimism/sdk
-```
+  {<h3>Install ethers.js</h3>}
 
-{<h3>Install ethers.js</h3>}
-
-```bash
-pnpm add ethers@^5
-```
-
+  ```bash
+  pnpm add ethers@^5
+  ```
 </Steps>
 
 <Callout type="info">
-Want to create a new wallet for this tutorial?
-If you have [`cast`](https://book.getfoundry.sh/getting-started/installation) installed you can run `cast wallet new` in your terminal to create a new wallet and get the private key.
+  Want to create a new wallet for this tutorial? If you have
+  [`cast`](https://book.getfoundry.sh/getting-started/installation) installed
+  you can run `cast wallet new` in your terminal to create a new wallet and get
+  the private key.
 </Callout>
 
 ## Get ETH on Sepolia and OP Sepolia
@@ -80,8 +90,10 @@ This tutorial explains how to bridge tokens from Sepolia to OP Sepolia.
 You will need to get some ETH on both of these testnets.
 
 <Callout type="info">
-You can use [this faucet](https://sepoliafaucet.com) to get ETH on Sepolia.
-You can use the [Superchain Faucet](https://app.optimism.io/faucet?utm_source=docs) to get ETH on OP Sepolia.
+  You can use [this faucet](https://sepoliafaucet.com) to get ETH on Sepolia.
+  You can use the [Superchain
+  Faucet](https://app.optimism.io/faucet?utm_source=docs) to get ETH on OP
+  Sepolia.
 </Callout>
 
 ## Add a Private Key to Your Environment
@@ -110,17 +122,15 @@ This will bring up a Node REPL prompt that allows you to run javascript code.
 You need to import some dependencies into your Node REPL session.
 
 <Steps>
+  {<h3>Import the Optimism SDK</h3>}
 
-{<h3>Import the Optimism SDK</h3>}
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L3 hash=26b2fdb17dd6c8326a54ec51f0769528
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L3 hash=26b2fdb17dd6c8326a54ec51f0769528
-```
+  {<h3>Import ethers.js</h3>}
 
-{<h3>Import ethers.js</h3>}
-
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L4 hash=69a65ef97862612e4978b8563e6dbe3a
-```
-
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L4 hash=69a65ef97862612e4978b8563e6dbe3a
+  ```
 </Steps>
 
 ## Set Session Variables
@@ -129,29 +139,31 @@ You'll need a few variables throughout this tutorial.
 Let's set those up now.
 
 <Steps>
+  {<h3>Load your private key</h3>}
 
-{<h3>Load your private key</h3>}
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L6 hash=755b77a7ffc7dfdc186f36c37d3d847a
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L6 hash=755b77a7ffc7dfdc186f36c37d3d847a
-```
+  {<h3>Create the RPC providers and wallets</h3>}
 
-{<h3>Create the RPC providers and wallets</h3>}
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L8-L11 hash=9afdce50665ae93bce602068071ffaa1
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L8-L11 hash=9afdce50665ae93bce602068071ffaa1
-```
+  {<h3>Set the L1 and L2 ERC-20 addresses</h3>}
 
-{<h3>Set the L1 and L2 ERC-20 addresses</h3>}
+  This tutorial uses existing ERC-20 tokens that have been deployed on Sepolia and OP Sepolia.
+  These tokens are designed for testing the bridging process.
 
-This tutorial uses existing ERC-20 tokens that have been deployed on Sepolia and OP Sepolia.
-These tokens are designed for testing the bridging process.
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L13-L14 hash=d8f0d4c8124782a6cd36097ff31010e5
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L13-L14 hash=d8f0d4c8124782a6cd36097ff31010e5
-```
-
-<Callout>
-If you're coming from the [Bridging Your Standard ERC-20 Token to OP Mainnet Using the Standard Bridge](./standard-bridge-standard-token) or [Bridging Your Custom ERC-20 Token to OP Mainnet Using the Standard Bridge](./standard-bridge-custom-token) tutorials, you can use the addresses of your own ERC-20 tokens here instead.
-</Callout>
-
+  <Callout>
+    If you're coming from the [Bridging Your Standard ERC-20 Token to OP Mainnet
+    Using the Standard Bridge](./standard-bridge-standard-token) or [Bridging Your
+    Custom ERC-20 Token to OP Mainnet Using the Standard
+    Bridge](./standard-bridge-custom-token) tutorials, you can use the addresses
+    of your own ERC-20 tokens here instead.
+  </Callout>
 </Steps>
 
 ## Get L1 Tokens
@@ -160,27 +172,25 @@ You're going to need some tokens on L1 that you can bridge to L2.
 The L1 testing token located at [`0x5589BB8228C07c4e15558875fAf2B859f678d129`](https://sepolia.etherscan.io/address/0x5589BB8228C07c4e15558875fAf2B859f678d129) has a `faucet` function that makes it easy to get tokens.
 
 <Steps>
+  {<h3>Set the ERC20 ABI</h3>}
 
-{<h3>Set the ERC20 ABI</h3>}
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L16 hash=d1caeba8dc014637e2b0b72f5cd076d0
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L16 hash=d1caeba8dc014637e2b0b72f5cd076d0
-```
+  {<h3>Create a Contract instance for the L1 token</h3>}
 
-{<h3>Create a Contract instance for the L1 token</h3>}
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L18 hash=9f9d7e38319ff5263e0e99d80d495554
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L18 hash=9f9d7e38319ff5263e0e99d80d495554
-```
+  {<h3>Request some tokens</h3>}
 
-{<h3>Request some tokens</h3>}
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L21-L22 hash=3533ec5426e8845fdb9af1e9e8d3de4c
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L21-L22 hash=3533ec5426e8845fdb9af1e9e8d3de4c
-```
+  {<h3>Check your token balance</h3>}
 
-{<h3>Check your token balance</h3>}
-
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L25 hash=d7a60aa394d1055555c2aeab2a2e111d
-```
-
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L25 hash=d7a60aa394d1055555c2aeab2a2e111d
+  ```
 </Steps>
 
 ## Deposit Tokens
@@ -189,71 +199,71 @@ Now that you have some tokens on L1, you can deposit those tokens into the `L1St
 You'll then receive the same number of tokens on L2 in return.
 
 <Steps>
+  {<h3>Define the amount to deposit</h3>}
 
-{<h3>Define the amount to deposit</h3>}
+  The testing token has 18 decimal places, so you'll want to define a variable that represents one token.
 
-The testing token has 18 decimal places, so you'll want to define a variable that represents one token.
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L27 hash=9349517ae6165a8798e49750da8faeee
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L27 hash=9349517ae6165a8798e49750da8faeee
-```
+  {<h3>Create a CrossChainMessenger instance</h3>}
 
-{<h3>Create a CrossChainMessenger instance</h3>}
+  The Optimism SDK exports a `CrossChainMessenger` class that makes it easy to interact with the `L1StandardBridge` contract.
 
-The Optimism SDK exports a `CrossChainMessenger` class that makes it easy to interact with the `L1StandardBridge` contract.
+  Create an instance of the `CrossChainMessenger` class:
 
-Create an instance of the `CrossChainMessenger` class:
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L29-L34 hash=997b9c4cdd5fb1f9d4e0882a683ae016
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L29-L34 hash=997b9c4cdd5fb1f9d4e0882a683ae016
-```
+  {<h3>Allow the Standard Bridge to access your tokens</h3>}
 
-{<h3>Allow the Standard Bridge to access your tokens</h3>}
+  Before you can deposit your tokens, you'll need to give the Standard Bridge contract an allowance of tokens on L1.
+  This will allow the Standard Bridge to pull these tokens out of your address and escrow inside the bridge.
 
-Before you can deposit your tokens, you'll need to give the Standard Bridge contract an allowance of tokens on L1.
-This will allow the Standard Bridge to pull these tokens out of your address and escrow inside the bridge.
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L37-L38 hash=3d9347e57540e808d71230c1bbe49db5
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L37-L38 hash=3d9347e57540e808d71230c1bbe49db5
-```
+  {<h3>Deposit your tokens</h3>}
 
-{<h3>Deposit your tokens</h3>}
+  Now you can deposit your tokens into the Standard Bridge contract.
 
-Now you can deposit your tokens into the Standard Bridge contract.
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L41-L42 hash=0dc6191c87c0a371d7a469ed98190e57
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L41-L42 hash=0dc6191c87c0a371d7a469ed98190e57
-```
+  <Callout>
+    Using a smart contract wallet? As a safety measure, `depositERC20` will fail
+    if you try to deposit ETH from a smart contract wallet without specifying a
+    `recipient`. Add the `recipient` option to the `depositERC20` call to fix
+    this. Check out the [Optimism SDK
+    docs](https://sdk.optimism.io/classes/crosschainmessenger#depositERC20-2) for
+    more info on the options you can pass to `depositERC20`.
+  </Callout>
 
-<Callout>
-Using a smart contract wallet?
-As a safety measure, `depositERC20` will fail if you try to deposit ETH from a smart contract wallet without specifying a `recipient`.
-Add the `recipient` option to the `depositERC20` call to fix this.
-Check out the [Optimism SDK docs](https://sdk.optimism.io/classes/crosschainmessenger#depositERC20-2) for more info on the options you can pass to `depositERC20`.
-</Callout>
+  {<h3>Wait for the deposit to be relayed</h3>}
 
-{<h3>Wait for the deposit to be relayed</h3>}
+  You can use the `waitForMessageStatus` function to wait for the deposit to be relayed to L2.
 
-You can use the `waitForMessageStatus` function to wait for the deposit to be relayed to L2.
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L45 hash=659971675ab8d53bc2bd5196f72c873b
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L45 hash=659971675ab8d53bc2bd5196f72c873b
-```
+  {<h3>Check your token balance on L1</h3>}
 
-{<h3>Check your token balance on L1</h3>}
+  You should now have one less token on L1.
 
-You should now have one less token on L1.
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L48 hash=d7a60aa394d1055555c2aeab2a2e111d
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L48 hash=d7a60aa394d1055555c2aeab2a2e111d
-```
+  {<h3>Create a Contract instance for the L2 token</h3>}
 
-{<h3>Create a Contract instance for the L2 token</h3>}
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L50 hash=d7ab5afad79dafcb7be976c3d0d3df84
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L50 hash=d7ab5afad79dafcb7be976c3d0d3df84
-```
+  {<h3>Check your token balance on L2</h3>}
 
-{<h3>Check your token balance on L2</h3>}
+  You should now have one more token on L2.
 
-You should now have one more token on L2.
-
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L53 hash=b332b68817359e4c6e991ed83de6e490
-```
-
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L53 hash=b332b68817359e4c6e991ed83de6e490
+  ```
 </Steps>
 
 ## Withdraw Tokens
@@ -263,75 +273,74 @@ Nice!
 Now you're going to repeat the process in reverse to bridge some tokens from L2 to L1.
 
 <Steps>
+  {<h3>Start your withdrawal on L2</h3>}
 
-{<h3>Start your withdrawal on L2</h3>}
+  The first step to withdrawing tokens from L2 to L1 is to start the withdrawal on L2.
 
-The first step to withdrawing tokens from L2 to L1 is to start the withdrawal on L2.
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L56-L57 hash=b97f906085a2c350d9113488ea9b1d45
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L56-L57 hash=b97f906085a2c350d9113488ea9b1d45
-```
+  {<h3>Check your token balance on L2</h3>}
 
-{<h3>Check your token balance on L2</h3>}
+  You should now have one less token on L2, but your token balance on L1 will not have changed yet.
 
-You should now have one less token on L2, but your token balance on L1 will not have changed yet.
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L60 hash=b332b68817359e4c6e991ed83de6e490
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L60 hash=b332b68817359e4c6e991ed83de6e490
-```
+  {<h3>Wait until the withdrawal is ready to prove</h3>}
 
-{<h3>Wait until the withdrawal is ready to prove</h3>}
+  The second step to withdrawing tokens from L2 to L1 is to prove to the bridge on L1 that the withdrawal happened on L2.
+  You first need to wait until the withdrawal is ready to prove.
 
-The second step to withdrawing tokens from L2 to L1 is to prove to the bridge on L1 that the withdrawal happened on L2.
-You first need to wait until the withdrawal is ready to prove.
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L63 hash=e8b55ec0f16f90ba4d4197cf47ff8e6d
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L63 hash=e8b55ec0f16f90ba4d4197cf47ff8e6d
-```
+  <Callout type="info">
+    This step can take a few minutes. Feel free to take a quick break while you
+    wait.
+  </Callout>
 
-<Callout type="info">
-This step can take a few minutes.
-Feel free to take a quick break while you wait.
-</Callout>
+  {<h3>Prove the withdrawal on L1</h3>}
 
-{<h3>Prove the withdrawal on L1</h3>}
+  Once the withdrawal is ready to be proven, you'll send an L1 transaction to prove that the withdrawal happened on L2.
 
-Once the withdrawal is ready to be proven, you'll send an L1 transaction to prove that the withdrawal happened on L2.
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L66 hash=fee5f5e924472ee9daceb681ccae1cb9
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L66 hash=fee5f5e924472ee9daceb681ccae1cb9
-```
+  {<h3>Wait until the withdrawal is ready for relay</h3>}
 
-{<h3>Wait until the withdrawal is ready for relay</h3>}
+  The final step to withdrawing tokens from L2 to L1 is to relay the withdrawal on L1.
+  This can only happen after the fault proof period has elapsed.
+  On OP Mainnet, this takes 7 days.
 
-The final step to withdrawing tokens from L2 to L1 is to relay the withdrawal on L1.
-This can only happen after the fault proof period has elapsed.
-On OP Mainnet, this takes 7 days.
+  <Callout>
+    We're currently testing fault proofs on OP Sepolia, so withdrawal times
+    reflect Mainnet times.
+  </Callout>
 
-<Callout>
-We're currently testing fault proofs on OP Sepolia, so withdrawal times reflect Mainnet times.
-</Callout>
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L69 hash=55a41ac5586b8a688ffd6dfbb20f2d15
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L69 hash=55a41ac5586b8a688ffd6dfbb20f2d15
-```
+  {<h3>Relay the withdrawal on L1</h3>}
 
-{<h3>Relay the withdrawal on L1</h3>}
+  Once the withdrawal is ready to be relayed, you can finally complete the withdrawal process.
 
-Once the withdrawal is ready to be relayed, you can finally complete the withdrawal process.
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L85 hash=f8d30944dad1664d82b9fdf14da59f9e
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L85 hash=f8d30944dad1664d82b9fdf14da59f9e
-```
+  {<h3>Wait until the withdrawal is relayed</h3>}
 
-{<h3>Wait until the withdrawal is relayed</h3>}
+  Now you simply wait until the message is relayed.
 
-Now you simply wait until the message is relayed.
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L88 hash=c2c14a739c44011a058e9848a0019f15
+  ```
 
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L88 hash=c2c14a739c44011a058e9848a0019f15
-```
+  {<h3>Check your token balance on L1</h3>}
 
-{<h3>Check your token balance on L1</h3>}
+  You should now have one more token on L1.
 
-You should now have one more token on L1.
-
-```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L91 hash=d7a60aa394d1055555c2aeab2a2e111d
-```
-
+  ```js file=<rootDir>/public/tutorials/cross-dom-bridge-erc20.js#L91 hash=d7a60aa394d1055555c2aeab2a2e111d
+  ```
 </Steps>
 
 ## Next Steps

--- a/styles/global.css
+++ b/styles/global.css
@@ -1,12 +1,12 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400..700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400..700&display=swap');
-@import url("colors.css");
-@import url("theme.css");
+@import url('colors.css');
+@import url('theme.css');
 
 /* Override Nextra so content gets more breathing room */
 .nextra-content h2 ~ p,
 .nextra-content h3 ~ p {
-  margin-top: 1.0rem;
+  margin-top: 1rem;
 }
 
 /* Custom div that can contain Nextra images */
@@ -53,3 +53,31 @@ span.shasum code {
   background-color: transparent !important;
 }
 
+div.custom-callouts {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 65px;
+  padding: 5px;
+  background-color: #fefce8;
+  border: 2px solid #ffdc00;
+  z-index: 9999;
+  border-radius: 4px;
+}
+a.callout-link {
+  color: #006be6;
+  text-decoration: underline;
+}
+
+@media only screen and (max-width: 767px) {
+  div.custom-callouts {
+    top: 105px;
+  }
+}
+
+html.dark div.custom-callouts {
+  color: white;
+  background-color: #432c11;
+}
+html.dark a.callout-link {
+  color: #008ae6;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
       "@/components/*": ["components/*"],
       "@/utils/*": ["utils/*"],
       "@/pages/*": ["pages/*"],
+      "@/message/*": ["messages/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],

--- a/words.txt
+++ b/words.txt
@@ -132,7 +132,6 @@ ignoreprice
 implicity
 Inator
 inator
-incentivized
 INFLUXDBV
 influxdbv
 initcode


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->


**Description**

Adds support for custom callout messages in the `WipCallout` component.  This feature allows you to add a custom callout to a page, notifying users that it is currently undergoing maintenance.


**Additional context**

```typescript
... in mdx file

<WipCallout /> // with default message

<WipCallout context="this tutorial is outdated" /> // with custom message

// with a custom `.md` file
import WipMsg from "@/message/WipMsg.md" //import the md file

<WipCallout context={<WipMsg/>} />  // with custom .md file
```
![Callout image](https://github.com/ethereum-optimism/docs/assets/41796074/c462b90b-9463-4aff-a522-2b3db01073b5)

![This is an image showing that the callout sticks to the top when the page is scrolled](https://github.com/ethereum-optimism/docs/assets/41796074/ddc1decc-add4-408a-92e4-98fcf10498c3)

**This is an image showing that the callout sticks to the top when the page is scrolled**


The color scheme is open for suggestions, and I'll update this PR accordingly.

Example link:
http://localhost:3000/builders/app-developers/tutorials/cross-dom-bridge-erc20