### PR TITLE
altda: soften beta warning wording

### DIFF
--- a/pages/builders/chain-operators/features/alt-da-mode.mdx
+++ b/pages/builders/chain-operators/features/alt-da-mode.mdx
@@ -9,7 +9,8 @@ import { Callout, Steps } from 'nextra/components'
 # How to Run an Alt-DA Mode Chain
 
 <Callout type="warning">
-  The Alt-DA Mode feature is a Beta feature of the MIT licensed OP Stack. While it has received initial review from core contributors, it is still undergoing testing and may have bugs or other issues.
+  The Alt-DA Mode feature is currently in <strong>Beta</strong>  within the MIT-licensed OP Stack. Beta features are built and reviewed by the Optimism Collective’s core contributors, and provide developers with early access to highly requested configurations.
+  These features may experience stability issues, and we encourage feedback from our early users.
 </Callout>
 
 This guide provides a walkthrough for chain operators who want to run an Alt-DA Mode chain. See the [Alt-DA Mode Explainer](/stack/protocol/features/alt-da-mode) for a general overview of this OP Stack configuration.

--- a/pages/builders/chain-operators/features/alt-da-mode.mdx
+++ b/pages/builders/chain-operators/features/alt-da-mode.mdx
@@ -9,7 +9,7 @@ import { Callout, Steps } from 'nextra/components'
 # How to Run an Alt-DA Mode Chain
 
 <Callout type="warning">
-  The Alt-DA Mode feature is currently in <strong>Beta</strong>  within the MIT-licensed OP Stack. Beta features are built and reviewed by the Optimism Collective’s core contributors, and provide developers with early access to highly requested configurations.
+  The Alt-DA Mode feature is currently in <strong>Beta</strong>  within the MIT-licensed OP Stack. Beta features are built and reviewed by Optimism Collective core contributors, and provide developers with early access to highly requested configurations.
   These features may experience stability issues, and we encourage feedback from our early users.
 </Callout>
 

--- a/pages/builders/chain-operators/tutorials/integrating-da-layer.mdx
+++ b/pages/builders/chain-operators/tutorials/integrating-da-layer.mdx
@@ -9,7 +9,8 @@ import { Callout, Steps } from 'nextra/components'
 # Integrating a New DA Layer with Alt-DA
 
 <Callout type="warning">
-  The Alt-DA Mode feature is a Beta feature of the MIT licensed OP Stack. While it has received initial review from core contributors, it is still undergoing testing and may have bugs or other issues.
+  The Alt-DA Mode feature is currently in <strong>Beta</strong>  within the MIT-licensed OP Stack. Beta features are built and reviewed by the Optimism Collective’s core contributors, and provide developers with early access to highly requested configurations.
+  These features may experience stability issues, and we encourage feedback from our early users.
 </Callout>
 
 [Alt-DA Mode](/stack/protocol/features/alt-da-mode) enables seamless integration of any DA Layer, regardless of their commitment type, into the OP Stack. After a DA Server is built for a DA Layer, any chain operator can launch an OP Stack chain using that DA Layer for sustainably low costs.

--- a/pages/builders/chain-operators/tutorials/integrating-da-layer.mdx
+++ b/pages/builders/chain-operators/tutorials/integrating-da-layer.mdx
@@ -9,7 +9,7 @@ import { Callout, Steps } from 'nextra/components'
 # Integrating a New DA Layer with Alt-DA
 
 <Callout type="warning">
-  The Alt-DA Mode feature is currently in <strong>Beta</strong>  within the MIT-licensed OP Stack. Beta features are built and reviewed by the Optimism Collective’s core contributors, and provide developers with early access to highly requested configurations.
+  The Alt-DA Mode feature is currently in <strong>Beta</strong>  within the MIT-licensed OP Stack. Beta features are built and reviewed by Optimism Collective core contributors, and provide developers with early access to highly requested configurations.
   These features may experience stability issues, and we encourage feedback from our early users.
 </Callout>
 


### PR DESCRIPTION
There are a couple places where our docs have a warning/callout about altda being in `beta`. This pr updates two instances so that the warning/callout is the same across all three instances, and the language used is softer than the original wording