### PR TITLE
Added link and pointers to use Superchain Faucet to get the required fund for spinning up an OP Stack testnet chain

### DIFF
--- a/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
+++ b/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
@@ -275,6 +275,8 @@ It's recommended to fund the addresses with the following amounts when using Sep
 *   `Proposer` — 0.2 Sepolia ETH
 *   `Batcher` — 0.1 Sepolia ETH
 
+**To get the required Sepolia ETH to fund the addresses, we recommend using the [Superchain Faucet](https://console.optimism.io/faucet)** together with [Coinbase verification](https://help.coinbase.com/en/coinbase/getting-started/getting-started-with-coinbase/id-doc-verification).
+
 </Steps>
 
 ## Load Environment variables


### PR DESCRIPTION
Added links and pointers to recommend using superchain faucet to get the required fund for spinning up an OP Stack testnet chain. Using Superchain Faucet with Coinbase verifications would give 1 Sepolia ETH a day - enough for the user to be able to complete the guide

![Screenshot 2024-09-12 at 2 43 39 PM](https://github.com/user-attachments/assets/3c13e4c0-306f-4234-96af-9ecc005ddd63)

cc @fainashalts 


