### PR TITLE
fix: Add missing safedb.path op-node config option

### DIFF
--- a/pages/builders/node-operators/configuration/consensus-config.mdx
+++ b/pages/builders/node-operators/configuration/consensus-config.mdx
@@ -723,6 +723,16 @@ RPC listening port. Default is `9545`.
   <Tabs.Tab>`OP_NODE_RPC_PORT=9545`</Tabs.Tab>
 </Tabs>
 
+### safedb.path
+
+File path used to persist safe head update data. Disabled if not set.
+
+<Tabs items={['Syntax', 'Example', 'Environment Variable']}>
+  <Tabs.Tab>`--safedb.path=<value>`</Tabs.Tab>
+  <Tabs.Tab>`--safedb.path=/db`</Tabs.Tab>
+  <Tabs.Tab>`SAFEDB_PATH=/db`</Tabs.Tab>
+</Tabs>
+
 ### sequencer.enabled
 
 Enable sequencing of new L2 blocks. A separate batch submitter has to be deployed to publish the data for verifiers. Default is `false`.

--- a/words.txt
+++ b/words.txt
@@ -304,6 +304,7 @@ RPGF
 Rpgf
 rpgf
 RWAs
+safedb
 Schnorr
 secp
 SELFDESTRUCT
@@ -343,7 +344,6 @@ syncmode
 SYNCTARGET
 synctarget
 syscalls
-Terraform
 therealbytes
 Thirdweb
 threadcreate


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Adds a missing option to the `op-node` config page: `safedb.path`: https://github.com/ethereum-optimism/optimism/blob/f33a0a9e65e40afb7d62dc264ed36f28a29d9360/op-node/flags/flags.go#L313-L318

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

Manually tested.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
