### PR TITLE
Add Blocknative to Developer Tools

### DIFF
--- a/pages/builders/tools/monitor/analytics-tools.mdx
+++ b/pages/builders/tools/monitor/analytics-tools.mdx
@@ -10,6 +10,15 @@ import { Callout } from 'nextra/components'
 
 The following guide lists platforms you can use to gather analytics and setup customizations about OP Mainnet.
 
+## Blocknative
+
+[Blocknative](https://www.blocknative.com/) lets you [decode](http://docs.blocknative.com/ethernow/batch-decoder-api) and [analyze](https://docs.blocknative.com/blocknative-data-archive/blob-archive) OP Stack Batches submitted to the Ethereum L1. You can inspect, analyze, decode, and download the data of any batch – confirmed on-chain or not – via public APIs or visually through the [Ethernow Explorer](http://ethernow.xyz). Below you can find links to the different resources:
+
+*   [Batch Decoding API](http://docs.blocknative.com/ethernow/batch-decoder-api): decode OP Stack Batch transactions into its human-readable, JSON format.
+*   [Blob Archive API](https://docs.blocknative.com/blocknative-data-archive/blob-archive): take any versioned hash of an OP Stack Blob and receive the blob data (even beyond the 4096 epoch window of storage).
+*   [Mempool Archive](https://docs.blocknative.com/blocknative-data-archive/mempool-archive): Analyze any OP Stack transaction that was in the Ethereum mempool to see detection time, time pending, gas, etc.
+*   [Ethernow explorer](http://ethernow.xyz): Visually see transactions and batches enter the mempool and get organized into blocks. Use this filter to see OP Stack Batches enter the mempool and land on-chain.
+
 ## Tenderly
 
 [Tenderly](https://tenderly.co/) monitoring stack lets you [inspect any transaction execution on OP Mainnet or OP Sepolia](https://docs.tenderly.co/debugger#how-to-use-tenderly-debugger).
@@ -25,7 +34,7 @@ It helps you to inspect states at every instance of transaction and gives a plat
 ## Dune Analytics
 
 [Dune Analytics](https://dune.com) allows anyone to create dashboards that present information about OP Chains (OP Mainnet, Base, and Zora are available). See [Dune Docs](https://dune.com/docs/) for more info.
-You can find a list of community created dashboards for OP Chains [here](https://dune.com/browse/dashboards?q=tags%3Aop%2Coptimism%2Csuperchain&order=trending&time_range=24h), or [create your own](https://docs.dune.com/#queries) dashboard.
+You can find a list of community created dashboards for OP Chains [here](https://dune.com/browse/dashboards?q=tags%3Aop%2Coptimism%2Csuperchain\&order=trending\&time_range=24h), or [create your own](https://docs.dune.com/#queries) dashboard.
 
 Here are some of our favorite dashboards so far:
 

--- a/words.txt
+++ b/words.txt
@@ -86,6 +86,7 @@ Erigon
 erigon
 ETHERBASE
 etherbase
+Ethernow
 ETHSTATS
 ethstats
 EVMTIMEOUT


### PR DESCRIPTION
Adding in Blocknative Optimism tooling to support developers using the OP Stack.

This is related to two grants received by Blocknative from Optimism:
- https://app.charmverse.io/op-grants/page-3483779137072336
- https://app.charmverse.io/op-grants/batcher-gas-fee-optimization-research-and-implementation-419013603973726

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adding in a section for Blocknative that includes developer tooling for OP Stack Batch decoding, Blob Archive, Mempool Archive, and Explorer. These are related to two grants given to Blocknative.

**Tests**

N/

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
