### PR TITLE
docs: update SuperchainERC20 deployment guide link

### DIFF
--- a/pages/stack/interop/assets/superchain-erc20.mdx
+++ b/pages/stack/interop/assets/superchain-erc20.mdx
@@ -81,7 +81,7 @@ Application developers must do two things to make their tokens `SuperchainERC20`
 
 For now, application developers should view `SuperchainERC20`as ERC20 tokens with additional built-in functions that allow cross-chain asset movement that will be enabled once Interop goes live.
 
-For step-by-step information on implementing SuperchainERC20, see [Deploy assets using SuperchainERC20](/stack/interop/deploy-superchain-erc20)
+For step-by-step information on implementing SuperchainERC20, see [Deploy assets using SuperchainERC20](/stack/interop/assets/deploy-superchain-erc20)
 
 <Callout type="warning">
   To enable asset interoperability, `SuperchainERC20` must give access to the address where the future `SuperchainERC20Bridge` will live.


### PR DESCRIPTION
Updated the link for the SuperchainERC20 deployment guide to the correct path: `stack/interop/assets/superchain-erc20`.

### References
- Old URL: `/stack/interop/deploy-superchain-erc20`
- New URL: `/stack/interop/assets/superchain-erc20`