### PR TITLE
adding the content eval back

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_audit_results.md
+++ b/.github/ISSUE_TEMPLATE/docs_audit_results.md
@@ -111,6 +111,7 @@ zdd-service
 snapman
 security-tools
 superchain-ops
+op-deployer
 ```
 </details>
 

--- a/.github/ISSUE_TEMPLATE/docs_audit_results.md
+++ b/.github/ISSUE_TEMPLATE/docs_audit_results.md
@@ -16,6 +16,7 @@ labels: 'docs-audit-2024-Q4,op-labs'
 > Choose the appropriate github issue labels for each page.
 
 <details>
+
 <summary>Priority</summary>
 
 - `p-on-hold`: (Defer) Tasks that are currently not actionable due to various reasons like waiting for external inputs, dependencies, or resource constraints. These are reviewed periodically to decide if they can be moved to a more active status.
@@ -26,6 +27,7 @@ labels: 'docs-audit-2024-Q4,op-labs'
 </details>
 
 <details>
+
 <summary>T-shirt size</summary>
 
 - `s-XS`: (< 1 day) Very simple tasks that require minimal time and effort.
@@ -36,6 +38,7 @@ labels: 'docs-audit-2024-Q4,op-labs'
 </details>
 
 <details>
+
 <summary>Content evaluation</summary>
 - `a-delete`: don't need this page 
 - `a-duplicate`: some content lives elsewhere 
@@ -60,6 +63,7 @@ description: "A short description of the content."
 
 <details>
 <summary>Component tags</summary>
+
 ```
 op-node
 op-geth
@@ -117,6 +121,7 @@ op-deployer
 
 <details>
 <summary>Engineering tags</summary>
+
 ```
 eng-platforms
 eng-growth

--- a/.github/ISSUE_TEMPLATE/docs_audit_results.md
+++ b/.github/ISSUE_TEMPLATE/docs_audit_results.md
@@ -23,7 +23,6 @@ labels: 'docs-audit-2024-Q4,op-labs'
 - `p-medium`: (Could do) Tasks that need to be done but are less critical than high-priority tasks. These often improve processes or efficiency but can be postponed if necessary without immediate severe repercussions.
 - `p-high`: (Should do) Important tasks that contribute significantly to long-term goals but may not have an immediate deadline. Delaying these tasks could have considerable negative effects but are not as immediate as critical tasks.
 - `p-critical`: Tasks that have immediate deadlines or significant consequences if not completed on time. These are non-negotiable and often linked to core business functions or legal requirements. 
-
 </details>
 
 <details>
@@ -34,7 +33,15 @@ labels: 'docs-audit-2024-Q4,op-labs'
 - `s-M`: (1-2 weeks) Tasks that involve a moderate level of complexity and collaboration.
 - `s-L`: (several weeks) Complex tasks that require significant time investment and coordination across multiple teams. 
 - `s-XL`: (> 1 month) Very large and complex projects that involve extensive planning, execution, and testing. 
+</details>
 
+<details>
+<summary>Content evaluation</summary>
+- `a-delete`: don't need this page 
+- `a-duplicate`: some content lives elsewhere 
+- `a-minor`: needs small revisions 
+- `a-moderate`: needs moderate revisions 
+- `a-critical`: needs a lot of work
 </details>
 
 ## MDX Metadata format


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Okay I remember why this is here, its not to inform the amount of work required to update, but to take account of the docs state when we ran the audit.
