### PR TITLE
fix: wrong Deploy.s.sol file path

### DIFF
--- a/pages/builders/chain-operators/deploy/smart-contracts.mdx
+++ b/pages/builders/chain-operators/deploy/smart-contracts.mdx
@@ -44,7 +44,7 @@ the outputs inside [`snapshots/state-diff/`](https://github.com/ethereum-optimis
 Run the deployment with state diffs by executing:
 
 ```bash
-forge script -vvv scripts/Deploy.s.sol:Deploy --sig 'runWithStateDiff()' --rpc-url $ETH_RPC_URL --broadcast --private-key $PRIVATE_KEY
+forge script -vvv scripts/deploy/Deploy.s.sol:Deploy --sig 'runWithStateDiff()' --rpc-url $ETH_RPC_URL --broadcast --private-key $PRIVATE_KEY
 ```
 
 ### Execution
@@ -71,7 +71,7 @@ shared SuperchainConfig contract.
 ```
 DEPLOYMENT_OUTFILE=deployments/artifact.json \
 DEPLOY_CONFIG_PATH=<PATH_TO_MY_DEPLOY_CONFIG> \
-  forge script scripts/Deploy.s.sol:Deploy \
+  forge script scripts/deploy/Deploy.s.sol:Deploy \
   --broadcast --private-key $PRIVATE_KEY \
   --rpc-url $ETH_RPC_URL
 ```

--- a/pages/builders/chain-operators/features/custom-gas-token.mdx
+++ b/pages/builders/chain-operators/features/custom-gas-token.mdx
@@ -56,7 +56,7 @@ section of the docs.
   ```bash
   DEPLOYMENT_OUTFILE=deployments/artifact.json \
   DEPLOY_CONFIG_PATH=<PATH_TO_MY_DEPLOY_CONFIG> \
-    forge script scripts/Deploy.s.sol:Deploy \
+    forge script scripts/deploy/Deploy.s.sol:Deploy \
     --broadcast --private-key $PRIVATE_KEY \
     --rpc-url $ETH_RPC_URL
   ```

--- a/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
+++ b/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
@@ -418,7 +418,7 @@ Once you've configured your network, it's time to deploy the L1 contracts necess
 {<h3>Deploy the L1 contracts</h3>}
 
 ```bash
-forge script scripts/Deploy.s.sol:Deploy --private-key $GS_ADMIN_PRIVATE_KEY --broadcast --rpc-url $L1_RPC_URL --slow
+forge script scripts/deploy/Deploy.s.sol:Deploy --private-key $GS_ADMIN_PRIVATE_KEY --broadcast --rpc-url $L1_RPC_URL --slow
 ```
 
 <Callout>


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

the [deploy.sol](https://github.com/ethereum-optimism/optimism/tree/232c54d44ba206220a9997b076c829d6000c79f5/packages/contracts-bedrock/scripts/deploy/Deploy.sol) is at `scripts/deploy/Deploy.sol` instead of `scripts/Deploy.sol`

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
