### PR TITLE
Update schemas to add new application attestation schema.mdx

### DIFF
--- a/pages/chain/identity/schemas.mdx
+++ b/pages/chain/identity/schemas.mdx
@@ -59,16 +59,17 @@ Used to associate metadata to a project. Re-issued each time there is a change t
 | metadataType         | How the metadata can be accessed. 1 for ipfs, 2 for http                                                        |
 | metadataUrl          | The storage location where the metadata can be retrieved                                                        |
 
-### [Retro Funding Application](https://optimism.easscan.org/schema/view/0x88b62595c76fbcd261710d0930b5f1cc2e56758e155dea537f82bf0baadd9a32)
+### [Retro Funding Application](https://optimism.easscan.org/schema/view/0x2169b74bfcb5d10a6616bbc8931dc1c56f8d1c305319a9eeca77623a991d4b80)
 
-Used to identify a project's application to a specific Retro Funding Round.
+Used to identify a project's application to a specific Retro Funding Round. This attestation is used for Retro Funding Round 6 and beyond.
 
-| Schema UID              | `0x88b62595c76fbcd261710d0930b5f1cc2e56758e155dea537f82bf0baadd9a32`                                             |
+| Schema UID              | `0x2169b74bfcb5d10a6616bbc8931dc1c56f8d1c305319a9eeca77623a991d4b80`                                             |
 | ----------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | Issuer                  | Attestations issued as part of Retro Funding sign up are issued by: `0xF6872D315CC2E1AfF6abae5dd814fd54755fE97C` |
 | Recipient               | Null                                                                                                             |
 | round                   | The round number for which this application was submitted                                                        |
-| projectRefUID           | The unique identifier of the project that submitted this application                                             |
+| metadataType            | How the metadata can be accessed. 1 for ipfs, 2 for http                                                         |
+| metadataUrl             | The storage location where the metadata can be retrieved                                                         |
 | farcasterID             | The individual that submitted this application on behalf of the project.                                         |
 | metadataSnapshot RefUID | The project metadata at the time the application was submitted.                                                  |
 
@@ -145,6 +146,19 @@ Issued to those who held governance roles in the Collective, such as Grants Coun
 ## Archived Schemas
 
 These schemas are no longer being actively issued, but capture valuable historical data.
+
+### [Retro Funding Application](https://optimism.easscan.org/schema/view/0x88b62595c76fbcd261710d0930b5f1cc2e56758e155dea537f82bf0baadd9a32)
+
+Used to identify a project's application to a specific Retro Funding Round. This attestation was used for Retro Funding Rounds 4 and 5.
+
+| Schema UID              | `0x88b62595c76fbcd261710d0930b5f1cc2e56758e155dea537f82bf0baadd9a32`                                             |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Issuer                  | Attestations issued as part of Retro Funding sign up are issued by: `0xF6872D315CC2E1AfF6abae5dd814fd54755fE97C` |
+| Recipient               | Null                                                                                                             |
+| round                   | The round number for which this application was submitted                                                        |
+| projectRefUID           | The unique identifier of the project that submitted this application                                             |
+| farcasterID             | The individual that submitted this application on behalf of the project.                                         |
+| metadataSnapshot RefUID | The project metadata at the time the application was submitted.                                                  |
 
 ### [Retro Funding Badgeholders](https://optimism.easscan.org/schema/view/0xfdcfdad2dbe7489e0ce56b260348b7f14e8365a8a325aef9834818c00d46b31b)
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

From Round 6 we have changed the application attestation schema that is issued when someone applies for Retro Funding. I added that schema and moved the old one to the archive

**Tests**

none

**Additional context**

n/a

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
