### PR TITLE
tutorials: make geth before using geth init

### DIFF
--- a/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
+++ b/pages/builders/chain-operators/tutorials/create-l2-rollup.mdx
@@ -503,6 +503,12 @@ cd ~/op-geth
 mkdir datadir
 ```
 
+{<h3>Build the op-geth binary</h3>}
+
+```bash
+make geth
+```
+
 {<h3>Initialize op-geth</h3>}
 
 ```bash


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

We need to build the op-geth binary, else the following `build/bin/geth init` failed with `No such file or directory`

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
