### PR TITLE
fix: incorrect option name in op-batcher configuration

### DIFF
--- a/pages/builders/chain-operators/configuration/batcher.mdx
+++ b/pages/builders/chain-operators/configuration/batcher.mdx
@@ -288,8 +288,8 @@ default value is `false`.
 Enable plasma mode. The default value is `false`.
 
 <Tabs items={['Syntax', 'Example', 'Environment Variable']}>
-  <Tabs.Tab>`--altda.enabled=<value>`</Tabs.Tab>
-  <Tabs.Tab>`--altda.enabled=false`</Tabs.Tab>
+  <Tabs.Tab>`--plasma.enabled=<value>`</Tabs.Tab>
+  <Tabs.Tab>`--plasma.enabled=false`</Tabs.Tab>
   <Tabs.Tab>`OP_BATCHER_PLASMA_ENABLED=false`</Tabs.Tab>
 </Tabs>
 
@@ -299,8 +299,8 @@ Verify input data matches the commitments from the DA storage service. The
 default value is `true`.
 
 <Tabs items={['Syntax', 'Example', 'Environment Variable']}>
-  <Tabs.Tab>`--altda.verify-on-read=<value>`</Tabs.Tab>
-  <Tabs.Tab>`--altda.verify-on-read=true`</Tabs.Tab>
+  <Tabs.Tab>`--plasma.verify-on-read=<value>`</Tabs.Tab>
+  <Tabs.Tab>`--plasma.verify-on-read=true`</Tabs.Tab>
   <Tabs.Tab>`OP_BATCHER_PLASMA_VERIFY_ON_READ=true`</Tabs.Tab>
 </Tabs>
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

In the op-batcher configuration, the option name --altda.enabled is used incorrectly. The correct option name is --plasma.enabled, which is responsible for enabling Plasma mode. A typo in the option name causes the system not to recognize this parameter.

Consequences if not corrected:

1.Incorrect configuration: op-batcher will ignore the invalid option --altda.enabled and use the default value (false). This may lead to the deactivation of necessary features related to Plasma.
2.Missing required features: Plasma mode will not be activated, which may disrupt the system's operation when using features that rely on Plasma.
3.Execution errors: Failures or incorrect operation of op-batcher may occur, requiring additional time for diagnosis and correction.

Fixed -  <Tabs.Tab>--altda.verify-on-read=true</Tabs.Tab> option. to <Tabs.Tab>--plasma.verify-on-read=true</Tabs.Tab> option. And --altda.enabled=<value> on --plasma.enabled=<value>
![Снимок экрана 2024-10-20 в 16 34 49](https://github.com/user-attachments/assets/d36ddbb5-787b-4fef-a25c-17f3ce63eb04)

Include a link to any github issues that this may close in the following form:
- Fixes #1011 

