### PR TITLE
Improve op-conductor docs.

### DIFF
--- a/pages/builders/chain-operators/tools/op-challenger.mdx
+++ b/pages/builders/chain-operators/tools/op-challenger.mdx
@@ -82,32 +82,38 @@ This guide provides a walkthrough of setting up the configuration and monitoring
   #### `--rollup-rpc`
 
   *   This needs to be an`op-node` archive node because challenger needs access to output roots from back when the games start.
-      
+
       #### Important Configuration Details
 
-      1. Safe Head Database (SafeDB) Configuration for op-node:
-        *   The `op-node` behind the `op-conductor` must have the SafeDB enabled to ensure it is not stateless.
-        *   **How to Enable SafeDB:**
-            *   Set the `--safedb.path` value in your configuration. This specifies the file path used to persist safe head update data.
-            *   Example:
-                ```
-                --safedb.path <path-to-safe-head-db>   # Replace <path-to-safe-head-db> with your actual path
-                ```
-            *   If this path is not set, the SafeDB feature will be disabled.
-      
-      2. Ensuring Historical Data Availability:
-        *   Both `op-node` and `op-geth` must have data from the start of the games to maintain network consistency and allow nodes to reference historical state and transactions.
-        *   For `op-node`:
-            *   Configure it to maintain a sufficient history of blockchain data locally or use an archive node.
-        *   For `op-geth`:
-            *   Similarly, configure to store or access historical data.
-        
-        **Example Configuration**
-        ```
-        op-node \
-        --rollup-rpc <op-node-archive-node-url> \
-        --safedb.path <path-to-safe-head-db>
-        ```
+      1.  Safe Head Database (SafeDB) Configuration for op-node:
+
+      *   The `op-node` behind the `op-conductor` must have the SafeDB enabled to ensure it is not stateless.
+      *   **How to Enable SafeDB:**
+          *   Set the `--safedb.path` value in your configuration. This specifies the file path used to persist safe head update data.
+
+          *   Example:
+              ```
+              --safedb.path <path-to-safe-head-db>   # Replace <path-to-safe-head-db> with your actual path
+              ```
+
+          *   If this path is not set, the SafeDB feature will be disabled.
+
+      2.  Ensuring Historical Data Availability:
+
+      *   Both `op-node` and `op-geth` must have data from the start of the games to maintain network consistency and allow nodes to reference historical state and transactions.
+      *   For `op-node`:
+          *   Configure it to maintain a sufficient history of blockchain data locally or use an archive node.
+      *   For `op-geth`:
+          *   Similarly, configure to store or access historical data.
+
+      **Example Configuration**
+
+      ```
+      op-node \
+      --rollup-rpc <op-node-archive-node-url> \
+      --safedb.path <path-to-safe-head-db>
+      ```
+
       Replace `<op-node-archive-node-url>` with the URL of your archive node and `<path-to-safe-head-db>` with the desired path for storing SafeDB data.
 
   #### `--private-key`

--- a/pages/builders/chain-operators/tools/op-challenger.mdx
+++ b/pages/builders/chain-operators/tools/op-challenger.mdx
@@ -85,9 +85,9 @@ This guide provides a walkthrough of setting up the configuration and monitoring
 
       #### Important Configuration Details
 
-1.  Safe Head Database (SafeDB) Configuration for op-node:
+  1.  Safe Head Database (SafeDB) Configuration for op-node:
 
-    *   The `op-node` behind the `op-conductor` must have the SafeDB enabled to ensure it is not stateless.
+      *   The `op-node` behind the `op-conductor` must have the SafeDB enabled to ensure it is not stateless.
       *   **How to Enable SafeDB:**
           *   Set the `--safedb.path` value in your configuration. This specifies the file path used to persist safe head update data.
 
@@ -100,10 +100,10 @@ This guide provides a walkthrough of setting up the configuration and monitoring
 
       2.  Ensuring Historical Data Availability:
 
-    *   Both `op-node` and `op-geth` must have data from the start of the games to maintain network consistency and allow nodes to reference historical state and transactions.
-    *   For `op-node`:
+      *   Both `op-node` and `op-geth` must have data from the start of the games to maintain network consistency and allow nodes to reference historical state and transactions.
+      *   For `op-node`:
       *   Configure it to maintain a sufficient history of blockchain data locally or use an archive node.
-    *   For `op-geth`:
+      *   For `op-geth`:
       *   Similarly, configure to store or access historical data.
 
       **Example Configuration**

--- a/pages/builders/chain-operators/tools/op-challenger.mdx
+++ b/pages/builders/chain-operators/tools/op-challenger.mdx
@@ -82,6 +82,33 @@ This guide provides a walkthrough of setting up the configuration and monitoring
   #### `--rollup-rpc`
 
   *   This needs to be an`op-node` archive node because challenger needs access to output roots from back when the games start.
+      
+      #### Important Configuration Details
+
+      1. Safe Head Database (SafeDB) Configuration for op-node:
+        *   The `op-node` behind the `op-conductor` must have the SafeDB enabled to ensure it is not stateless.
+        *   **How to Enable SafeDB:**
+            *   Set the `--safedb.path` value in your configuration. This specifies the file path used to persist safe head update data.
+            *   Example:
+                ```
+                --safedb.path <path-to-safe-head-db>   # Replace <path-to-safe-head-db> with your actual path
+                ```
+            *   If this path is not set, the SafeDB feature will be disabled.
+      
+      2. Ensuring Historical Data Availability:
+        *   Both `op-node` and `op-geth` must have data from the start of the games to maintain network consistency and allow nodes to reference historical state and transactions.
+        *   For `op-node`:
+            *   Configure it to maintain a sufficient history of blockchain data locally or use an archive node.
+        *   For `op-geth`:
+            *   Similarly, configure to store or access historical data.
+        
+        **Example Configuration**
+        ```
+        op-node \
+        --rollup-rpc <op-node-archive-node-url> \
+        --safedb.path <path-to-safe-head-db>
+        ```
+      Replace `<op-node-archive-node-url>` with the URL of your archive node and `<path-to-safe-head-db>` with the desired path for storing SafeDB data.
 
   #### `--private-key`
 

--- a/pages/builders/chain-operators/tools/op-challenger.mdx
+++ b/pages/builders/chain-operators/tools/op-challenger.mdx
@@ -81,40 +81,38 @@ This guide provides a walkthrough of setting up the configuration and monitoring
 
   #### `--rollup-rpc`
 
-  *   This needs to be an`op-node` archive node because challenger needs access to output roots from back when the games start.
-
-      #### Important Configuration Details
+  *   This needs to be an`op-node` archive node because challenger needs access to output roots from back when the games start. See below for important configuration details:
 
   1.  Safe Head Database (SafeDB) Configuration for op-node:
 
       *   The `op-node` behind the `op-conductor` must have the SafeDB enabled to ensure it is not stateless.
-      *   **How to Enable SafeDB:**
-          *   Set the `--safedb.path` value in your configuration. This specifies the file path used to persist safe head update data.
+      *   To Enable SafeDB, set the `--safedb.path` value in your configuration. This specifies the file path used to persist safe head update data.
+      *   Example Configuration:
 
-          *   Example:
-              ```
-              --safedb.path <path-to-safe-head-db>   # Replace <path-to-safe-head-db> with your actual path
-              ```
+          ```
+          --safedb.path <path-to-safe-head-db>   # Replace <path-to-safe-head-db> with your actual path
+          ```
 
-          *   If this path is not set, the SafeDB feature will be disabled.
+          <Callout type="info">
+          If this path is not set, the SafeDB feature will be disabled.
+          </Callout>
 
       2.  Ensuring Historical Data Availability:
 
       *   Both `op-node` and `op-geth` must have data from the start of the games to maintain network consistency and allow nodes to reference historical state and transactions.
-      *   For `op-node`:
-      *   Configure it to maintain a sufficient history of blockchain data locally or use an archive node.
-      *   For `op-geth`:
-      *   Similarly, configure to store or access historical data.
+      *   For `op-node`: Configure it to maintain a sufficient history of blockchain data locally or use an archive node.
+      *   For `op-geth`: Similarly, configure to store or access historical data.
+      *   Example Configuration:
 
-      **Example Configuration**
+          ```
+          op-node \
+          --rollup-rpc <op-node-archive-node-url> \
+          --safedb.path <path-to-safe-head-db>
+          ```
 
-      ```
-      op-node \
-      --rollup-rpc <op-node-archive-node-url> \
-      --safedb.path <path-to-safe-head-db>
-      ```
-
+      <Callout type="info">
       Replace `<op-node-archive-node-url>` with the URL of your archive node and `<path-to-safe-head-db>` with the desired path for storing SafeDB data.
+      </Callout>
 
   #### `--private-key`
 

--- a/pages/builders/chain-operators/tools/op-challenger.mdx
+++ b/pages/builders/chain-operators/tools/op-challenger.mdx
@@ -85,9 +85,9 @@ This guide provides a walkthrough of setting up the configuration and monitoring
 
       #### Important Configuration Details
 
-      1.  Safe Head Database (SafeDB) Configuration for op-node:
+1.  Safe Head Database (SafeDB) Configuration for op-node:
 
-      *   The `op-node` behind the `op-conductor` must have the SafeDB enabled to ensure it is not stateless.
+    *   The `op-node` behind the `op-conductor` must have the SafeDB enabled to ensure it is not stateless.
       *   **How to Enable SafeDB:**
           *   Set the `--safedb.path` value in your configuration. This specifies the file path used to persist safe head update data.
 
@@ -100,11 +100,11 @@ This guide provides a walkthrough of setting up the configuration and monitoring
 
       2.  Ensuring Historical Data Availability:
 
-      *   Both `op-node` and `op-geth` must have data from the start of the games to maintain network consistency and allow nodes to reference historical state and transactions.
-      *   For `op-node`:
-          *   Configure it to maintain a sufficient history of blockchain data locally or use an archive node.
-      *   For `op-geth`:
-          *   Similarly, configure to store or access historical data.
+    *   Both `op-node` and `op-geth` must have data from the start of the games to maintain network consistency and allow nodes to reference historical state and transactions.
+    *   For `op-node`:
+      *   Configure it to maintain a sufficient history of blockchain data locally or use an archive node.
+    *   For `op-geth`:
+      *   Similarly, configure to store or access historical data.
 
       **Example Configuration**
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Improvements include:

1. Safe Head Database (SafeDB) Configuration:
    * Detailed instructions on enabling the SafeDB for `op-node` by setting the `--safedb.path` value.
    * Explanation of the importance of SafeDB in ensuring the `op-node` is not stateless and can persist crucial update data.
    
2. Rollup RPC Configuration:
    * Clear guidelines on setting the `--rollup-rpc` flag to point to an `op-node` archive node, highlighting the need for the challenger to access historical output roots.
    * Inclusion of an example configuration snippet for ease of understanding and implementation.
   
3. Historical Data Requirements:
   * Emphasis on the necessity for both `op-node` and `op-geth` to have data from the start of the games to maintain network consistency.
   * Guidelines on ensuring sufficient historical data availability for both nodes, either through local storage or using archive nodes.




**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #788 
