### PR TITLE
Fix duplicated Retro Funding Governance contribution issuer

### DIFF
--- a/pages/chain/identity/schemas.mdx
+++ b/pages/chain/identity/schemas.mdx
@@ -126,7 +126,6 @@ These attestations are voting Badges issued for Retro Round 5 and beyond. They a
 | Schema UID             | `0x3743be2afa818ee40304516c153427be55931f238d961af5d98653a93192cdb3`                                                                                                               |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Issuer                 | Currently, the Optimism Foundation issues these from one of the following addresses: `0x621477dBA416E12df7FF0d48E14c4D20DC85D7D9` or `0xE4553b743E74dA3424Ac51f8C1E586fd43aE226F`. |
-| Issuer                 | Currently, the Optimism Foundation issues these from one of the following addresses: `0x621477dBA416E12df7FF0d48E14c4D20DC85D7D9` or `0xE4553b743E74dA3424Ac51f8C1E586fd43aE226F`  |
 | Recipient              | The address of the individual who made the contribution                                                                                                                            |
 | Rpgf\_round            | The round number for which this contribution was made                                                                                                                              |
 | RetroPGF\_Contribution | The type of contribution made                                                                                                                                                      |


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Retro Funding Governance contribution section of [Identity > Schemas](https://docs.optimism.io/chain/identity/schemas) page has duplicated Issuer in the table

![image](https://github.com/user-attachments/assets/5aba8b5a-cab7-40d2-a3bb-9f756a1f2051)

