### PR TITLE
docs: Update L1 and L2 URL examples for op-node setup

### DIFF
--- a/pages/builders/node-operators/configuration/consensus-config.mdx
+++ b/pages/builders/node-operators/configuration/consensus-config.mdx
@@ -95,8 +95,8 @@ Address of L1 Beacon-node HTTP endpoint to use.
 
 <Tabs items={['Syntax', 'Example', 'Environment Variable']}>
   <Tabs.Tab>`--l1.beacon=<value>`</Tabs.Tab>
-  <Tabs.Tab>`--l1.beacon="127.0.0.1:3500"`</Tabs.Tab>
-  <Tabs.Tab>`OP_NODE_L1_BEACON="127.0.0.1:3500"`</Tabs.Tab>
+  <Tabs.Tab>`--l1.beacon="http://127.0.0.1:3500"`</Tabs.Tab>
+  <Tabs.Tab>`OP_NODE_L1_BEACON="http://127.0.0.1:3500"`</Tabs.Tab>
 </Tabs>
 
 ### l1.beacon.fetch-all-sidecars

--- a/pages/builders/node-operators/configuration/consensus-config.mdx
+++ b/pages/builders/node-operators/configuration/consensus-config.mdx
@@ -211,7 +211,7 @@ Trust the L1 RPC, sync faster at risk of malicious/buggy RPC providing bad or in
 
 ### l2
 
-Address of L2 Engine JSON-RPC endpoints to use (engine and eth namespace required).
+Address of L2 Engine JSON-RPC endpoints to use (engine and eth namespace required). This is referred to as `authrpc` by Geth and Reth.
 
 <Tabs items={['Syntax', 'Example', 'Environment Variable']}>
   <Tabs.Tab>`--l2=<value>`</Tabs.Tab>

--- a/pages/builders/node-operators/tutorials/mainnet.mdx
+++ b/pages/builders/node-operators/tutorials/mainnet.mdx
@@ -126,9 +126,9 @@ Once you've started `op-geth`, you can start `op-node`.
   Set the following environment variables:
 
   ```bash
-  export L1_RPC_URL=...  # URL for the L1 node to sync from
+  export L1_RPC_URL=...  # URL for the L1 node to sync from. If your L1 RPC is a local node, the most common URL is http://127.0.0.1:8545
   export L1_RPC_KIND=... # RPC type (alchemy, quicknode, infura, parity, nethermind, debug_geth, erigon, basic, any)
-  export L1_BEACON_URL=... # URL address for the L1 Beacon-node HTTP endpoint to use.
+  export L1_BEACON_URL=... # URL address for the L1 Beacon-node HTTP endpoint to use. If your L1 Beacon is a local node, the most common URL is http://127.0.0.1:3500
   ```
 
   {<h3>Start op-node</h3>}

--- a/pages/builders/node-operators/tutorials/testnet.mdx
+++ b/pages/builders/node-operators/tutorials/testnet.mdx
@@ -124,9 +124,9 @@ cp /path/to/jwt.txt .
 Set the following environment variables:
 
 ```bash
-export L1_RPC_URL=...  # URL for the L1 node to sync from
+export L1_RPC_URL=...  # URL for the L1 node to sync from. If your L1 RPC is a local node, the most common URL is http://127.0.0.1:8545
 export L1_RPC_KIND=... # RPC type (alchemy, quicknode, infura, parity, nethermind, debug_geth, erigon, basic, any)
-export L1_BEACON_URL=... # URL address for the L1 Beacon-node HTTP endpoint to use.
+export L1_BEACON_URL=... # URL address for the L1 Beacon-node HTTP endpoint to use. If your L1 Beacon is a local node, the most common URL is http://127.0.0.1:3500
 ```
 
 {<h3>Start op-node</h3>}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The tutorial for setting up `op-node` does not give URL and port examples for its environment variables, which can make it difficult to figure out which URLs should be used. I gave the default ports used by Geth/Reth and Prysm local nodes respectively.

In addition, the `op-node` documentation does not state that Geth/Reth use different terminology from `op-node` when referring to the Engine API. I specified that when Geth/Reth refer to the `authrpc` parameter, they are referring to the same value used by the L2 Engine JSON-RPC endpoint.

**Tests**

Confirmed that all changes format well visually and pass all lint checks

**Additional context**

N/A

**Metadata**

N/A
