### PR TITLE
formatting the page header thing

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_audit_results.md
+++ b/.github/ISSUE_TEMPLATE/docs_audit_results.md
@@ -43,11 +43,13 @@ labels: 'docs-audit-2024-Q4,op-labs'
 > If I was actively searching for this page on google and this description was the search result, would I know it's the correct page?
 > Parse the component and feature tags to add.
 
+```mdx
 ---
 title: "Your Title Here"
 tags: ["tag1", "tag2"]
 description: "A short description of the content."
 ---
+```
 
 <details>
 <summary>Component tags</summary>


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Fixing the template so there isn't a big bold header

<img width="829" alt="Screenshot 2024-09-11 at 3 02 20 PM" src="https://github.com/user-attachments/assets/ee3dd9c1-eac2-49c5-baca-2e67099ed195">

