### PR TITLE
fix: Corrected undefined 'abi' to 'l2OutputOracleProxyABI' in system contracts docs

### DIFF
--- a/pages/builders/app-developers/contracts/system-contracts.mdx
+++ b/pages/builders/app-developers/contracts/system-contracts.mdx
@@ -90,7 +90,7 @@ import {
 } from '@eth-optimism/contracts-ts'
 
 // Note that the address is keyed by chain ID!
-console.log(l2OutputOracleAddresses[10], abi)
+console.log(l2OutputOracleAddresses[10], l2OutputOracleProxyABI)
 ```
 ### Interacting with the Contract
 You can then feed this address and ABI into your favorite web3 library to interact with the contract.


### PR DESCRIPTION
**Description**

Fixed an issue in the system contracts documentation where an undefined variable `abi` was used in a code snippet. The variable has been replaced with `l2OutputOracleProxyABI`, which is correctly imported and provides the necessary `ABI` (Application Binary Interface) for the `L2OutputOracleProxy` contract. This change ensures that the script will run correctly and interact with the contract as expected.

**Tests**

No additional tests were added since this change only impacts a documentation code snippet. The focus was to correct a variable name to avoid runtime errors in example code.

**Additional context**

The previous use of `abi` would have resulted in a ReferenceError: `abi` is not defined during script execution. This fix prevents that error by utilizing the already imported and appropriate `l2OutputOracleProxyABI`.

**Metadata**


Include a link to any github issues that this may close in the following form:
- Fixes #1007 

