### PR TITLE
feat: add GA natively instead of via netlify injection

### DIFF
--- a/pages/_app.mdx
+++ b/pages/_app.mdx
@@ -1,5 +1,0 @@
-import '../styles/global.css'
-
-export default function App({ Component, pageProps }) {
-    return <Component {...pageProps} />
-}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,20 @@
+import '../styles/global.css'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+import * as gtag from '../utils/gtag'
+
+export default function App({ Component, pageProps }) {
+  const router = useRouter()
+  useEffect(() => {
+    const handleRouteChange = (url) => {
+      gtag.pageview(url)
+    }
+    router.events.on('routeChangeComplete', handleRouteChange)
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange)
+    }
+  }, [router.events])
+
+  return <Component {...pageProps} />
+}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,36 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+
+import { GA_TRACKING_ID } from '../utils/gtag'
+
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <Html>
+        <Head>
+          {/* Global Site Tag (gtag.js) - Google Analytics */}
+          <script
+            async
+            src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+          />
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', '${GA_TRACKING_ID}', {
+              page_path: window.location.pathname,
+            });
+          `,
+            }}
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}

--- a/utils/gtag.ts
+++ b/utils/gtag.ts
@@ -1,0 +1,17 @@
+export const GA_TRACKING_ID = process.env.NEXT_PUBLIC_GA_ID
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+export const pageview = (url) => {
+  (window as any).gtag('config', GA_TRACKING_ID, {
+    page_path: url,
+  })
+}
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+export const event = ({ action, category, label, value }) => {
+  (window as any).gtag('event', action, {
+    event_category: category,
+    event_label: label,
+    value: value,
+  })
+}


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Looks like GA broke at some point, probably because Netlify automatically upgraded the version of Next.js it was using. We can no longer use snippet injection so instead we have to natively support GA.