### PR TITLE
Two broken links

### DIFF
--- a/pages/stack/explainer.mdx
+++ b/pages/stack/explainer.mdx
@@ -16,7 +16,7 @@ The next major scalability improvement to the OP Stack after Bedrock is to intro
 
 The launch of the Superchain would merge OP Mainnet and other chains into a single unified network of OP Chains (i.e., chains within the Superchain), and mark a major step towards bringing scalable and decentralized compute to the world. The goal of this document is to describe the scalability vision, the Superchain concept, and some changes to the OP Stack required to make this vision a reality.
 
-This is the detailed explanation. [Click here for a less technical introduction](https://app.optimism.io/superchain/).
+This is the detailed explanation. [Click here for a less technical introduction](https://www.superchain.eco/).
 
 <Callout type="info">
   Today, the Superchain is a concept and in-flight project, not a concrete reality.  This documentation represents our best current guess as to what the Superchain's components, features, and roadmap will be. Ultimately, its actualization will depend on (and change alongside) contributions from across the entire Optimism Collective. We cannot wait to see where it goes.
@@ -154,7 +154,7 @@ The fault proof implementation may initially rely on a trusted set of chain atte
 
 The attestation-based fault proof should be designed to prefer safety over liveness. That means that if these chain attestors are malicious they cannot alone break the safety of withdrawals. The worst failure they can cause is preventing withdrawals from being processed until the next upgrade—a liveness failure.
 
-In the future, the attestation proof will be incrementally phased out and replaced with trust-minimized proofs such as the [Cannon proof system](https://github.com/ethereum-optimism/cannon).
+In the future, the attestation proof will be incrementally phased out and replaced with trust-minimized proofs such as the [Cannon proof system](https://github.com/ethereum-optimism/optimism/tree/develop/cannon).
 
 ### Configurable sequencer per OP Chain
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Just fixing two broken links. 

Was using page, wanted to see non-technical explainer, but link is broken. Believe the first corresponds to original intention although it's not really an 'explainer' as such, so maybe something else works?

**Tests**

No tests, in-place link substitution.

**Additional context**

No add'l context.

**Metadata**

- no issue associated
