### PR TITLE
Fix invalid stroke-width attribute Update Loader.tsx

### DIFF
--- a/components/calculator/Loader.tsx
+++ b/components/calculator/Loader.tsx
@@ -7,7 +7,7 @@ export const Loader: React.FC = () => {
           <circle
             fill="#FF0420"
             stroke="#FF0420"
-            strokeWidth="15
+            strokeWidth="15"
             r="15"
             cx="40"
             cy="65"

--- a/components/calculator/Loader.tsx
+++ b/components/calculator/Loader.tsx
@@ -7,7 +7,7 @@ export const Loader: React.FC = () => {
           <circle
             fill="#FF0420"
             stroke="#FF0420"
-            stroke-width="15"
+            strokeWidth="15
             r="15"
             cx="40"
             cy="65"
@@ -25,7 +25,7 @@ export const Loader: React.FC = () => {
           <circle
             fill="#FF0420"
             stroke="#FF0420"
-            stroke-width="15"
+            strokeWidth="15"
             r="15"
             cx="100"
             cy="65"
@@ -43,7 +43,7 @@ export const Loader: React.FC = () => {
           <circle
             fill="#FF0420"
             stroke="#FF0420"
-            stroke-width="15"
+            strokeWidth="15"
             r="15"
             cx="160"
             cy="65"


### PR DESCRIPTION
#### Description  

This PR addresses an issue in the `Loader` component where the `stroke-width` attribute was incorrectly used in JSX. The attribute `stroke-width` is not valid in JSX, as JSX requires all attributes to be written in `camelCase`. The correct attribute name is `strokeWidth`.

#### Changes Made  

- Replaced all instances of `stroke-width` with the correct `strokeWidth` attribute in the `<circle>` elements.

#### Why This Fix Is Important  

1. **Prevents Potential Rendering Issues**: Using invalid attribute names in JSX can result in the browser ignoring the attribute, causing rendering issues or inconsistent visual behavior.  
2. **Ensures Compatibility**: The correction aligns with React's JSX syntax rules, ensuring the component behaves as expected across different environments.  
3. **Improves Code Consistency**: Following proper naming conventions improves maintainability and reduces the risk of future bugs.  

#### Before  

```tsx
<circle
  fill="#FF0420"
  stroke="#FF0420"
  stroke-width="15" <!-- Incorrect -->
  r="15"
  cx="40"
  cy="65"
/>
```

#### After  

```tsx
<circle
  fill="#FF0420"
  stroke="#FF0420"
  strokeWidth="15" <!-- Corrected -->
  r="15"
  cx="40"
  cy="65"
/>
```

#### Testing  

- Verified that the `Loader` component renders correctly in the browser without warnings or errors.
- Checked animations to confirm that the `strokeWidth` change did not affect visual behavior.

#### Checklist  

- [x] Corrected `stroke-width` to `strokeWidth`.  
- [x] Verified component rendering and functionality.  

#### Notes  

Please review and merge this PR to fix the JSX syntax issue. Let me know if additional changes are required.