### PR TITLE
Collapsing walkthrough section and disabling changed file summary

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,7 +4,8 @@ reviews:
   high_level_summary: false
   poem: false
   review_status: false
-  collapse_walkthrough: false
+  collapse_walkthrough: true
+  changed_files_summary: false
   path_instructions:
     - path: "**/*.mdx"
       instructions: |


### PR DESCRIPTION
CodeRabbit is a bit loud and the `Pull Request Summary` just makes a PR hard to read. I'm in favor of completely removing the summary, but this is a nice stopgap until we come to a decision. 