### PR TITLE
Update account-abstraction.mdx

### DIFF
--- a/pages/builders/tools/build/account-abstraction.mdx
+++ b/pages/builders/tools/build/account-abstraction.mdx
@@ -30,9 +30,6 @@ Ready to enable account abstraction experiences in your app? Here's some helpful
 *   [Alchemy](https://www.alchemy.com/account-abstraction): 
     Account Kit is a complete solution for account abstraction. Using Account Kit, you can create a smart contract wallet for every user that leverages account abstraction to simplify every step of your app's onboarding experience. It also offers Gas Manager and Bundler APIs for sponsoring gas and batching transactions.
 
-*   [thirdweb](https://portal.thirdweb.com/connect/account-abstraction/overview):
-    offers the complete tool-kit to leverage account abstraction technology to enable seamless user experiences for your users. This includes Account Factory contracts that lets your users spin up Smart Accounts, Bundler for UserOps support, and Paymaster to enable gas sponsorships. 
-
 *   [Biconomy](https://docs.biconomy.io/): is an Account Abstraction toolkit that enables you to provide the simplest UX for your app or wallet. It offers modular smart accounts, as well as paymasters and bundlers as a service for sponsoring gas and executing transactions at scale.
 
 *   [GroupOS](https://docs.groupos.xyz/introduction/group-os): provides Smart Wallets that are ERC-4337 compliant smart wallets, offering full flexibility, programmability and extensibility as well as out-of-the-box toolkit groups need to gaslessly onboard and activate wallets to games, applications, and/or protocols.
@@ -44,6 +41,9 @@ Ready to enable account abstraction experiences in your app? Here's some helpful
 *   [Safe](https://docs.safe.global/home/what-is-safe): provides modular smart account infrastructure and account abstraction stack via their Safe\{Core\} Account Abstraction SDK, API, and Protocol.
 
 *   [Stackup](https://docs.stackup.sh/docs): provides smart account tooling for building account abstraction within your apps. They offer Paymaster and Bundler APIs for sponsoring gas and sending account abstraction transactions.
+
+*   [Thirdweb](https://portal.thirdweb.com/connect/account-abstraction/overview):
+    offers the complete tool-kit to leverage account abstraction technology to enable seamless user experiences for your users. This includes Account Factory contracts that lets your users spin up Smart Accounts, Bundler for UserOps support, and Paymaster to enable gas sponsorships. 
 
 ## Helpful Tips
 

--- a/pages/builders/tools/build/account-abstraction.mdx
+++ b/pages/builders/tools/build/account-abstraction.mdx
@@ -30,6 +30,9 @@ Ready to enable account abstraction experiences in your app? Here's some helpful
 *   [Alchemy](https://www.alchemy.com/account-abstraction): 
     Account Kit is a complete solution for account abstraction. Using Account Kit, you can create a smart contract wallet for every user that leverages account abstraction to simplify every step of your app's onboarding experience. It also offers Gas Manager and Bundler APIs for sponsoring gas and batching transactions.
 
+*   [thirdweb](https://portal.thirdweb.com/connect/account-abstraction/overview):
+    offers the complete tool-kit to leverage account abstraction technology to enable seamless user experiences for your users. This includes Account Factory contracts that lets your users spin up Smart Accounts, Bundler for UserOps support, and Paymaster to enable gas sponsorships. 
+
 *   [Biconomy](https://docs.biconomy.io/): is an Account Abstraction toolkit that enables you to provide the simplest UX for your app or wallet. It offers modular smart accounts, as well as paymasters and bundlers as a service for sponsoring gas and executing transactions at scale.
 
 *   [GroupOS](https://docs.groupos.xyz/introduction/group-os): provides Smart Wallets that are ERC-4337 compliant smart wallets, offering full flexibility, programmability and extensibility as well as out-of-the-box toolkit groups need to gaslessly onboard and activate wallets to games, applications, and/or protocols.

--- a/words.txt
+++ b/words.txt
@@ -336,6 +336,7 @@ SYNCTARGET
 synctarget
 syscalls
 therealbytes
+Thirdweb
 threadcreate
 tility
 timeseries


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adding thridweb link to Account Abstraction Support.

**Tests**
No tests added as this is adding links to the docs. 

**Additional context**
- none

**Metadata**

- Fixes #[Link to Issue]
