### PR TITLE
docs: Add rollup.sequencerhttp to node operation docs

### DIFF
--- a/pages/builders/chain-operators/management/operations.mdx
+++ b/pages/builders/chain-operators/management/operations.mdx
@@ -155,6 +155,9 @@ If you do it this way, you won't have to wait until the transactions are written
     If you already have peer to peer synchronization, add the new node to the `--p2p.static` list so it can synchronize.
 
 ### Start `op-geth` (using the same command line you used on the initial node)
+<Callout type="warning">
+**Important:** Make sure to configure the `--rollup.sequencerhttp` flag to point to your sequencer node. This HTTP endpoint is crucial because `op-geth` will route `eth_sendRawTransaction` calls to this URL. The OP Stack does not currently have a public mempool, so configuring this is required if you want your node to support transaction submission.
+</Callout>
 
 ### Start `op-node` (using the same command line you used on the initial node)
 </Steps>


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Added a callout to the node operation documentation in step 7, instructing users to configure the `--rollup.sequencerhttp` flag.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #519 
