### PR TITLE
Changing faucet link across docs

### DIFF
--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -1,4 +1,4 @@
-{  
+{
   "index": {
     "title": "Getting Started",
     "display": "hidden",
@@ -40,7 +40,7 @@
   "faucet": {
     "title": "Superchain Faucet",
     "type": "page",
-    "href": "https://app.optimism.io/faucet?utm_source=docs",
+    "href": "https://console.optimism.io/faucet?utm_source=docs",
     "newWindow": true
   },
   "gas": {

--- a/pages/builders/app-developers/quick-start.mdx
+++ b/pages/builders/app-developers/quick-start.mdx
@@ -16,7 +16,7 @@ This quick start uses [`Scaffold-OP`](https://github.com/ethereum-optimism/scaff
 ## Step 1: Get Testnet ETH from Superchain Faucet
 
 You'll need some testnet ETH on OP Sepolia to pay for the [gas fees](https://ethereum.org/en/developers/docs/gas/) associated with deploying your test application.
-Use the [Optimism Superchain Faucet](https://app.optimism.io/faucet?utm_source=scaffoldop) to get some free ETH on OP Sepolia for multiple OP Chains with just one click.
+Use the [Optimism Superchain Faucet](https://console.optimism.io/faucet?utm_source=scaffoldop) to get some free ETH on OP Sepolia for multiple OP Chains with just one click.
 You can request testnet ETH from the Superchain Faucet in one of two ways: **connect a wallet** or **login with Github**.
 
 <Image src="/img/builders/app-developers/quick-start/faucet-markup.png" alt="Superchain Faucet sign-up options" width={500} height={500} />

--- a/pages/builders/app-developers/tutorials/cross-dom-bridge-erc20.mdx
+++ b/pages/builders/app-developers/tutorials/cross-dom-bridge-erc20.mdx
@@ -85,7 +85,7 @@ You will need to get some ETH on both of these testnets.
 <Callout type="info">
   You can use [this faucet](https://sepoliafaucet.com) to get ETH on Sepolia.
   You can use the [Superchain
-  Faucet](https://app.optimism.io/faucet?utm_source=docs) to get ETH on OP
+  Faucet](https://console.optimism.io/faucet?utm_source=docs) to get ETH on OP
   Sepolia.
 </Callout>
 

--- a/pages/builders/app-developers/tutorials/cross-dom-solidity.mdx
+++ b/pages/builders/app-developers/tutorials/cross-dom-solidity.mdx
@@ -45,7 +45,7 @@ You will need to get some ETH on both of these testnets.
 
 <Callout type="info">
 You can use [this faucet](https://sepoliafaucet.com/) to get ETH on Sepolia.
-You can use the [Superchain Faucet](https://app.optimism.io/faucet?utm_source=docs) to get ETH on OP Sepolia.
+You can use the [Superchain Faucet](https://console.optimism.io/faucet?utm_source=docs) to get ETH on OP Sepolia.
 </Callout>
 
 ## Review the Contracts

--- a/pages/builders/app-developers/tutorials/first-contract.mdx
+++ b/pages/builders/app-developers/tutorials/first-contract.mdx
@@ -156,7 +156,7 @@ Click "Switch network" to continue.
 ## Get ETH on OP Sepolia
 
 You'll need some ETH on OP Sepolia to pay for the [gas fees](https://ethereum.org/en/developers/docs/gas/) associated with deploying a smart contract.
-You can use the [Optimism Superchain Faucet](https://app.optimism.io/faucet?utm_source=docs) to get some free ETH on OP Sepolia.
+You can use the [Optimism Superchain Faucet](https://console.optimism.io/faucet?utm_source=docs) to get some free ETH on OP Sepolia.
 
 <Callout>
 Having issues with the Optimism Superchain Faucet?

--- a/pages/builders/app-developers/tutorials/sdk-estimate-costs.mdx
+++ b/pages/builders/app-developers/tutorials/sdk-estimate-costs.mdx
@@ -69,7 +69,7 @@ This tutorial explains how estimate transaction costs on OP Sepolia.
 You will need to get some ETH on OP Sepolia in order to run the code in this tutorial.
 
 <Callout type="info">
-You can use the [Superchain Faucet](https://app.optimism.io/faucet?utm_source=docs) to get ETH on OP Sepolia.
+You can use the [Superchain Faucet](https://console.optimism.io/faucet?utm_source=docs) to get ETH on OP Sepolia.
 </Callout>
 
 ## Add a Private Key to Your Environment

--- a/pages/builders/app-developers/tutorials/send-tx-from-eth.mdx
+++ b/pages/builders/app-developers/tutorials/send-tx-from-eth.mdx
@@ -80,7 +80,7 @@ You will need to get some ETH on both of these testnets.
 
 <Callout type="info">
 You can use [this faucet](https://sepoliafaucet.com) to get ETH on Sepolia.
-You can use the [Superchain Faucet](https://app.optimism.io/faucet?utm_source=docs) to get ETH on OP Sepolia.
+You can use the [Superchain Faucet](https://console.optimism.io/faucet?utm_source=docs) to get ETH on OP Sepolia.
 </Callout>
 
 ## Add a Private Key to Your Environment

--- a/pages/builders/app-developers/tutorials/standard-bridge-custom-token.mdx
+++ b/pages/builders/app-developers/tutorials/standard-bridge-custom-token.mdx
@@ -42,7 +42,7 @@ You will need to get some ETH on both of these testnets.
 
 <Callout type="info">
 You can use [this faucet](https://sepoliafaucet.com/) to get ETH on Sepolia.
-You can use the [Superchain Faucet](https://app.optimism.io/faucet?utm_source=docs) to get ETH on OP Sepolia.
+You can use the [Superchain Faucet](https://console.optimism.io/faucet?utm_source=docs) to get ETH on OP Sepolia.
 </Callout>
 
 ## Add OP Sepolia to Your Wallet

--- a/pages/builders/app-developers/tutorials/standard-bridge-standard-token.mdx
+++ b/pages/builders/app-developers/tutorials/standard-bridge-standard-token.mdx
@@ -41,7 +41,7 @@ You will need to get some ETH on both of these testnets.
 
 <Callout type="info">
 You can use [this faucet](https://sepoliafaucet.com) to get ETH on Sepolia.
-You can use the [Superchain Faucet](https://app.optimism.io/faucet?utm_source=docs) to get ETH on OP Sepolia.
+You can use the [Superchain Faucet](https://console.optimism.io/faucet?utm_source=docs) to get ETH on OP Sepolia.
 </Callout>
 
 ## Get an L1 ERC-20 Token Address

--- a/pages/builders/tools/build/faucets.mdx
+++ b/pages/builders/tools/build/faucets.mdx
@@ -24,7 +24,7 @@ Faucets can occasionally also run out of ETH, so if you're having trouble gettin
 
 ## Superchain Faucet
 
-The [Superchain Faucet](https://app.optimism.io/faucet?utm_source=docs) is a developer tool hosted by Optimism that allows developers to get free testnet ETH to test apps on testnet OP Chains like Base Sepolia, OP Sepolia, PGN Sepolia, Zora Sepolia, and other OP Chains in the Superchain.
+The [Superchain Faucet](https://console.optimism.io/faucet?utm_source=docs) is a developer tool hosted by Optimism that allows developers to get free testnet ETH to test apps on testnet OP Chains like Base Sepolia, OP Sepolia, PGN Sepolia, Zora Sepolia, and other OP Chains in the Superchain.
 The Superchain Faucet is a great place to start if you're looking for testnet ETH.
 
 ## Additional Faucets

--- a/pages/builders/tools/op-tools/_meta.json
+++ b/pages/builders/tools/op-tools/_meta.json
@@ -17,7 +17,7 @@
       "faucet": {
         "title": "Superchain Faucet",
         "type": "page",
-        "href": "https://app.optimism.io/faucet?utm_source=docs",
+        "href": "https://console.optimism.io/faucet?utm_source=docs",
         "newWindow": true
       },
       "console": {

--- a/pages/builders/tools/overview.mdx
+++ b/pages/builders/tools/overview.mdx
@@ -24,8 +24,8 @@ If you are already familiar with [building on OP Mainnet](/chain/getting-started
 ## Building
 
 <Cards>
-  <Card title="Faucets" href="/builders/tools/build/faucets" icon={<img src="/img/icons/shapes.svg" />} /> 
-  
+  <Card title="Faucets" href="/builders/tools/build/faucets" icon={<img src="/img/icons/shapes.svg" />} />
+
   <Card title="Oracles" href="/builders/tools/build/oracles" icon={<img src="/img/icons/shapes.svg" />} />
 
   <Card title="NFT Tools" href="/builders/tools/build/nft-tools" icon={<img src="/img/icons/shapes.svg" />} />
@@ -51,8 +51,8 @@ If you are already familiar with [building on OP Mainnet](/chain/getting-started
   <Card title="Superchain Bridges" href="https://app.optimism.io/bridge" icon={<img src="/img/icons/shapes.svg" />} />
 
   <Card title="Optimism SDK" href="https://sdk.optimism.io/" icon={<img src="/img/icons/shapes.svg" />} />
-  
-  <Card title="Superchain Faucet" href="https://app.optimism.io/faucet?utm_source=docs" icon={<img src="/img/icons/shapes.svg" />} />
+
+  <Card title="Superchain Faucet" href="https://console.optimism.io/faucet?utm_source=docs" icon={<img src="/img/icons/shapes.svg" />} />
 
   <Card title="Superchain Dev Console" href="https://console.optimism.io/?utm_source=docs" icon={<img src="/img/icons/shapes.svg" />} />
 

--- a/pages/chain/getting-started.mdx
+++ b/pages/chain/getting-started.mdx
@@ -21,7 +21,7 @@ To access any Ethereum type network you need an endpoint. [These providers](/bui
 
 For development purposes we recommend you use either a local development node or [OP Sepolia](https://sepolia-optimism.etherscan.io).
 That way you don't need to spend real money.
-If you need ETH on OP Sepolia for testing purposes, [you can use this faucet](https://app.optimism.io/faucet?utm_source=docs).
+If you need ETH on OP Sepolia for testing purposes, [you can use this faucet](https://console.optimism.io/faucet?utm_source=docs).
 
 ## Interacting with Contracts on OP Mainnet or OP Sepolia
 

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -32,7 +32,7 @@ Whether you're a developer building a app on OP Mainnet, a node operator running
 Check out these amazing tools, so you can get building with Optimism.
 
 <Cards>
-  <Card title="Superchain Faucet" href="https://app.optimism.io/faucet?utm_source=docs" icon={<img src="img/icons/gear.svg" />} />
+  <Card title="Superchain Faucet" href="https://console.optimism.io/faucet?utm_source=docs" icon={<img src="img/icons/gear.svg" />} />
 
   <Card title="Scaffold-OP" href="/builders/app-developers/quick-start" icon={<img src="img/icons/gear.svg" />} />
 


### PR DESCRIPTION
**Description**

Modifying the faucet link to the new link 

It should point to https://console.optimism.io/faucet (and not https://app.optimism.io/faucet)
