### PR TITLE
doc: execution layer sync for alternative clients

### DIFF
--- a/pages/builders/node-operators/configuration/base-config.mdx
+++ b/pages/builders/node-operators/configuration/base-config.mdx
@@ -159,7 +159,8 @@ op-node --l1=<ethereum mainnet RPC url> \
         --rpc.port=9545 \
         --l2.jwt-secret=<path to JWT secret> \
         --l1.beacon=<http endpoint address of L1 Beacon-node> \
-        --syncmode=execution-layer
+        --syncmode=execution-layer \
+        --l2.enginekind=geth
 ```
 
 You can manually specify a path to a rollup config with the `--rollup.config` flag. This is used for testnets or internal deployments that are not migrated from a legacy network.

--- a/pages/builders/node-operators/configuration/consensus-config.mdx
+++ b/pages/builders/node-operators/configuration/consensus-config.mdx
@@ -229,6 +229,16 @@ Path to JWT secret key. Keys are 32 bytes, hex encoded in a file. A new key will
   <Tabs.Tab>`OP_NODE_L2_ENGINE_AUTH=/path/to/jwt/secret`</Tabs.Tab>
 </Tabs>
 
+### l2.enginekind
+
+The kind of engine client, used to control the behavior of optimism in respect to different types of engine clients. Valid options: `geth`, `reth`, `erigon`. The default value is `geth`.
+
+<Tabs items={['Syntax', 'Example', 'Environment Variable']}>
+  <Tabs.Tab>`--l2.enginekind=<value>`</Tabs.Tab>
+  <Tabs.Tab>`--l2.enginekind=geth`</Tabs.Tab>
+  <Tabs.Tab>`OP_NODE_L2_ENGINE_KIND=geth`</Tabs.Tab>
+</Tabs>
+
 ### log.color
 
 Color the log output if in terminal mode. The default value is `false`.

--- a/pages/builders/node-operators/management/snap-sync.mdx
+++ b/pages/builders/node-operators/management/snap-sync.mdx
@@ -81,6 +81,25 @@ Choose one of the following options to enable snap sync:
   </Tabs.Tab>
 </Tabs>
 
+## Enabling Execution Layer Sync for Alternative Clients
+In addition to op-geth, you can enable execution-layer syncing with alternative execution clients such as `reth` and `op-erigon`.
+
+Unlike `op-geth`, `reth` and `op-erigon` are designed as archive nodes, which means they require the complete history of the chain. 
+However, these clients can still retrieve block headers and data through the P2P network instead of deriving each individual block, resulting in a faster initial sync.
+
+For OP Mainnet, the [bedrock datadir](snapshots) is required. For other OP Stack networks, no datadir is required. 
+
+To enable execution layer sync for these clients, set the following flags on `op-node`:
+```shell
+# for reth
+--syncmode=execution-layer (not default)
+--l2.enginekind=reth (not default)
+
+# for erigon
+--syncmode=execution-layer (not default)
+--l2.enginekind=erigon (not default)
+```
+
 ## Next Steps
 
 *   See the [Node Configuration](/builders/node-operators/configuration/base-config#configuration) guide for additional explanation or customization. 

--- a/pages/builders/node-operators/tutorials/mainnet.mdx
+++ b/pages/builders/node-operators/tutorials/mainnet.mdx
@@ -154,7 +154,8 @@ Once you've started `op-geth`, you can start `op-node`.
     --l2=ws://localhost:8551 \
     --l2.jwt-secret=./jwt.txt \
     --network=op-mainnet \
-    --syncmode=execution-layer
+    --syncmode=execution-layer \
+    --l2.enginekind=geth
   ```
 
   <Callout>

--- a/words.txt
+++ b/words.txt
@@ -82,6 +82,7 @@ Eigen
 ENABLEDEPRECATEDPERSONAL
 enabledeprecatedpersonal
 enablements
+enginekind
 Erigon
 erigon
 ETHERBASE


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

A new `l2.enginekind` flag was added for op-node recently: https://github.com/ethereum-optimism/optimism/pull/10767. 
Setting this to the relevant engine client kind allows users to use snap sync (or execution-layer syncing to be more exact) on alternative clients like op-erigon and reth. 

This PR adds a section about using this flag in the `Using Snap Sync for Node Operators` docs. It also adds usage of `l2.enginekind` to various places in the docs so that users can notice this flag more. 

If you find other documentation that is more relevant for this change, please let me know! 😄 

**Tests**
All changes are formatted and linted via pnpm. 

**Additional context**
N/A

**Metadata**
N/A