### PR TITLE
Improve discoverability for gas limit

### DIFF
--- a/pages/stack/transactions/fees.mdx
+++ b/pages/stack/transactions/fees.mdx
@@ -7,9 +7,9 @@ description: Learn how transaction fees work on OP Mainnet.
 import { Callout } from 'nextra/components'
 
 <Callout>
-  The OP Stack maintains a distinct gas limit compared to the Ethereum mainnet.\
-  While both chains use the same underlying transaction formats, Optimism's gas limits are tailored for optimal Layer 2 performance and scalability.\
-  As a result, transactions on Optimism may behave differently from the mainnet regarding gas usage and fee estimation.\
+  The OP Stack maintains a distinct gas limit compared to the Ethereum mainnet.
+  While both chains use the same underlying transaction formats, Optimism's gas limits are tailored for optimal Layer 2 performance and scalability.
+  As a result, transactions on Optimism may behave differently from the mainnet regarding gas usage and fee estimation.
   For a detailed comparison of gas limits between Optimism and Ethereum, see the [Optimism Chain Differences documentation](https://docs.optimism.io/chain/differences#transaction-fees).
 </Callout>
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Added a "callout" highlighting and linking to the unique gas limits of the OP Stack compared to Ethereum mainnet, directly on the app developers' transactions and fees page to improve discoverability.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

 Fixes #530

