### PR TITLE
fix: updated broken links in custom-bridge.mdx

### DIFF
--- a/pages/builders/app-developers/bridging/custom-bridge.mdx
+++ b/pages/builders/app-developers/bridging/custom-bridge.mdx
@@ -8,7 +8,7 @@ import { Callout } from 'nextra/components'
 
 # Custom Bridges
 
-Custom token bridges are any bridges other than the [Standard Bridge](./standard-bridge).
+Custom token bridges are any bridges other than the [Standard Bridge](./standard-bridge.mdx).
 You may find yourself in a position where you need to build a custom token bridge because the Standard Bridge doesn't completely support your use case.
 This guide provides important information you should be aware of when building a custom bridge.
 
@@ -27,7 +27,7 @@ Doing so will provide you with an audited foundation upon which you can add extr
 
 If you choose not to extend the `StandardBridge` contract, you may still want to follow the interface that the `StandardBridge` provides.
 Bridges that extend this interface will be compatible with the [Superchain Bridges UI](https://app.optimism.io/bridge).
-You can read more about the design of the Standard Bridge in the guide on [Using the Standard Bridge](./standard-bridge).
+You can read more about the design of the Standard Bridge in the guide on [Using the Standard Bridge](./standard-bridge.mdx).
 
 ## The Superchain Token List
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

I have updated the custom-bridge.mdx file to fix an issue where the “Standard Bridge” link was styled as a hyperlink but had no valid destination. I replaced the broken link with the correct relative path to the standard-bridge.mdx file, ensuring users can now navigate properly within the documentation.

**Tests**

No additional tests were added, as this change affects documentation formatting. The updated link has been manually tested to confirm it correctly navigates to the standard-bridge.mdx file.

**Additional context**

The issue was identified during a review of internal documentation links. This change improves the usability and accuracy of the documentation by ensuring that links between relevant sections are functional.
**Metadata**

Fixes #1005 

