### PR TITLE
Update schemas.mdx

### DIFF
--- a/pages/chain/identity/schemas.mdx
+++ b/pages/chain/identity/schemas.mdx
@@ -75,7 +75,7 @@ Used to identify the reward amount each approved project received in a Retro Fun
 | Schema UID    | `0x670ad6e6ffb842d37e050ea6d3a5ab308195c6f584cf2121076067e0d8adde18`                                                         |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | Issuer        | Currently, the Optimism Foundation issues these from one the following address: `0xE4553b743E74dA3424Ac51f8C1E586fd43aE226F` |
-| Recipient     | Null                                                                                                                         |  
+| Recipient     | Null                                                                                                                         |
 | refUID        | The UID of the Retro Funding application                                                                                     |
 | projectRefUID | The unique identifier of the project                                                                                         |
 | round         | The retro round for which the project was rewarded                                                                           |

--- a/pages/chain/identity/schemas.mdx
+++ b/pages/chain/identity/schemas.mdx
@@ -75,7 +75,8 @@ Used to identify the reward amount each approved project received in a Retro Fun
 | Schema UID    | `0x670ad6e6ffb842d37e050ea6d3a5ab308195c6f584cf2121076067e0d8adde18`                                                         |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | Issuer        | Currently, the Optimism Foundation issues these from one the following address: `0xE4553b743E74dA3424Ac51f8C1E586fd43aE226F` |
-| Recipient     | Null                                                                                                                         |
+| Recipient     | Null                                                                                                                         |  
+| refUID        | The UID of the Retro Funding application                                                                                     |
 | projectRefUID | The unique identifier of the project                                                                                         |
 | round         | The retro round for which the project was rewarded                                                                           |
 | OPamount      | The amount of OP awarded to the project                                                                                      |


### PR DESCRIPTION
adding a clarification that the refUID field for the retro funding award attestation refers to the application UID

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adding a clarification that the refUID field on the retro funding awards schema refers to the application UID

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
