### PR TITLE
Updated coderabbit rules

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,10 +14,14 @@ reviews:
         - Monitor capitalization for emphasis. Avoid using all caps, italics, or bold for emphasis.
         - Ensure proper nouns are capitalized in sentences.
         - Apply the Oxford comma.
-        - Use proper title case for headers, buttons, tab names, page names, and links. Sentence case should be used for body content and short phrases, even in links.
+        - Use proper title case for buttons, tab names, page names, and links. Sentence case should be used for body content and short phrases, even in links.
         - Use correct spelling and grammar at all times (IMPORTANT).
-        - Use sentence case for H1, H2, and H3 headers, capitalizing only the first word and any proper nouns.
-        - For all headers (H1, H2, H3), do not change the capitalization of proper nouns; keep them as they are.
+        - For H1, H2, and H3 headers:
+          1. Use sentence case, capitalizing only the first word.
+          2. Preserve the capitalization of proper nouns, technical terms, and acronyms. Examples include 'Optimism', 'OP Mainnet', 'Ethereum', 'JavaScript', 'NFT', etc.
+          3. Do not automatically lowercase words that might be proper nouns or technical terms.
+        - Flag any headers that seem to inconsistently apply these rules for manual review.
+        - Refer to a predefined list of proper nouns and technical terms specific to the project, which should be kept capitalized regardless of their position in the header.
         "
   auto_review:
     enabled: true


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updated CodeRabbit rules to:

1. Proper Noun Preservation: Proper nouns like "Optimism", "OP Mainnet", and "Ethereum" will now retain their capitalization in headers (H1, H2, H3), even with sentence case.

2. Manual Flagging for Edge Cases: Any headers that don’t follow these rules exactly will be flagged for manual review to avoid false positives.
<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
