### PR TITLE
Update differences.mdx

### DIFF
--- a/pages/chain/differences.mdx
+++ b/pages/chain/differences.mdx
@@ -64,7 +64,7 @@ The EIP-1559 parameters used by OP Mainnet differ from those used by Ethereum as
 | ------------------------------------- | ---------------: | -----------------------------: |
 | Block gas limit                       |   30,000,000 gas |                 30,000,000 gas |
 | Block gas target                      |    5,000,000 gas |                 15,000,000 gas |
-| EIP-1559 elasticity multiplier        |                6 |                              2 |
+| EIP-1559 elasticity multiplier        |               10 |                              2 |
 | EIP-1559 denominator                  |              250 |                              8 |
 | Maximum base fee increase (per block) |               2% |                          12.5% |
 | Maximum base fee decrease (per block) |             0.4% |                          12.5% |


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Updated elasticity multiplier to correct value: 10

**Tests**

n/a

**Additional context**

Correct value is the second parameter returned from the resourceConfiggetter:

https://etherscan.io/address/0x229047fed2591dbec1eF1118d64F7aF3dB9EB290#readProxyContract

https://sepolia.etherscan.io/address/0x034edD2A225f7f429A63E0f1D2084B9E0A93b538#readProxyContract

Both give 10

It's correct in the specs (https://specs.optimism.io/protocol/configurability.html?highlight=op%20stack#resource-config) but not in this doc (https://docs.optimism.io/chain/differences#eip-1559-parameters)

**Metadata**

- Fixes #[Link to Issue]
