### PR TITLE
Add callout on the cap for sequencer.l1-confs and verifier.l1-confs

### DIFF
--- a/pages/builders/node-operators/configuration/consensus-config.mdx
+++ b/pages/builders/node-operators/configuration/consensus-config.mdx
@@ -743,6 +743,10 @@ Number of L1 blocks to keep distance from the L1 head as a sequencer for picking
   <Tabs.Tab>`OP_NODE_SEQUENCER_L1_CONFS=4`</Tabs.Tab>
 </Tabs>
 
+<Callout type="warning">
+**Important:** The maximum value for `sequencer.l1-confs` cannot exceed the sequencer drift, which is currently set to 30 minutes (1800 seconds or 150 blocks). Configuring a value higher than the allowed limit will prevent the sequencer from producing blocks within the sequence window.
+</Callout>
+
 ### sequencer.max-safe-lag
 
 Maximum number of L2 blocks for restricting the distance between L2 safe and unsafe. Disabled if 0. Default is `0`.
@@ -782,6 +786,10 @@ Number of L1 blocks to keep distance from the L1 head before deriving L2 data fr
   <Tabs.Tab>`--verifier.l1-confs=0`</Tabs.Tab>
   <Tabs.Tab>`OP_NODE_VERIFIER_L1_CONFS=0`</Tabs.Tab>
 </Tabs>
+
+<Callout type="info">
+**Suggested:** While `verifier.l1-confs` does not have a strict limit, it is recommended to keep this value within 12-13 minutes (realistically 10-20 blocks) to ensure optimal performance. Configuring this parameter beyond the recommended range may impact the verifier's ability to process data efficiently.
+</Callout>
 
 ## Miscellaneous
 

--- a/pages/builders/node-operators/configuration/consensus-config.mdx
+++ b/pages/builders/node-operators/configuration/consensus-config.mdx
@@ -744,7 +744,7 @@ Number of L1 blocks to keep distance from the L1 head as a sequencer for picking
 </Tabs>
 
 <Callout type="warning">
-**Important:** The maximum value for `sequencer.l1-confs` cannot exceed the sequencer drift, which is currently set to 30 minutes (1800 seconds or 150 blocks). Configuring a value higher than the allowed limit will prevent the sequencer from producing blocks within the sequence window.
+The maximum value for `sequencer.l1-confs` cannot exceed the sequencer drift, currently set to 30 minutes (1800 seconds or 150 blocks). Setting a value higher than this limit will prevent the sequencer from producing blocks within the sequence window.
 </Callout>
 
 ### sequencer.max-safe-lag

--- a/pages/builders/node-operators/configuration/consensus-config.mdx
+++ b/pages/builders/node-operators/configuration/consensus-config.mdx
@@ -788,7 +788,7 @@ Number of L1 blocks to keep distance from the L1 head before deriving L2 data fr
 </Tabs>
 
 <Callout type="info">
-**Suggested:** While `verifier.l1-confs` does not have a strict limit, it is recommended to keep this value within 12-13 minutes (realistically 10-20 blocks) to ensure optimal performance. Configuring this parameter beyond the recommended range may impact the verifier's ability to process data efficiently.
+While `verifier.l1-confs` has no strict limit, it's recommended to keep this value within 12-13 minutes (typically 10-20 blocks) for optimal performance. Exceeding this range may impact the verifier's data processing efficiency.
 </Callout>
 
 ## Miscellaneous


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Added a callout to the `sequencer.l1-confs` and `verifier.l1-confs` configuration options in the node operation documentation. The callout highlighted the maximum values for `sequencer.l1-confs` to be 1800 seconds (150 blocks) since the Fjord upgrade is live. It also suggests keeping `verifier.l1-confs` within a 12-13 minute range (10-20 blocks) for optimal performance.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #563 
