### PR TITLE
docs: remove duplicate word "the"

### DIFF
--- a/pages/builders/chain-operators/architecture.mdx
+++ b/pages/builders/chain-operators/architecture.mdx
@@ -83,7 +83,7 @@ handle the state changing RPC request `eth_sendRawTransaction`. It can be peered
 replica nodes to gossip new `unsafe` blocks to the rest of the network.
 
 <Callout type="info">
-To run a rollup, you need a minimum of one archive node. This is required by the proposer as the the data that it needs can be older than the data available to a full node.  Note that since the proposer doesn't care what archive node it points to, you can technically point it towards an archive node that isn't the sequencer. 
+To run a rollup, you need a minimum of one archive node. This is required by the proposer as the data that it needs can be older than the data available to a full node.  Note that since the proposer doesn't care what archive node it points to, you can technically point it towards an archive node that isn't the sequencer. 
 </Callout>
 
 <Image src="/img/builders/chain-operators/sequencer-node.png" alt="Sequencer Node Diagram" width={400} height={400} />


### PR DESCRIPTION
Was reading the docs and found this little typo. This PR removes the extraneous "the" from the docs.
