### PR TITLE
feat: docs for sendRawTranscationConditional

### DIFF
--- a/pages/builders/tools/build/account-abstraction.mdx
+++ b/pages/builders/tools/build/account-abstraction.mdx
@@ -25,6 +25,10 @@ The OP Stack includes support for the `eth_sendRawTransactionConditional` RPC me
 
 If enabled by the chain operator, also see the supplemental [op-txproxy](/stack/operators/features/op-txproxy) service, if applied, as this enforces request authentication for this method.
 
+<Callout type="info">
+    As of today, this endpoint is not enabled by default in the stack. The operator must explicitly configure this.
+</Callout>
+
 ## Superchain Paymaster
 
 The Superchain paymaster is an ERC-4337 verifying paymaster that sponsors transactions for smart accounts on the Superchain. Use the Superchain Paymaster to get your transactions sponsored to remove friction from your app experience. [View the implementation guide and tutorials here.](https://github.com/ethereum-optimism/ecosystem/tree/main/docs/superchain-paymaster)

--- a/pages/builders/tools/build/account-abstraction.mdx
+++ b/pages/builders/tools/build/account-abstraction.mdx
@@ -19,6 +19,12 @@ import { Callout } from 'nextra/components'
 *   Sponsor the gas fees for transactions
 *   Enable users to pay gas in the token(s) of their choice
 
+## Bundlers
+
+The OP Stack includes support for the `eth_sendRawTransactionConditional` RPC method to assist bundlers on shared 4337 mempools. See the [specification](/stack/protocol/features/send-raw-transaction-conditional) for how this method is implemented in op-geth.
+
+If enabled by the chain operator, also see the supplemental [op-txproxy](/stack/operators/features/op-txproxy) service, if applied, as this enforces request authentication for this method.
+
 ## Superchain Paymaster
 
 The Superchain paymaster is an ERC-4337 verifying paymaster that sponsors transactions for smart accounts on the Superchain. Use the Superchain Paymaster to get your transactions sponsored to remove friction from your app experience. [View the implementation guide and tutorials here.](https://github.com/ethereum-optimism/ecosystem/tree/main/docs/superchain-paymaster)

--- a/pages/stack/operators/features/_meta.json
+++ b/pages/stack/operators/features/_meta.json
@@ -1,3 +1,4 @@
 {
-    "proxyd": "proxyd"
+    "proxyd": "proxyd",
+    "op-txproxy": "op-txproxy"
 }

--- a/pages/stack/operators/features/op-txproxy.mdx
+++ b/pages/stack/operators/features/op-txproxy.mdx
@@ -1,0 +1,96 @@
+---
+title: op-txproxy
+lang: en-US
+description: A passthrough proxy service that can apply additional constraints on transactions prior to reaching the sequencer.
+---
+
+import { Callout, Steps } from 'nextra/components'
+
+# op-txproxy
+
+A [passthrough proxy](https://github.com/ethereum-optimism/infra/tree/main/op-txproxy) for the execution engine endpoint. This proxy does not forward all rpc traffic and only exposes a specific set of methods. Operationally, the ingress router should only re-route request for these methods.
+
+<Callout type="info">
+    [proxyd](./proxyd) as an ingress router supports the mapping of specific methods to unique backends.
+</Callout>
+
+## Methods
+
+### eth_sendRawTransactionConditional
+
+To safely expose this endpoint publicly, additional stateless constraints are applied to horizontally scale validation rules and preemptively reject conditional transactions prior to reaching the sequencer.
+
+A variety of metrics are emitted for to inform adjustments to be made.
+
+#### Authentication
+
+The caller authenticates themselves with any valid ECDSA-secp256k1 key, like an Ethereum key. The computed signature is over the [EIP-191](https://eips.ethereum.org/EIPS/eip-191) hash of the request body. This calling address does **not need to hold an ethereum balance**. It simply is used for identification.
+
+With the signature and signing address, the request is authenticated under the `X-Optimism-Signature` header with the value `<public key address>: <signature>`.
+
+* Requests with missing a missing authentication header fail with the `-32003` (transaction rejected) json rpc error code.
+* Requests with a mismatch in recovered signer and supplied public key will have the http request failed with status code `400 - Bad Request`.
+
+As of today, no authorization policies are implemented on this endpoint. This has preemptively in place allow for new policies (allowlist, localized rate limits, etc)
+
+#### Runtime Shutoff
+
+This service can be rolled with a flag/env switch to reject conditional transaction without needing to interrupt the execution engine. Useful in diagnosing issues.
+
+    `--sendRawTxConditional.enabled (default: true) ($OP_TXPROXY_SENDRAWTXCONDITIONAL_ENABLED)`
+
+When disabled, requests will fail with the `-32003` (transaction rejected) json rpc error code with a message stating that the method is disabled.
+
+#### Rate Limits
+
+Even though the op-geth implementation of this endpoint includes rate limits, it is instead applied here to terminate these requests early.
+
+    `--sendRawTxConditional.ratelimit (default: 5000) ($OP_TXPROXY_SENDRAWTXCONDITIONAL_RATELIMIT)`
+
+#### Stateless Validation
+* Conditional cost is below the max
+* Conditional values are valid (i.e min < max)
+* Transaction target are only 4337 Entrypoint contracts
+
+<Callout type="info">
+    The motivating factor for this endpoint is to enable permissionless 4337 mempools, hence the restricted usage of this methods to just [Entrypoint](https://github.com/eth-infinitism/account-abstraction/blob/develop/contracts/core/EntryPoint.sol) transactions.
+
+    Please open up an issue if you'd like this restriction to be optional via configuration to broaden usage of this endpoint.
+</Callout>
+
+When the request passes validation, it is passed through to the configured backend URL
+
+    `--sendRawTxConditional.backend ($OP_TXPROXY_SENDRAWTXCONDITIONAL_BACKENDS)`
+
+<Callout type="warning">
+    Per the [specification](/stack/protocol/features/send-raw-transaction-conditional), conditional transactions are not gossip'd between peers. Thus if you use replicas in an active/passive sequencer setup, this request must be broadcasted to all replicas.
+
+    [proxyd](./proxyd) as an egress router for this method supports this broadcasting functionality.
+</Callout>
+
+## How it works
+
+To start using `op-txproxy`, follow these steps:
+
+<Steps>
+    ### Build the Binary or Pull the Image
+    1. Run the following command to build the binary
+      ```bash
+      make build
+      ```
+    2. This will build and output the binary under `/bin/op-txproxy`.
+
+    The image for this binary is also available as a docker artifact (DOCS ON THE THE LINK FOR THIS).
+
+    ### Configure
+    The binary accepts configuration through cli flags which also settable via ENV variables. Either set the flags explicitly when starting the binary or set the environment variables of the host starting the proxy
+
+    See [methods](#methods) on the configuration options available for each method. 
+
+    ### Start
+    start the service with the following command
+    ```bash
+    op-txproxy // ... with flags if env variables are not set
+    ```
+</Steps>
+

--- a/pages/stack/operators/features/op-txproxy.mdx
+++ b/pages/stack/operators/features/op-txproxy.mdx
@@ -11,12 +11,12 @@ import { Callout, Steps } from 'nextra/components'
 A [passthrough proxy](https://github.com/ethereum-optimism/infra/tree/main/op-txproxy) for the execution engine endpoint. This proxy does not forward all rpc traffic and only exposes a specific set of methods. Operationally, the ingress router should only re-route request for these methods.
 
 <Callout type="info">
-    [proxyd](./proxyd) as an ingress router supports the mapping of specific methods to unique backends.
+  [proxyd](./proxyd) as an ingress router supports the mapping of specific methods to unique backends.
 </Callout>
 
 ## Methods
 
-### eth_sendRawTransactionConditional
+### **eth_sendRawTransactionConditional**
 
 To safely expose this endpoint publicly, additional stateless constraints are applied to horizontally scale validation rules and preemptively reject conditional transactions prior to reaching the sequencer.
 
@@ -28,8 +28,8 @@ The caller authenticates themselves with any valid ECDSA-secp256k1 key, like an 
 
 With the signature and signing address, the request is authenticated under the `X-Optimism-Signature` header with the value `<public key address>: <signature>`.
 
-* Requests with missing a missing authentication header fail with the `-32003` (transaction rejected) json rpc error code.
-* Requests with a mismatch in recovered signer and supplied public key will have the http request failed with status code `400 - Bad Request`.
+*   Requests with missing a missing authentication header fail with the `-32003` (transaction rejected) json rpc error code.
+*   Requests with a mismatch in recovered signer and supplied public key will have the http request failed with status code `400 - Bad Request`.
 
 As of today, no authorization policies are implemented on this endpoint. This has preemptively in place allow for new policies (allowlist, localized rate limits, etc)
 
@@ -37,7 +37,7 @@ As of today, no authorization policies are implemented on this endpoint. This ha
 
 This service can be rolled with a flag/env switch to reject conditional transaction without needing to interrupt the execution engine. Useful in diagnosing issues.
 
-    `--sendRawTxConditional.enabled (default: true) ($OP_TXPROXY_SENDRAWTXCONDITIONAL_ENABLED)`
+`--sendRawTxConditional.enabled (default: true) ($OP_TXPROXY_SENDRAWTXCONDITIONAL_ENABLED)`
 
 When disabled, requests will fail with the `-32003` (transaction rejected) json rpc error code with a message stating that the method is disabled.
 
@@ -45,27 +45,29 @@ When disabled, requests will fail with the `-32003` (transaction rejected) json 
 
 Even though the op-geth implementation of this endpoint includes rate limits, it is instead applied here to terminate these requests early.
 
-    `--sendRawTxConditional.ratelimit (default: 5000) ($OP_TXPROXY_SENDRAWTXCONDITIONAL_RATELIMIT)`
+`--sendRawTxConditional.ratelimit (default: 5000) ($OP_TXPROXY_SENDRAWTXCONDITIONAL_RATELIMIT)`
 
 #### Stateless Validation
-* Conditional cost is below the max
-* Conditional values are valid (i.e min < max)
-* Transaction target are only 4337 Entrypoint contracts
+
+*   Conditional cost is below the max
+*   Conditional values are valid (i.e min \< max)
+*   Transaction target are only 4337 Entrypoint contracts
 
 <Callout type="info">
-    The motivating factor for this endpoint is to enable permissionless 4337 mempools, hence the restricted usage of this methods to just [Entrypoint](https://github.com/eth-infinitism/account-abstraction/blob/develop/contracts/core/EntryPoint.sol) transactions.
+  The motivating factor for this endpoint is to enable permissionless 4337 mempools, hence the restricted usage of this methods to just [Entrypoint](https://github.com/eth-infinitism/account-abstraction/blob/develop/contracts/core/EntryPoint.sol) transactions.
 
-    Please open up an issue if you'd like this restriction to be optional via configuration to broaden usage of this endpoint.
+  Please open up an issue if you'd like this restriction to be optional via configuration to broaden usage of this endpoint.
 </Callout>
 
 When the request passes validation, it is passed through to the configured backend URL
 
-    `--sendRawTxConditional.backend ($OP_TXPROXY_SENDRAWTXCONDITIONAL_BACKENDS)`
+`--sendRawTxConditional.backend ($OP_TXPROXY_SENDRAWTXCONDITIONAL_BACKENDS)`
+
 
 <Callout type="warning">
-    Per the [specification](/stack/protocol/features/send-raw-transaction-conditional), conditional transactions are not gossip'd between peers. Thus if you use replicas in an active/passive sequencer setup, this request must be broadcasted to all replicas.
+  Per the [specification](/stack/protocol/features/send-raw-transaction-conditional), conditional transactions are not gossip'd between peers. Thus if you use replicas in an active/passive sequencer setup, this request must be broadcasted to all replicas.
 
-    [proxyd](./proxyd) as an egress router for this method supports this broadcasting functionality.
+  [proxyd](./proxyd) as an egress router for this method supports this broadcasting functionality.
 </Callout>
 
 ## How it works
@@ -73,24 +75,27 @@ When the request passes validation, it is passed through to the configured backe
 To start using `op-txproxy`, follow these steps:
 
 <Steps>
-    ### Build the Binary or Pull the Image
-    1. Run the following command to build the binary
-      ```bash
-      make build
-      ```
-    2. This will build and output the binary under `/bin/op-txproxy`.
+  ### Build the Binary or Pull the Docker Image
 
-    The image for this binary is also available as a docker artifact (DOCS ON THE THE LINK FOR THIS).
+  1.  Run the following command to build the binary
+  ```bash
+  make build
+  ```
+  2.  This will build and output the binary under `/bin/op-txproxy`.
 
-    ### Configure
-    The binary accepts configuration through cli flags which also settable via ENV variables. Either set the flags explicitly when starting the binary or set the environment variables of the host starting the proxy
+  The image for this binary is also available as a [docker artifact](https://us-docker.pkg.dev/oplabs-tools-artifacts/images/op-txproxy).
 
-    See [methods](#methods) on the configuration options available for each method. 
+  ### Configure
 
-    ### Start
-    start the service with the following command
-    ```bash
-    op-txproxy // ... with flags if env variables are not set
-    ```
+  The binary accepts configuration through cli flags which also settable via ENV variables. Either set the flags explicitly when starting the binary or set the environment variables of the host starting the proxy
+
+  See [methods](#methods) on the configuration options available for each method.
+
+  ### Start
+
+  start the service with the following command
+
+  ```bash
+  op-txproxy // ... with flags if env variables are not set
+  ```
 </Steps>
-

--- a/pages/stack/operators/features/op-txproxy.mdx
+++ b/pages/stack/operators/features/op-txproxy.mdx
@@ -8,7 +8,7 @@ import { Callout, Steps } from 'nextra/components'
 
 # op-txproxy
 
-A [passthrough proxy](https://github.com/ethereum-optimism/infra/tree/main/op-txproxy) for the execution engine endpoint. This proxy does not forward all rpc traffic and only exposes a specific set of methods. Operationally, the ingress router should only re-route requests for these methods.
+A [passthrough proxy](https://github.com/ethereum-optimism/infra/tree/main/op-txproxy) for the execution engine endpoint. This proxy does not forward all RPC traffic and only exposes a specific set of methods. Operationally, the ingress router should only re-route requests for these specific methods.
 
 <Callout type="info">
   [proxyd](./proxyd) as an ingress router supports the mapping of specific methods to unique backends.
@@ -17,19 +17,19 @@ A [passthrough proxy](https://github.com/ethereum-optimism/infra/tree/main/op-tx
 
 ### **eth_sendRawTransactionConditional**
 
-To safely expose this endpoint publicly, additional stateless constraints are applied to horizontally scale validation rules and preemptively reject conditional transactions prior to reaching the sequencer.
+To safely expose this endpoint publicly, additional stateless constraints are applied. These constraints help scale validation rules horizontally and preemptively reject conditional transactions before they reach the sequencer.
 
-A variety of metrics are emitted to inform necessary adjustments.
+Various metrics are emitted to guide necessary adjustments.
 #### Authentication
 
-The caller authenticates themselves with any valid ECDSA-secp256k1 key, like an Ethereum key. The computed signature is over the [EIP-191](https://eips.ethereum.org/EIPS/eip-191) hash of the request body. This calling address does **not need to hold an ethereum balance**. It simply is used for identification.
+The caller authenticates using any valid ECDSA-secp256k1 key, such as an Ethereum key. The signature is computed over the [EIP-191](https://eips.ethereum.org/EIPS/eip-191) hash of the request body. The calling address does **not need to hold an Ethereum balance**; it is simply used for identification.
 
 With the signature and signing address, the request is authenticated under the `X-Optimism-Signature` header with the value `<public key address>: <signature>`.
 
 *   Requests with a missing authentication header fail with the `-32003` (transaction rejected) json rpc error code.
 *   Requests with a mismatch in recovered signer and supplied public key will have the http request failed with status code `400 - Bad Request`.
 
-As of today, no authorization policies are implemented on this endpoint. However, the authentication mechanism is in place to allow for future implementation of policies such as allowlists, localized rate limits, etc.
+Currently, no authorization policies are implemented on this endpoint. However, the authentication mechanism is in place to allow for future implementation of policies such as allowlists, localized rate limits, and other potential restrictions.
 #### Runtime Shutoff
 
 This service can be configured with a flag or environment variable to reject conditional transactions without needing to interrupt the execution engine. This feature is useful for diagnosing issues.

--- a/pages/stack/operators/features/op-txproxy.mdx
+++ b/pages/stack/operators/features/op-txproxy.mdx
@@ -61,7 +61,7 @@ When the request passes validation, it is passed through to the configured backe
 
 
 <Callout type="warning">
-  Per the [specification](/stack/protocol/features/send-raw-transaction-conditional), conditional transactions are not gossip'd between peers. Thus if you use replicas in an active/passive sequencer setup, this request must be broadcasted to all replicas.
+  Per the [specification](/stack/protocol/features/send-raw-transaction-conditional), conditional transactions are not gossiped between peers. Thus, if you use replicas in an active/passive sequencer setup, this request must be broadcasted to all replicas.
 
   [proxyd](./proxyd) as an egress router for this method supports this broadcasting functionality.
 </Callout>
@@ -83,7 +83,7 @@ To start using `op-txproxy`, follow these steps:
 
   ### Configure
 
-  The binary accepts configuration through cli flags which also settable via ENV variables. Either set the flags explicitly when starting the binary or set the environment variables of the host starting the proxy
+  The binary accepts configuration through CLI flags, which also settable via environment variables. Either set the flags explicitly when starting the binary or set the environment variables of the host starting the proxy.
 
   See [methods](#methods) on the configuration options available for each method.
 

--- a/pages/stack/operators/features/op-txproxy.mdx
+++ b/pages/stack/operators/features/op-txproxy.mdx
@@ -8,39 +8,35 @@ import { Callout, Steps } from 'nextra/components'
 
 # op-txproxy
 
-A [passthrough proxy](https://github.com/ethereum-optimism/infra/tree/main/op-txproxy) for the execution engine endpoint. This proxy does not forward all rpc traffic and only exposes a specific set of methods. Operationally, the ingress router should only re-route request for these methods.
+A [passthrough proxy](https://github.com/ethereum-optimism/infra/tree/main/op-txproxy) for the execution engine endpoint. This proxy does not forward all rpc traffic and only exposes a specific set of methods. Operationally, the ingress router should only re-route requests for these methods.
 
 <Callout type="info">
   [proxyd](./proxyd) as an ingress router supports the mapping of specific methods to unique backends.
 </Callout>
-
 ## Methods
 
 ### **eth_sendRawTransactionConditional**
 
 To safely expose this endpoint publicly, additional stateless constraints are applied to horizontally scale validation rules and preemptively reject conditional transactions prior to reaching the sequencer.
 
-A variety of metrics are emitted for to inform adjustments to be made.
-
+A variety of metrics are emitted to inform necessary adjustments.
 #### Authentication
 
 The caller authenticates themselves with any valid ECDSA-secp256k1 key, like an Ethereum key. The computed signature is over the [EIP-191](https://eips.ethereum.org/EIPS/eip-191) hash of the request body. This calling address does **not need to hold an ethereum balance**. It simply is used for identification.
 
 With the signature and signing address, the request is authenticated under the `X-Optimism-Signature` header with the value `<public key address>: <signature>`.
 
-*   Requests with missing a missing authentication header fail with the `-32003` (transaction rejected) json rpc error code.
+*   Requests with a missing authentication header fail with the `-32003` (transaction rejected) json rpc error code.
 *   Requests with a mismatch in recovered signer and supplied public key will have the http request failed with status code `400 - Bad Request`.
 
-As of today, no authorization policies are implemented on this endpoint. This has preemptively in place allow for new policies (allowlist, localized rate limits, etc)
-
+As of today, no authorization policies are implemented on this endpoint. However, the authentication mechanism is in place to allow for future implementation of policies such as allowlists, localized rate limits, etc.
 #### Runtime Shutoff
 
-This service can be rolled with a flag/env switch to reject conditional transaction without needing to interrupt the execution engine. Useful in diagnosing issues.
+This service can be configured with a flag or environment variable to reject conditional transactions without needing to interrupt the execution engine. This feature is useful for diagnosing issues.
 
 `--sendRawTxConditional.enabled (default: true) ($OP_TXPROXY_SENDRAWTXCONDITIONAL_ENABLED)`
 
 When disabled, requests will fail with the `-32003` (transaction rejected) json rpc error code with a message stating that the method is disabled.
-
 #### Rate Limits
 
 Even though the op-geth implementation of this endpoint includes rate limits, it is instead applied here to terminate these requests early.

--- a/pages/stack/protocol/features/_meta.json
+++ b/pages/stack/protocol/features/_meta.json
@@ -1,4 +1,5 @@
 {
     "custom-gas-token": "Custom Gas Token",
-    "alt-da-mode": "Alt-DA Mode"
+    "alt-da-mode": "Alt-DA Mode",
+    "send-raw-transaction-conditional": "SendRawTransactionConditional"
 }

--- a/pages/stack/protocol/features/send-raw-transaction-conditional.mdx
+++ b/pages/stack/protocol/features/send-raw-transaction-conditional.mdx
@@ -4,9 +4,9 @@ lang: en-US
 description: Learn the basic process, benefits, and considerations for running a custom gas token chain.
 ---
 
-# SendRawTransactionConditional Explainer
-
 import { Callout } from 'nextra/components'
+
+# SendRawTransactionConditional Explainer
 
 A sequencer rpc, `eth_sendRawTransactionConditional`, allowing callers to conditionally include a transaction based on a set of provided options.
 
@@ -56,5 +56,5 @@ This feature can be enabled with the addition of a flag to op-geth.
 * `--rollup.sequencertxconditionalcostratelimit` (default: 5000) an integer flag that sets the rate limit for cost observable per second.
 
 <Callout type="warning">
-    It is not advised to publicly expose this sequencer endpoint due to DoS concerns. This supplemental proxy [INSERT DOCS LINK] should be used to apply additional constraints on this endpoint prior to passing through to the sequencer.
+    It is not advised to publicly expose this sequencer endpoint due to DoS concerns. This supplemental proxy, [op-txproxy](/stack/operators/features/op-txproxy), should be used to apply additional constraints on this endpoint prior to passing through to the sequencer.
 </Callout>

--- a/pages/stack/protocol/features/send-raw-transaction-conditional.mdx
+++ b/pages/stack/protocol/features/send-raw-transaction-conditional.mdx
@@ -1,0 +1,60 @@
+---
+title: SendRawTransactionConditional Explainer
+lang: en-US
+description: Learn the basic process, benefits, and considerations for running a custom gas token chain.
+---
+
+# SendRawTransactionConditional Explainer
+
+import { Callout } from 'nextra/components'
+
+A sequencer rpc, `eth_sendRawTransactionConditional`, allowing callers to conditionally include a transaction based on a set of provided options.
+
+This feature is meant to unblock use cases that require atomic inclusion, otherwise possible on Ethereum through specialized block builders like Flashbots. Some examples:
+
+* 4337 Bundlers utilizing a shared mempool of UserOperations. Reverted transactions due to conflicting UserOperations would make it too costly for bundlers to operate on L2, forcing the use of private mempools.
+
+## Specification
+
+This endpoint is an extension of `eth_sendRawTransaction`, with an extra parameter of "options" with the following structure:
+```
+{
+    "knownAccounts": [optional] A map of accounts with expected storage. The key is account address
+                                If the value is hex string, it is the known storage root hash of that account.
+                                If the value is an object, then each member is in the format of "slot": "value", which are explicit slot values within that account storage.
+    "blockNumberMin": [optional] minimal block number for inclusion
+    "blockNumberMax": [optional] maximum block number for inclusion
+    "timestampMin": [optional] minimum block timestamp for inclusion
+    "timestampMax": [optional] maximum block timestamp for inclusion
+}
+```
+The "cost" of a given conditional is _approximately_ determined by the number of storage lookups that would be incurred by validating this conditional. There's a predefined max of `1000` that is allowed to prevent DoS.
+
+<Callout type="info">
+    Since the sequencer is not compensated for the additional state checks, otherwise through the GAS of the transaction, a configured rate limit is applied to this cost.
+
+    To also disincentive the use of this endpoint for MEV in comparison to `eth_sendRawTransaction`, the conditional is checked against the parent of the latest block.
+</Callout>
+
+This conditional is checked once at the RPC layer prior to mempool submission. If rejected against chain state, the RPC will return an error with the following spec
+* error code `-32003` (transaction rejected) with a reason string as to the specific failed check
+* error code `-32005` (conditional cost) with a reason string if the conditional cost exceeded the maximum OR the cost was rate limited due to network conditions. 
+
+Successful submission does **NOT** guarantee inclusion! The caller must observe the chain for a receipt with some timeout to determine non-inclusion. The conditional is also re-checked in the block building phase to handle intra-block conflicts.
+
+<Callout type="warning">
+    Conditional transactions are tied to the block builder they are submitted to. This means that these transactions **are not gossiped between configured peers!!!** 
+
+    If you are running an active/passive setup with replicas that gossip txs to an active sequencer, this endpoint should be fronted by a proxy that can broadcast the request to all replicas. 
+</Callout>
+
+## How To Enable
+
+This feature can be enabled with the addition of a flag to op-geth.
+
+* `--rollup.sequencertxconditionalenabled` (default: false) a boolean flag which enables the rpc.
+* `--rollup.sequencertxconditionalcostratelimit` (default: 5000) an integer flag that sets the rate limit for cost observable per second.
+
+<Callout type="warning">
+    It is not advised to publicly expose this sequencer endpoint due to DoS concerns. This supplemental proxy [INSERT DOCS LINK] should be used to apply additional constraints on this endpoint prior to passing through to the sequencer.
+</Callout>

--- a/pages/stack/protocol/features/send-raw-transaction-conditional.mdx
+++ b/pages/stack/protocol/features/send-raw-transaction-conditional.mdx
@@ -1,7 +1,7 @@
 ---
 title: SendRawTransactionConditional Explainer
 lang: en-US
-description: Learn the basic process, benefits, and considerations for running a custom gas token chain.
+description: Learn about the eth_sendRawTransactionConditional RPC method for conditional transaction inclusion on the OP Stack.
 ---
 
 import { Callout } from 'nextra/components'

--- a/pages/stack/protocol/features/send-raw-transaction-conditional.mdx
+++ b/pages/stack/protocol/features/send-raw-transaction-conditional.mdx
@@ -12,11 +12,12 @@ A sequencer rpc, `eth_sendRawTransactionConditional`, allowing callers to condit
 
 This feature is meant to unblock use cases that require atomic inclusion, otherwise possible on Ethereum through specialized block builders like Flashbots. Some examples:
 
-* 4337 Bundlers utilizing a shared mempool of UserOperations. Reverted transactions due to conflicting UserOperations would make it too costly for bundlers to operate on L2, forcing the use of private mempools.
+*   4337 Bundlers utilizing a shared mempool of UserOperations. Reverted transactions due to conflicting UserOperations would make it too costly for bundlers to operate on L2, forcing the use of private mempools.
 
 ## Specification
 
 This endpoint is an extension of `eth_sendRawTransaction`, with an extra parameter of "options" with the following structure:
+
 ```
 {
     "knownAccounts": [optional] A map of accounts with expected storage. The key is account address
@@ -28,33 +29,35 @@ This endpoint is an extension of `eth_sendRawTransaction`, with an extra paramet
     "timestampMax": [optional] maximum block timestamp for inclusion
 }
 ```
-The "cost" of a given conditional is _approximately_ determined by the number of storage lookups that would be incurred by validating this conditional. There's a predefined max of `1000` that is allowed to prevent DoS.
+
+The "cost" of a given conditional is *approximately* determined by the number of storage lookups that would be incurred by validating this conditional. There's a predefined max of `1000` that is allowed to prevent DoS.
 
 <Callout type="info">
-    Since the sequencer is not compensated for the additional state checks, otherwise through the GAS of the transaction, a configured rate limit is applied to this cost.
+  Since the sequencer is not compensated for the additional state checks, otherwise through the GAS of the transaction, a configured rate limit is applied to this cost.
 
-    To also disincentive the use of this endpoint for MEV in comparison to `eth_sendRawTransaction`, the conditional is checked against the parent of the latest block.
+  To also disincentive the use of this endpoint for MEV in comparison to `eth_sendRawTransaction`, the conditional is checked against the parent of the latest block.
 </Callout>
 
 This conditional is checked once at the RPC layer prior to mempool submission. If rejected against chain state, the RPC will return an error with the following spec
-* error code `-32003` (transaction rejected) with a reason string as to the specific failed check
-* error code `-32005` (conditional cost) with a reason string if the conditional cost exceeded the maximum OR the cost was rate limited due to network conditions. 
+
+*   error code `-32003` (transaction rejected) with a reason string as to the specific failed check
+*   error code `-32005` (conditional cost) with a reason string if the conditional cost exceeded the maximum OR the cost was rate limited due to network conditions.
 
 Successful submission does **NOT** guarantee inclusion! The caller must observe the chain for a receipt with some timeout to determine non-inclusion. The conditional is also re-checked in the block building phase to handle intra-block conflicts.
 
 <Callout type="warning">
-    Conditional transactions are tied to the block builder they are submitted to. This means that these transactions **are not gossiped between configured peers!!!** 
+  Conditional transactions are tied to the block builder they are submitted to. This means that these transactions **are not gossiped between configured peers!!!**
 
-    If you are running an active/passive setup with replicas that gossip txs to an active sequencer, this endpoint should be fronted by a proxy that can broadcast the request to all replicas. 
+  If you are running an active/passive setup with replicas that gossip txs to an active sequencer, this endpoint should be fronted by a proxy that can broadcast the request to all replicas.
 </Callout>
 
 ## How To Enable
 
 This feature can be enabled with the addition of a flag to op-geth.
 
-* `--rollup.sequencertxconditionalenabled` (default: false) a boolean flag which enables the rpc.
-* `--rollup.sequencertxconditionalcostratelimit` (default: 5000) an integer flag that sets the rate limit for cost observable per second.
+*   `--rollup.sequencertxconditionalenabled` (default: false) a boolean flag which enables the rpc.
+*   `--rollup.sequencertxconditionalcostratelimit` (default: 5000) an integer flag that sets the rate limit for cost observable per second.
 
 <Callout type="warning">
-    It is not advised to publicly expose this sequencer endpoint due to DoS concerns. This supplemental proxy, [op-txproxy](/stack/operators/features/op-txproxy), should be used to apply additional constraints on this endpoint prior to passing through to the sequencer.
+  It is not advised to publicly expose this sequencer endpoint due to DoS concerns. This supplemental proxy, [op-txproxy](/stack/operators/features/op-txproxy), should be used to apply additional constraints on this endpoint prior to passing through to the sequencer.
 </Callout>

--- a/words.txt
+++ b/words.txt
@@ -104,6 +104,7 @@ farcaster
 FDLIMIT
 fdlimit
 featureset
+Flashbots
 forkable
 forkchoice
 FPVM
@@ -342,7 +343,6 @@ syncmode
 SYNCTARGET
 synctarget
 syscalls
-Terraform
 therealbytes
 Thirdweb
 threadcreate
@@ -355,6 +355,7 @@ txfeecap
 txmgr
 TXPOOL
 txpool
+txproxy
 uncountered
 Unprotect
 unsubmitted


### PR DESCRIPTION
**Description**

This is split between different sections
1. protocol docs for how this method is implemented in the execution engine
2. operator docs for the op-txproxy service that _should_ be applied in front of this method
3. account abstraction docs for bundlers integrating this endpoint

**Additional context**

Inspiration for this method comes from this design: https://notes.ethereum.org/@yoav/SkaX2lS9j

This design is also implemented by Arbitrum and Polygon
