### PR TITLE
making updates after the granite activation

### DIFF
--- a/pages/builders/chain-operators/configuration/rollup.mdx
+++ b/pages/builders/chain-operators/configuration/rollup.mdx
@@ -306,9 +306,9 @@ valid. A transaction channel frame is a chunk of a compressed batch of
 transactions. After the timeout, the frame is dropped.
 
 *   **Type:** Number of blocks
-*   **Default value:** None
+*   **Default value:** 50
 *   **Recommended value:** 
-*   **Notes:** 300 (1 hour) is suggested
+*   **Notes:** This default value was introduced in the [Granite network upgrade](/builders/node-operators/network-upgrades#granite)
 *   **Standard Config Requirement:**  
 
 ***

--- a/pages/builders/chain-operators/deploy/smart-contracts.mdx
+++ b/pages/builders/chain-operators/deploy/smart-contracts.mdx
@@ -15,8 +15,7 @@ for the official release versions. Changes to the smart contracts are
 generally not considered backwards compatible.
 
 <Callout>
-  Standard OP Stack chains should use governance approved and audited versions
-  of the smart contract code.
+  Standard OP Stack chains should use the latest governance approved and audited versions of the smart contract code.
 </Callout>
 
 ## Deployment Configuration

--- a/pages/stack/smart-contracts.mdx
+++ b/pages/stack/smart-contracts.mdx
@@ -33,12 +33,43 @@ Contract releases have a component name of `op-contracts` and therefore are tagg
   smart contracts—only deploy from `op-contracts/vX.Y.Z`
 </Callout>
 
-#### op-contracts/v1.5.0 - Safe Extensions
+#### op-contracts/v1.6.0 - Fault Proof Fixes
 
-<Callout type="info">
-  Note: While these are a governance approved contract release, the recommended 
-  release for new production chains is `op-contracts/v1.6.0`. 
-</Callout>
+The release fixes security vulnerabilities found in Fault Proof contracts. They were made in response to security vulnerabilities identified during a series of third-party security audits by Spearbit, Cantina, and Code4rena. None of the vulnerabilities have been exploited, and user assets are not and were never at risk.
+
+The upgrade was coupled with the [Granite network upgrade](/builders/node-operators/network-upgrades#granite) to improve the stability and performance of the fault proof system. In addition, the capabilities of the Guardian and DeputyGuardian have been extended to set the anchor state for the fault proof system in order to prevent referencing invalid anchor states.
+
+*   [Official - Fault Proof Fixes Release](https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.6.0)
+*   [Governance Post](https://gov.optimism.io/t/upgrade-proposal-10-granite-network-upgrade/8733)
+
+<details>
+  <summary>**Changelog**</summary>
+  **Added:**
+
+  *   MIPS: [1.1.0](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.6.0/packages/contracts-bedrock/src/cannon/MIPS.sol)
+  *   PreimageOracle: [1.1.2](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.6.0/packages/contracts-bedrock/src/cannon/PreimageOracle.sol)
+  *   FaultDisputeGame: [1.3.0](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.6.0/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol#L73)
+  *   PermissionedDisputeGame: [1.3.0](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.6.0/packages/contracts-bedrock/src/dispute/PermissionedDisputeGame.sol)
+  *   DelayedWETH: [1.1.0](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.6.0/packages/contracts-bedrock/src/dispute/weth/DelayedWETH.sol#L25)
+  *   DeputyGuardianModule: [2.0.0](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.6.0/packages/contracts-bedrock/src/Safe/SafeSigners.sol)
+  *   AnchorStateRegistry: [2.0.0](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.6.0/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol#L31)
+
+  **No change:**
+
+  *   AddressManager: [Latest (this has no version)](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.2.0/packages/contracts-bedrock/src/legacy/AddressManager.sol)
+  *   L1CrossDomainMessenger: [2.3.0](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.3.0/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol#L24)
+  *   L1ERC721Bridge: [2.1.0](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.3.0/packages/contracts-bedrock/src/L1/L1ERC721Bridge.sol#L27)
+  *   L1StandardBridge: [2.1.0](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.3.0/packages/contracts-bedrock/src/L1/L1StandardBridge.sol#L73)
+  *   OptimismMintableERC20Factory: [1.9.0](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.3.0/packages/contracts-bedrock/src/universal/OptimismMintableERC20Factory.sol#L46)
+  *   OptimismPortal: [3.10.0](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.4.0/packages/contracts-bedrock/src/L1/OptimismPortal2.sol#L144)
+  *   SystemConfig: [2.0.0](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.4.0/packages/contracts-bedrock/src/L1/SystemConfig.sol#L111)
+  *   DisputeGameFactory: [1.0.0](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.4.0/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol#L25)
+  *   SuperchainConfig: [1.1.0](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.2.0/packages/contracts-bedrock/src/L1/SuperchainConfig.sol#L38)
+  *   ProtocolVersions: [1.0.0](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.2.0/packages/contracts-bedrock/src/L1/ProtocolVersions.sol#L39)
+
+</details>
+
+#### op-contracts/v1.5.0 - Safe Extensions
 
 The Safe Extensions protocol upgrade is intended to increase the security and
 decentralization of the Superchain by:
@@ -89,11 +120,6 @@ vote for L2 predeploy upgrades and is a requirement for Stage 1.
 </details>
 
 #### op-contracts/v1.4.0 - Fault Proofs
-
-<Callout type="info">
-  Note: While these are a governance approved contract release, the recommended 
-  release for new production chains is `op-contracts/v1.3.0`. 
-</Callout>
 
 This protocol upgrade reduces the trust assumptions for users of the OP Stack
 by enabling permissionless output proposals and a permissionless fault proof


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

- Added the latest smart contract release version `op-contracts/v1.6.0`
- Updated the channelTimeout to reflect the change in granite

**Metadata**

- Fixes https://github.com/ethereum-optimism/docs/issues/887
- Fixes https://github.com/ethereum-optimism/docs/issues/898
