### PR TITLE
Make callouts fixed instead of sticky

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -54,8 +54,7 @@ span.shasum code {
 }
 
 div.custom-callouts {
-  position: -webkit-sticky;
-  position: sticky;
+  position: fixed;
   top: 65px;
   padding: 5px;
   background-color: #fefce8;


### PR DESCRIPTION
Makes callouts fixed instead of sticky. 

Sticky banners look really bad and reduce readability on mobile: https://x.com/JeffInTokyo/status/1838725233009893656