### PR TITLE
Update create-l2-rollup.mdx

### DIFF
--- a/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
+++ b/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
@@ -594,7 +594,6 @@ cd ~/optimism/op-node
   --verifier.l1-confs=4 \
   --rollup.config=./rollup.json \
   --rpc.addr=0.0.0.0 \
-  --rpc.port=8547 \
   --p2p.disable \
   --rpc.enable-admin \
   --p2p.sequencer.key=$GS_SEQUENCER_PRIVATE_KEY \
@@ -662,13 +661,13 @@ cd ~/optimism/op-batcher
   --rpc.addr=0.0.0.0 \
   --rpc.port=8548 \
   --rpc.enable-admin \
-  --max-channel-duration=1 \
+  --max-channel-duration=25 \
   --l1-eth-rpc=$L1_RPC_URL \
   --private-key=$GS_BATCHER_PRIVATE_KEY
 ```
 
 <Callout type="info">
-The `--max-channel-duration=n` setting tells the batcher to write all the data to L1 every `n` L1 blocks.
+The [`--max-channel-duration=n`](/builders/chain-operators/configuration/batcher#set-your--op_batcher_max_channel_duration) setting tells the batcher to write all the data to L1 every `n` L1 blocks.
 When it is low, transactions are written to L1 frequently and other nodes can synchronize from L1 quickly.
 When it is high, transactions are written to L1 less frequently and the batcher spends less ETH.
 If you want to reduce costs, either set this value to 0 to disable it or increase it to a higher value.
@@ -699,7 +698,7 @@ cd ~/optimism/op-proposer
   --poll-interval=12s \
   --rpc.port=8560 \
   --rollup-rpc=http://localhost:8547 \
-  --l2oo-address=$(cat ../packages/contracts-bedrock/deployments/getting-started/L2OutputOracleProxy.json | jq -r .address) \
+  --l2oo-address=$(cat ../packages/contracts-bedrock/deployments/getting-started/.deploy | jq -r .L2OutputOracleProxy) \
   --private-key=$GS_PROPOSER_PRIVATE_KEY \
   --l1-eth-rpc=$L1_RPC_URL
 ```
@@ -728,7 +727,7 @@ cd ~/optimism/packages/contracts-bedrock
 {<h3>Get the address of the L1StandardBridgeProxy contract</h3>}
 
 ```bash
-cat deployments/getting-started/L1StandardBridgeProxy.json | jq -r .address
+cat deployments/getting-started/.deploy | jq -r .L1StandardBridgeProxy
 ```
 
 {<h3>Send some Sepolia ETH to the L1StandardBridgeProxy contract</h3>}

--- a/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
+++ b/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
@@ -697,7 +697,7 @@ cd ~/optimism/op-proposer
 ./bin/op-proposer \
   --poll-interval=12s \
   --rpc.port=8560 \
-  --rollup-rpc=http://localhost:8547 \
+  --rollup-rpc=http://localhost:9545 \
   --l2oo-address=$(cat ../packages/contracts-bedrock/deployments/getting-started/.deploy | jq -r .L2OutputOracleProxy) \
   --private-key=$GS_PROPOSER_PRIVATE_KEY \
   --l1-eth-rpc=$L1_RPC_URL


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

1. **Removed `--rpc.port=8547` from `op-node`:**  
   Use the default value to align with the [JSON-RPC API](https://docs.optimism.io/builders/node-operators/json-rpc#optimism_syncstatus) documentation.  
   **Flag description:**  
   `--rpc.port value` (default: 9545) ($OP_NODE_RPC_PORT)  
   RPC listening port.

2. **Changed `--max-channel-duration` for `op-batcher`:**  
   Updated `--max-channel-duration=1` to `--max-channel-duration=25`, referencing the corresponding configuration value from `op-sepolia`.

3. **Added link target for `--max-channel-duration=n`:**  
   Added a link to "Set Your OP_BATCHER_MAX_CHANNEL_DURATION" to provide relevant recommendations.

4. **Updated `op-proposer` command for L1StandardBridgeProxy address:**  
   Changed the command from  
   ```bash
   cat deployments/getting-started/L1StandardBridgeProxy.json | jq -r .address
   ```  
   to  
   ```bash
   cat ../packages/contracts-bedrock/deployments/getting-started/.deploy | jq -r .L2OutputOracleProxy
   ```  
   as the previous command was no longer valid.

5. **Updated command to retrieve L1StandardBridgeProxy address:**  
   Changed the command from  
   ```bash
   cat deployments/getting-started/L1StandardBridgeProxy.json | jq -r .address
   ```  
   to  
   ```bash
   cat deployments/getting-started/.deploy | jq -r .L1StandardBridgeProxy
   ```  
   due to the previous command becoming invalid.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
