### PR TITLE
remove op-heartbeat configurations

### DIFF
--- a/pages/builders/node-operators/configuration/consensus-config.mdx
+++ b/pages/builders/node-operators/configuration/consensus-config.mdx
@@ -49,36 +49,6 @@ Conductor service rpc timeout. The default value is `1s`.
   <Tabs.Tab>`OP_NODE_CONDUCTOR_RPC_TIMEOUT=1s`</Tabs.Tab>
 </Tabs>
 
-### heartbeat.enabled
-
-Enables or disables heartbeating. The default value is `false`.
-
-<Tabs items={['Syntax', 'Example', 'Environment Variable']}>
-  <Tabs.Tab>`--heartbeat.enabled=<boolean>`</Tabs.Tab>
-  <Tabs.Tab>`--heartbeat.enabled=false`</Tabs.Tab>
-  <Tabs.Tab>`OP_NODE_HEARTBEAT_ENABLED=false`</Tabs.Tab>
-</Tabs>
-
-### heartbeat.moniker
-
-Sets a moniker for this node.
-
-<Tabs items={['Syntax', 'Example', 'Environment Variable']}>
-  <Tabs.Tab>`--heartbeat.moniker=<value>`</Tabs.Tab>
-  <Tabs.Tab>`--heartbeat.moniker=soyboy`</Tabs.Tab>
-  <Tabs.Tab>`OP_NODE_HEARTBEAT_MONIKER=soyboy`</Tabs.Tab>
-</Tabs>
-
-### heartbeat.url
-
-Sets the URL to heartbeat to. The default value is `"https://heartbeat.optimism.io"`.
-
-<Tabs items={['Syntax', 'Example', 'Environment Variable']}>
-  <Tabs.Tab>`--heartbeat.url=<value>`</Tabs.Tab>
-  <Tabs.Tab>`--heartbeat.url="https://heartbeat.optimism.io"`</Tabs.Tab>
-  <Tabs.Tab>`OP_NODE_HEARTBEAT_URL="https://heartbeat.optimism.io"`</Tabs.Tab>
-</Tabs>
-
 ### l1
 
 Address of L1 User JSON-RPC endpoint to use (eth namespace required). The default value is `"http://127.0.0.1:8545"`.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Fixes https://github.com/ethereum-optimism/docs/issues/863

However this configuration pages should be updated again with the latest op stack release to ensure all of these flags are up to date. 
