### PR TITLE
contracts: update standard version to v1.6.0, CGT to v2.0.0-beta.3

### DIFF
--- a/pages/builders/chain-operators/deploy/smart-contracts.mdx
+++ b/pages/builders/chain-operators/deploy/smart-contracts.mdx
@@ -83,9 +83,13 @@ single contract.
 Production users should deploy their L1 contracts from a contracts release.
 All contracts releases are on git tags with the following format:
 `op-contracts/vX.Y.Z`. If you're deploying a new standard chain, you should
-deploy the [Fault Proof Fixes release](https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.6.0).
-We're working on writing more documentation to prepare OP Stack chain operators
-to run a fault proof chain effectively.
+deploy the [Fault Proof Fixes release](https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.6.0) with the permissioned game type
+enabled.
+Starting with permissioned fault proofs gives chain operators time to get comfortable
+running the additional infrastructure requirements: [op-challenger](https://github.com/ethereum-optimism/optimism/tree/develop/op-challenger) and
+[monitoring](https://github.com/ethereum-optimism/monitorism/tree/main). There are also
+additional changes to the economics of operating a permissionless fault proof that chain
+operators should have a firm understanding of. 
 
 ## Next Steps
 

--- a/pages/builders/chain-operators/deploy/smart-contracts.mdx
+++ b/pages/builders/chain-operators/deploy/smart-contracts.mdx
@@ -83,7 +83,7 @@ single contract.
 Production users should deploy their L1 contracts from a contracts release.
 All contracts releases are on git tags with the following format:
 `op-contracts/vX.Y.Z`. If you're deploying a new standard chain, you should
-deploy the [Multi-Chain Prep (MCP) L1 release](https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.3.0).
+deploy the [Fault Proof Fixes release](https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.6.0).
 We're working on writing more documentation to prepare OP Stack chain operators
 to run a fault proof chain effectively.
 

--- a/pages/builders/chain-operators/features/custom-gas-token.mdx
+++ b/pages/builders/chain-operators/features/custom-gas-token.mdx
@@ -18,7 +18,7 @@ An OP Stack chain that uses the custom gas token feature enables an end user to 
 <Steps>
   ### Deploying Your Contracts
 
-  *   Checkout the [`v2.0.0-beta.2` of the contracts](https://github.com/ethereum-optimism/optimism/tree/op-contracts/v2.0.0-beta.2) and use the commit to deploy.
+  *   Checkout the [`v2.0.0-beta.3` of the contracts](https://github.com/ethereum-optimism/optimism/tree/op-contracts/v2.0.0-beta.3) and use the commit to deploy.
 
   <Callout type="error">
     Be sure to check out this tag or you will not deploy a chain that uses custom gas token!
@@ -47,7 +47,7 @@ An OP Stack chain that uses the custom gas token feature enables an end user to 
     You will NOT be able to change the address of the custom gas token after it is set during deployment.
   </Callout>
 
-  *   The [`v2.0.0-beta.2` release](https://github.com/ethereum-optimism/optimism/tree/op-contracts/v2.0.0-beta.2)
+  *   The [`v2.0.0-beta.3` release](https://github.com/ethereum-optimism/optimism/tree/op-contracts/v2.0.0-beta.3)
 enables fee withdrawals to L1 and L2. For more details on these values, see the [Withdrawal Network](/builders/chain-operators/configuration/rollup.mdx#withdrawal-network) 
 section of the docs.
 

--- a/pages/stack/smart-contracts.mdx
+++ b/pages/stack/smart-contracts.mdx
@@ -37,7 +37,7 @@ Contract releases have a component name of `op-contracts` and therefore are tagg
 
 <Callout type="info">
   Note: While these are a governance approved contract release, the recommended 
-  release for new production chains is `op-contracts/v1.3.0`. 
+  release for new production chains is `op-contracts/v1.6.0`. 
 </Callout>
 
 The Safe Extensions protocol upgrade is intended to increase the security and


### PR DESCRIPTION
**Description**

The recommended monorepo contracts tag/release is now v1.6.0.

The recommended monorepo contracts tag for CustomGasToken is now v2.0.0-beta.3

**Tests**

No tests added. Just changed some text.
