### PR TITLE
Change from fixed to static

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -54,12 +54,13 @@ span.shasum code {
 }
 
 div.custom-callouts {
-  position: fixed;
-  top: 65px;
-  padding: 5px;
+  position: static;
+  top: 45px;
+  padding-left: 0;
+  padding-right: 0;
+  width: 100%;
   background-color: #fefce8;
   border: 2px solid #ffdc00;
-  z-index: 9999;
   border-radius: 4px;
 }
 a.callout-link {


### PR DESCRIPTION
We were a bit too quick on the draw for #925. This uses static instead of sticky/fixed to make sure the content in banners looks correct in the context of the rest of the doc. 

Pasting the description from the other PR:

```
Makes callouts fixed instead of sticky.

Sticky banners look really bad and reduce readability on mobile: https://x.com/JeffInTokyo/status/1838725233009893656
```