### PR TITLE
Typo Update content-reuse.md

### DIFF
--- a/notes/content-reuse.md
+++ b/notes/content-reuse.md
@@ -10,7 +10,7 @@ The content directory contains markdown files that can be imported across the ne
 
 Create a `.md` file in the `/content` directory.
 
-### How to Use a Single Reusable Content Components
+### How to Use a Single Reusable Content Component
 
 1. Import it at the top of `.mdx` file:
 


### PR DESCRIPTION
#### Description of the Change:

This PR fixes a typo in the heading for the **"How to Use a Single Reusable Content Components"** section. The word **"Components"** has been corrected to **"Component"** to match the section's focus on a single content component.

#### Importance of the Change:

- The original heading was grammatically incorrect, as the section discusses how to use **one** reusable content component. 
- This change ensures consistency and clarity, making the documentation easier to understand.
- Using the singular form of "Component" aligns the heading with the actual content and improves the overall professionalism of the documentation.

#### Summary:

- Fixed typo in the section title.
- Corrected the plural form to singular to reflect the content accurately.

**This minor correction helps maintain clarity and consistency across the documentation.**

---

This structure highlights the typo fix and explains why it's important for clarity and consistency in the documentation.