### PR TITLE
Add information about minimum archive node reqs

### DIFF
--- a/pages/builders/chain-operators/architecture.mdx
+++ b/pages/builders/chain-operators/architecture.mdx
@@ -5,7 +5,7 @@ description: Learn about the OP chain architecture.
 ---
 
 import Image from 'next/image'
-
+import { Callout } from 'nextra/components'
 import {OpProposerDescriptionShort} from '@/content/index.js' 
 
 # Chain Architecture

--- a/pages/builders/chain-operators/architecture.mdx
+++ b/pages/builders/chain-operators/architecture.mdx
@@ -83,7 +83,7 @@ handle the state changing RPC request `eth_sendRawTransaction`. It can be peered
 replica nodes to gossip new `unsafe` blocks to the rest of the network.
 
 <Callout type="info">
-To run a rollup, you need a minimum of one archive node. This is required by the proposer as the the data that it needs can be older than the data available to a full node. Note that the sequencer doesn't need to be the archive node. 
+To run a rollup, you need a minimum of one archive node. This is required by the proposer as the the data that it needs can be older than the data available to a full node.  Note that since the proposer doesn't care what archive node it points to, you can technically point it towards an archive node that isn't the sequencer. 
 </Callout>
 
 <Image src="/img/builders/chain-operators/sequencer-node.png" alt="Sequencer Node Diagram" width={400} height={400} />

--- a/pages/builders/chain-operators/architecture.mdx
+++ b/pages/builders/chain-operators/architecture.mdx
@@ -82,6 +82,10 @@ The Sequencer node works with the batcher and proposer to create new blocks. So 
 handle the state changing RPC request `eth_sendRawTransaction`. It can be peered with
 replica nodes to gossip new `unsafe` blocks to the rest of the network.
 
+<Callout type="info">
+To run a rollup, you need a minimum of one archive node. This is required by the proposer as the the data that it needs can be older than the data available to a full node. Note that the sequencer doesn't need to be the archive node. 
+</Callout>
+
 <Image src="/img/builders/chain-operators/sequencer-node.png" alt="Sequencer Node Diagram" width={400} height={400} />
 
 ### Replica node

--- a/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
+++ b/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
@@ -530,8 +530,8 @@ cd ~/op-geth
 
 <Callout type="info">
 You're using `--gcmode=archive` to run `op-geth` here because this node will act as your Sequencer.
-It's useful to run the Sequencer in archive mode because the `op-proposer` requires access to the full state.
-Feel free to run other (non-Sequencer) nodes in full mode if you'd like to save disk space.
+It's useful to run the Sequencer in archive mode because the `op-proposer` requires access to the full state, but it isn't required.
+Feel free to run other (non-Sequencer) nodes in full mode if you'd like to save disk space. Just make sure at least one other archive node exists and the `op-proposer` points to it.
 </Callout>
 
 <Callout type="info">

--- a/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
+++ b/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
@@ -530,7 +530,7 @@ cd ~/op-geth
 
 <Callout type="info">
 You're using `--gcmode=archive` to run `op-geth` here because this node will act as your Sequencer.
-It's useful to run the Sequencer in archive mode because the `op-proposer` requires access to the full state, but it isn't required.
+It's useful to run the Sequencer in archive mode because the `op-proposer` requires access to the full state.
 Feel free to run other (non-Sequencer) nodes in full mode if you'd like to save disk space. Just make sure at least one other archive node exists and the `op-proposer` points to it.
 </Callout>
 


### PR DESCRIPTION
Adds info about the minimum archive nodes required for a rollup. Also clarifies that the sequencer does NOT need to be the archive node. 