### PR TITLE
Removed old help center links and revised Telegram link

### DIFF
--- a/pages/builders/app-developers/transactions/troubleshooting.mdx
+++ b/pages/builders/app-developers/transactions/troubleshooting.mdx
@@ -34,14 +34,14 @@ Wallets are usually in charge of determining the default priority fee and max fe
 
 #### Recommendations for app developers
 
-As an app developer you can usually override the default recommendation of the wallet
+As an app developer, you can usually override the default recommendation of the wallet
 (see, for example, [ethers](https://github.com/ethers-io/ethers.js/blob/v5.7/packages/contracts/lib/index.d.ts#L10-L11)). 
 As long as not all wallets are upgraded according to our recommendations, it makes sense for apps to get the current base fee and recommend a value based on that.
 
 
 #### Recommendations for users
 
-As a user you are the final authority on transaction fields. Sometimes when submitting a transaction, the gas fee is set too low, and it gets stuck in the transaction pool (a.k.a. mempool). If you want to push that transaction through, [you can cancel it by submitting another transaction with the same nonce](https://info.etherscan.com/how-to-cancel-ethereum-pending-transactions/). This method increases the fee and the sequencer will process it from the mempool quicker.
+As a user, you are the final authority on transaction fields. Sometimes when submitting a transaction, the gas fee is set too low, and it gets stuck in the transaction pool (a.k.a. mempool). If you want to push that transaction through, [you can cancel it by submitting another transaction with the same nonce](https://info.etherscan.com/how-to-cancel-ethereum-pending-transactions/). This method increases the fee and the sequencer will process it from the mempool quicker.
 
 ## Deposit transactions don't have a chainId on L2
 

--- a/pages/builders/app-developers/transactions/troubleshooting.mdx
+++ b/pages/builders/app-developers/transactions/troubleshooting.mdx
@@ -41,11 +41,7 @@ As long as not all wallets are upgraded according to our recommendations, it mak
 
 #### Recommendations for users
 
-As a user you are the final authority on transaction fields.
-[See the help center](https://help.optimism.io/hc/en-us/articles/16711400204315-Managing-the-gas-fees-that-make-up-the-L2-execution-fee) for an explanation of how to modify the fees.
-
-If you already have a transaction that is stuck and you want to cancel it, or increase its base fee, submit another transaction with the same nonce value. 
-[See the help center for information on how to do it](https://help.optimism.io/hc/en-us/articles/17045804513307-What-to-do-with-a-stuck-pending-transaction-).
+As a user you are the final authority on transaction fields. Sometimes when submitting a transaction, the gas fee is set too low, and it gets stuck in the transaction pool (a.k.a. mempool). If you want to push that transaction through, [you can cancel it by submitting another transaction with the same nonce](https://info.etherscan.com/how-to-cancel-ethereum-pending-transactions/). This method increases the fee and the sequencer will process it from the mempool quicker.
 
 ## Deposit transactions don't have a chainId on L2
 

--- a/pages/builders/app-developers/tutorials/first-contract.mdx
+++ b/pages/builders/app-developers/tutorials/first-contract.mdx
@@ -361,9 +361,7 @@ Since this function doesn't have any access control, anyone can update the `mess
 
 ## Next Steps
 
-To learn more about Solidity, check out [this list of resources on the Optimism Help Center](https://help.optimism.io/hc/en-us/articles/4412777835675-Developer-information#h_01FVSVQ5ZQFJDSRYY6WTY18F0N).
-If you learn best by reading source code, check out [this annotated code for an ERC-20 token contract](https://ethereum.org/en/developers/tutorials/erc20-annotated-code/).
-You can also check out the [Solidity documentation](https://docs.soliditylang.org/en/latest/) for more information about the language itself.
+To learn more about Solidity, check out the [Solidity documentation](https://docs.soliditylang.org/en/latest/) for more information about the language itself. If you learn best by reading source code, check out [this annotated code for an ERC-20 token contract](https://ethereum.org/en/developers/tutorials/erc20-annotated-code/).
 
 Now that you know how to deploy a smart contract to OP Sepolia, you can deploy a smart contract to OP Mainnet in exactly the same way.
 If you're up for a challenge, try [creating a token on Sepolia and OP Sepolia](./standard-bridge-standard-token) and then [using the Optimism SDK](./cross-dom-bridge-erc20) to bridge some tokens between the two networks.

--- a/pages/builders/chain-operators/features/custom-gas-token.mdx
+++ b/pages/builders/chain-operators/features/custom-gas-token.mdx
@@ -157,5 +157,5 @@ section of the docs.
 ## Next Steps
 
 *   Additional questions? See the FAQ section in the [Custom Gas Token Explainer](/stack/protocol/features/custom-gas-token#faqs).
-*   For more detailed info on custom gas tokens, see the [specs](https://specs.optimism.io/protocol/granite/custom-gas-token.html).
+*   For more detailed info on custom gas tokens, see the [specs](https://specs.optimism.io/experimental/custom-gas-token.html).
 *   If you experience any problems, please reach out to [developer support](https://github.com/ethereum-optimism/developers/discussions).

--- a/pages/builders/node-operators/rollup-node.mdx
+++ b/pages/builders/node-operators/rollup-node.mdx
@@ -104,7 +104,7 @@ It is important to regularly monitor your node, and you can optionally configure
 
 *   It's important to keep your node software up to date. Software updates can also include important bug fixes and patches that can help keep your node stable.
 *   Refer to the [Software Releases](/builders/node-operators/releases) page for a detailed look at the latest releases of various rollup node and execution client implementations.
-*   Notifications are also posted to the Optimism Upgrade Announcement Channels on [**Discord**](https://discord.com/channels/667044843901681675/754090866435424270) and [**Telegram**](https://t.me/+vPoESXHxEm83YWQx).
+*   Notifications are also posted to the Optimism Upgrade Announcement Channels on [**Discord**](https://discord.com/channels/667044843901681675/754090866435424270) and [**Telegram**](https://t.me/+LtAJL1Mt1PYyNjBh).
 
 ## Node Operator Tutorials
 

--- a/pages/stack/protocol/features/custom-gas-token.mdx
+++ b/pages/stack/protocol/features/custom-gas-token.mdx
@@ -69,7 +69,7 @@ The custom token being used must adhere to the following constraints to be able 
 ## Next Steps
 
 *   Ready to get started? Read our guide on how to [deploy your custom gas token chain](/builders/chain-operators/features/custom-gas-token).
-*   For more info about how the custom gas token feature works under the hood, [check out the specs](https://specs.optimism.io/protocol/granite/custom-gas-token.html).
+*   For more info about how the custom gas token feature works under the hood, [check out the specs](https://specs.optimism.io/experimental/custom-gas-token.html).
 
 ## FAQs
 


### PR DESCRIPTION

**Description**

Revisions to change links and resources.

Help Center
- Revised troubleshooting.mdx to remove links to help center. Since the content was straightforward I moved those paragraphs into this page.
- first-contract.mdx: Removed reference to help center’s list of “how can I start writing solidity”. We may want to add a standalone page for Solidity education resources at a later date, but for now I’m simply removing it.

Telegram
- Set up permanent link for TG node announcement channel (https://t.me/+LtAJL1Mt1PYyNjBh)
- Changed link on rollup-node.mdx

