### PR TITLE
Update create-l2-rollup.mdx

### DIFF
--- a/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
+++ b/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
@@ -428,6 +428,11 @@ If the same `IMPL_SALT` is used to deploy the same contracts twice, the second d
 **You can generate a new `IMPL_SALT` by running `direnv allow` anywhere in the Optimism Monorepo.**
 </Callout>
 
+<Callout>
+If you see a nondescript error that includes `[Revert] revert: Misconfigured networks: `
+you should change the network ID in contracts-bedrock/deployments/getting-started/.chainId from 1 to the network ID you intend to use as Layer 1. For example, change it to 11155111 if you are using the Sepolia network.
+</Callout>
+
 {<h3>Generate contract artifacts</h3>}
 
 ```bash


### PR DESCRIPTION

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
when I used this tutorial script it says it is using sepolia but chain id in getting started is 1. people will encounter this error like me if there are any warning about it

<!--
A clear and concise description of the features you're adding in this pull request.
-->
when I copy and pasted the script below I encounter error like below
```
forge script scripts/Deploy.s.sol:Deploy --private-key $GS_ADMIN_PRIVATE_KEY --broadcast --rpc-url $L1_RPC_URL --slow
```
It could be solved when I changed chain id to sepolia eth in getting-started configuration in below
original chain id is 1 so we need to warn people to change this chain id as sepolia network
```
optimism/packages/contracts-bedrock/deployments/getting-started/.chainId
```

**Tests**
```
[⠃] Compiling...
No files changed, compilation skipped
Traces:
  [57372465] → new Deploy@0x5b73C5498c1E3b4dbA84de0F1833c4a029d90519
    └─ ← [Return] 285705 bytes of code

  [287516] Deploy::setUp()
    ├─ [0] VM::projectRoot() [staticcall]
    │   └─ ← [Return] "/Users/chohk/git/blockchain101/layer2/optimism/packages/contracts-bedrock"
    ├─ [0] VM::envOr("DEPLOY_SCRIPT", "Deploy")
    │   └─ ← [Return] <env var value>
    ├─ [0] VM::envOr("DEPLOYMENT_CONTEXT", "")
    │   └─ ← [Return] <env var value>
    ├─ [0] VM::envOr("SIG", "run")
    │   └─ ← [Return] <env var value>
    ├─ [0] VM::envOr("DEPLOY_FILE", "run-latest.json")
    │   └─ ← [Return] <env var value>
    ├─ [0] VM::envOr("CHAIN_ID", 11155111 [1.115e7])
    │   └─ ← [Return] <env var value>
    ├─ [0] VM::toString(11155111 [1.115e7]) [staticcall]
    │   └─ ← [Return] "11155111"
    ├─ [0] VM::createDir("/Users/chohk/git/blockchain101/layer2/optimism/packages/contracts-bedrock/deployments/getting-started", true)
    │   └─ ← [Return] 
    ├─ [0] VM::readFile("/Users/chohk/git/blockchain101/layer2/optimism/packages/contracts-bedrock/deployments/getting-started/.chainId") [staticcall]
    │   └─ ← [Return] <file>
    ├─ [0] VM::envOr("STRICT_DEPLOYMENT", true)
    │   └─ ← [Return] <env var value>
    ├─ [0] VM::parseUint("1") [staticcall]
    │   └─ ← [Return] 1
    ├─ [0] VM::toString(11155111 [1.115e7]) [staticcall]
    │   └─ ← [Return] "11155111"
    └─ ← [Revert] revert: Misconfigured networks: 1 != 11155111


Error: 
script failed: <empty revert data>
```
<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
