### PR TITLE
Add caveat for the priority fee

### DIFF
--- a/pages/stack/transactions/fees.mdx
+++ b/pages/stack/transactions/fees.mdx
@@ -52,7 +52,8 @@ Read more about the base fee in the [Ethereum.org documentation](https://ethereu
 Just like on Ethereum, OP Mainnet transactions can specify a **priority fee**.
 This priority fee is a price per unit of gas that is paid on top of the base fee.
 For example, if the block base fee is 1 gwei and the transaction specifies a priority fee of 1 gwei, the total price per unit of gas is 2 gwei.
-The priority fee is an optional component of the execution gas fee and can be set to 0.
+The priority fee is an optional component of the execution gas fee and can technically be set to 0.
+However, while EIP-1559 does not define a minimum priority fee, certain wallets and mempool implementations (like Geth) may enforce a minimum value. Geth, for example, typically hardcodes a minimum of 1 wei but defaults to a configurable minimum of around 1 gwei..
 
 **The OP Mainnet sequencer will prioritize transactions with a higher priority fee** and execute them before any transactions with a lower priority fee.
 If transaction speed is important to your application, you may want to set a higher priority fee to ensure that your transaction is included more quickly.

--- a/pages/stack/transactions/fees.mdx
+++ b/pages/stack/transactions/fees.mdx
@@ -52,8 +52,8 @@ Read more about the base fee in the [Ethereum.org documentation](https://ethereu
 Just like on Ethereum, OP Mainnet transactions can specify a **priority fee**.
 This priority fee is a price per unit of gas that is paid on top of the base fee.
 For example, if the block base fee is 1 gwei and the transaction specifies a priority fee of 1 gwei, the total price per unit of gas is 2 gwei.
-The priority fee is an optional component of the execution gas fee and can technically be set to 0.
-However, while EIP-1559 does not define a minimum priority fee, certain wallets and mempool implementations (like Geth) may enforce a minimum value. Geth, for example, typically hardcodes a minimum of 1 wei but defaults to a configurable minimum of around 1 gwei..
+The priority fee(tip) is an optional component of the execution gas fee and can technically be set to 0.
+However, while EIP-1559 does not define a minimum priority fee, certain wallets and mempool implementations (like Geth) may enforce a minimum value. For instance, Geth typically defaults to a minimum priority fee of 1 gwei, but this can be configured to other values.
 
 **The OP Mainnet sequencer will prioritize transactions with a higher priority fee** and execute them before any transactions with a lower priority fee.
 If transaction speed is important to your application, you may want to set a higher priority fee to ensure that your transaction is included more quickly.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This update clarifies that, although the priority fee in the OP Stack can technically be set to 0, certain wallet and mempool implementations, like Geth, may impose a minimum fee, usually 1 wei or a configurable default of 1 gwei. 


Include a link to any github issues that this may close in the following form:
- Fixes #559 
