### PR TITLE
adding audit template

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_audit_results.md
+++ b/.github/ISSUE_TEMPLATE/docs_audit_results.md
@@ -50,11 +50,15 @@ labels: 'docs-audit-2024-Q4,op-labs'
 
 ## MDX Metadata format
 
-> We will be adding better metadata to the header of each page. Parse the component and feature tags to add.
+> We will be adding better metadata to the header of each page. 
+> If I was actively searching for this page on google and this description was the search result, would I know it's the correct page?
+> Parse the component and feature tags to add.
 
-```
+---
+title: "Your Title Here"
 tags: ["tag1", "tag2"]
-```
+description: "A short description of the content."
+---
 
 <details>
 <summary>Component tags</summary>

--- a/.github/ISSUE_TEMPLATE/docs_audit_results.md
+++ b/.github/ISSUE_TEMPLATE/docs_audit_results.md
@@ -16,17 +16,6 @@ labels: 'docs-audit-2024-Q4,op-labs'
 > Choose the appropriate github issue labels for each page.
 
 <details>
-<summary>Content evaluation</summary>
-
-- `a-delete`: don't need this page 
-- `a-duplicate`: some content lives elsewhere 
-- `a-minor`: needs small revisions 
-- `a-moderate`: needs moderate revisions 
-- `a-critical`: needs a lot of work
-
-</details>
-
-<details>
 <summary>Priority</summary>
 
 - `p-on-hold`: (Defer) Tasks that are currently not actionable due to various reasons like waiting for external inputs, dependencies, or resource constraints. These are reviewed periodically to decide if they can be moved to a more active status.

--- a/.github/ISSUE_TEMPLATE/docs_audit_results.md
+++ b/.github/ISSUE_TEMPLATE/docs_audit_results.md
@@ -15,7 +15,8 @@ labels: 'docs-audit-2024-Q4,op-labs'
 
 > Choose the appropriate github issue labels for each page.
 
-**Content evaluation:**
+<details>
+<summary>Content evaluation</summary>
 
 - `a-delete`: don't need this page 
 - `a-duplicate`: some content lives elsewhere 
@@ -23,7 +24,10 @@ labels: 'docs-audit-2024-Q4,op-labs'
 - `a-moderate`: needs moderate revisions 
 - `a-critical`: needs a lot of work
 
-**Priority:**
+</details>
+
+<details>
+<summary>Priority</summary>
 
 - `p-on-hold`: (Defer) Tasks that are currently not actionable due to various reasons like waiting for external inputs, dependencies, or resource constraints. These are reviewed periodically to decide if they can be moved to a more active status.
 - `p-low`: (Nice to do) Tasks that have minimal impact on core operations and no immediate deadlines. These tasks are often more about quality of life improvements rather than essential needs.
@@ -31,7 +35,10 @@ labels: 'docs-audit-2024-Q4,op-labs'
 - `p-high`: (Should do) Important tasks that contribute significantly to long-term goals but may not have an immediate deadline. Delaying these tasks could have considerable negative effects but are not as immediate as critical tasks.
 - `p-critical`: Tasks that have immediate deadlines or significant consequences if not completed on time. These are non-negotiable and often linked to core business functions or legal requirements. 
 
-**T-shirt size:**
+</details>
+
+<details>
+<summary>T-shirt size</summary>
 
 - `s-XS`: (< 1 day) Very simple tasks that require minimal time and effort.
 - `s-S`: (few days) Tasks that are straightforward but require a bit more time to complete.
@@ -39,6 +46,7 @@ labels: 'docs-audit-2024-Q4,op-labs'
 - `s-L`: (several weeks) Complex tasks that require significant time investment and coordination across multiple teams. 
 - `s-XL`: (> 1 month) Very large and complex projects that involve extensive planning, execution, and testing. 
 
+</details>
 
 ## MDX Metadata format
 

--- a/.github/ISSUE_TEMPLATE/docs_audit_results.md
+++ b/.github/ISSUE_TEMPLATE/docs_audit_results.md
@@ -1,0 +1,119 @@
+---
+name: Docs audit results
+about: Template for a formal technical documentation audits run by OP Labs
+title: "[2024 Q4 Audit] [page-path]"
+labels: 'docs-audit-2024-Q4,op-labs'
+---
+
+<!-- this template is intended for internal OP Labs usage -->
+
+## Description of the updates required
+
+> Write a description of the current state of the page.
+
+## Github issue label criteria
+
+> Choose the appropriate github issue labels for each page.
+
+**Content evaluation:**
+
+- `a-delete`: don't need this page 
+- `a-duplicate`: some content lives elsewhere 
+- `a-minor`: needs small revisions 
+- `a-moderate`: needs moderate revisions 
+- `a-critical`: needs a lot of work
+
+**Priority:**
+
+- `p-on-hold`: (Defer) Tasks that are currently not actionable due to various reasons like waiting for external inputs, dependencies, or resource constraints. These are reviewed periodically to decide if they can be moved to a more active status.
+- `p-low`: (Nice to do) Tasks that have minimal impact on core operations and no immediate deadlines. These tasks are often more about quality of life improvements rather than essential needs.
+- `p-medium`: (Could do) Tasks that need to be done but are less critical than high-priority tasks. These often improve processes or efficiency but can be postponed if necessary without immediate severe repercussions.
+- `p-high`: (Should do) Important tasks that contribute significantly to long-term goals but may not have an immediate deadline. Delaying these tasks could have considerable negative effects but are not as immediate as critical tasks.
+- `p-critical`: Tasks that have immediate deadlines or significant consequences if not completed on time. These are non-negotiable and often linked to core business functions or legal requirements. 
+
+**T-shirt size:**
+
+- `s-XS`: (< 1 day) Very simple tasks that require minimal time and effort.
+- `s-S`: (few days) Tasks that are straightforward but require a bit more time to complete.
+- `s-M`: (1-2 weeks) Tasks that involve a moderate level of complexity and collaboration.
+- `s-L`: (several weeks) Complex tasks that require significant time investment and coordination across multiple teams. 
+- `s-XL`: (> 1 month) Very large and complex projects that involve extensive planning, execution, and testing. 
+
+
+## MDX Metadata format
+
+> We will be adding better metadata to the header of each page. Parse the component and feature tags to add.
+
+```
+tags: ["tag1", "tag2"]
+```
+
+<details>
+<summary>Component tags</summary>
+```
+op-node
+op-geth
+op-reth
+op-erigon
+op-nethermind
+batcher
+standard-bridge
+sequencer
+l1-contracts
+l2-contracts
+precompiles
+predeploys
+preinstalls
+op-proposer
+op-challenger
+op-gov-token
+op-supervisor
+op-conductor
+fp-contracts
+cannon
+op-program
+asterisc
+kona
+superchain-registry
+supersim
+dev-console
+opsm
+mcp
+mcp-l2
+deputy-guardian
+liveness-guard
+dispute-mon
+op-beat
+op-signer
+monitorism
+blockspace-charters
+op-workbench
+kubernetes-infrastructure
+devops-tooling
+artifacts-packaging
+sequencer-in-a-box
+devnets
+op-supervisor
+performance-tooling
+peer-management-service
+proxyd
+zdd-service
+snapman
+security-tools
+superchain-ops
+```
+</details>
+
+<details>
+<summary>Engineering tags</summary>
+```
+eng-platforms
+eng-growth
+eng-devx
+eng-protocol
+eng-proofs
+eng-evm
+eng-security
+```
+</details>
+

--- a/pages/builders/chain-operators/configuration/rollup.mdx
+++ b/pages/builders/chain-operators/configuration/rollup.mdx
@@ -442,7 +442,7 @@ SuperchainConfig. Has the ability to pause withdrawals.
 *   **Recommended value:** 
 *   **Notes:** Must not be `address(0)`
 *   **Standard Config Requirement:** [0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2](https://etherscan.io/address/0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2)
-A 1/1 Safe owned by the Security Council Safe, with the [Deputy Guardian Module](https://specs.optimism.io/experimental/security-council-safe.html#deputy-guardian-module)
+A 1/1 Safe owned by the Security Council Safe, with the [Deputy Guardian Module](https://specs.optimism.io/protocol/safe-extensions.html#deputy-guardian-module)
 enabled to allow the Optimism Foundation to act as Guardian.
 
 ***

--- a/pages/stack/protocol/fault-proofs/fp-components.mdx
+++ b/pages/stack/protocol/fault-proofs/fp-components.mdx
@@ -16,7 +16,7 @@ The system is designed to eventually enable secure bridging without central fall
 The modular design of the fault proof system lays the foundation for a multi-proof future, inclusive of ZK proofs, and significantly increases the opportunities for ecosystem contributors to build alternative fault proof components to secure the system.
 
 <Callout type="info">
-  Visit the [Immunefi bug bounty page](https://immunefi.com/bounty/optimism/?ref=blog.oplabs.co) for details on testing and helping to build a robust fault proof system.
+  Visit the [Immunefi bug bounty page](https://immunefi.com/bounty/optimism/) for details on testing and helping to build a robust fault proof system.
 </Callout>
 
 ## System Design & Modularity


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

I'm going to use this issue template for running through the technical documentation audit.