### PR TITLE
Change Algolia logo display

### DIFF
--- a/components/Search/docsearch.tsx
+++ b/components/Search/docsearch.tsx
@@ -325,10 +325,18 @@ export function DocSearch({
               </span>
             )}
           </ul>
-          <div className="nx-absolute nx-bottom-0 nx-right-0 nx-px-2 nx-py-2">
+          <div
+            className="nx-absolute nx-px-2 nx-py-2 nx-bg-white dark:nx-bg-dark/50"
+            style={{
+              top: "1px",
+              right: "1px",
+              borderBottomLeftRadius: "0.5rem",
+              borderTopRightRadius: "0.5rem",
+            }}
+          >
             <img
               src="/logos/algolia-logo-blue.png"
-              style={{ width: "80px" }}
+              style={{ width: "60px" }}
               alt="Algolia logo"
             />
           </div>


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Change Algolia logo display because it was overlaying some of the results text.

![IMAGE 2024-08-19 10:36:09](https://github.com/user-attachments/assets/df82ee47-94f2-4ed9-926e-604349331d34)
![IMAGE 2024-08-19 10:36:20](https://github.com/user-attachments/assets/a0dbf6c8-f1ae-4ff2-a808-5381718ab111)

