### PR TITLE
Add dev node RPC ports to local node instructions

### DIFF
--- a/pages/chain/testing/dev-node.mdx
+++ b/pages/chain/testing/dev-node.mdx
@@ -107,8 +107,7 @@ After installation, you can verify Go is correctly installed by running:
 ## Operations
 
 *   To start, run (in the root directory of the monorepo) `make devnet-up`.\
-    The first time it runs it will be relatively slow because it needs to download the images, after that it will be faster.
-
+    The first time it runs it will be relatively slow because it needs to download the images, after that it will be faster.\
     After the devnet starts, the L2 RPC server will be available at `127.0.0.1:9545` and the L1 RPC server will be available at `127.0.0.1:8545`.
 
 *   To stop, run (in the root directory of the monorepo) `make devnet-down`.

--- a/pages/chain/testing/dev-node.mdx
+++ b/pages/chain/testing/dev-node.mdx
@@ -109,6 +109,8 @@ After installation, you can verify Go is correctly installed by running:
 *   To start, run (in the root directory of the monorepo) `make devnet-up`.\
     The first time it runs it will be relatively slow because it needs to download the images, after that it will be faster.
 
+    After the devnet starts, the L2 RPC HTTP server will be available at `127.0.0.1:9545` and the L1 RPC HTTP server will be available at `127.0.0.1:8545`.
+
 *   To stop, run (in the root directory of the monorepo) `make devnet-down`.
 
 *   To clean everything, run (in the root directory of the monorepo) `make devnet-clean`.

--- a/pages/chain/testing/dev-node.mdx
+++ b/pages/chain/testing/dev-node.mdx
@@ -109,7 +109,7 @@ After installation, you can verify Go is correctly installed by running:
 *   To start, run (in the root directory of the monorepo) `make devnet-up`.\
     The first time it runs it will be relatively slow because it needs to download the images, after that it will be faster.
 
-    After the devnet starts, the L2 RPC HTTP server will be available at `127.0.0.1:9545` and the L1 RPC HTTP server will be available at `127.0.0.1:8545`.
+    After the devnet starts, the L2 RPC server will be available at `127.0.0.1:9545` and the L1 RPC server will be available at `127.0.0.1:8545`.
 
 *   To stop, run (in the root directory of the monorepo) `make devnet-down`.
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The local node documentation does not list the RPC ports needed to access a local node. They are included in the CLI output but not the docs, so this PR adds them to the docs.

**Tests**

This can be verified after running `make devnet-up` via the CLI output (included in a commit below) and:
```
cast chain-id --rpc-url http://127.0.0.1:8545
900
cast chain-id --rpc-url http://127.0.0.1:9545
901
```