### PR TITLE
fix op-deployer commands

### DIFF
--- a/pages/builders/chain-operators/tools/op-deployer.mdx
+++ b/pages/builders/chain-operators/tools/op-deployer.mdx
@@ -138,16 +138,16 @@ Inspect the `state.json` file by navigating to your working directory. With the 
 
 ```
 cd .deployer
-op-deployer --workdir .deployer inspect genesis <l2-chain-id> > genesis.json
-op-deployer --workdir .deployer inspect rollup <l2-chain-id> > rollup.json
+op-deployer inspect genesis --workdir .deployer <l2-chain-id> > genesis.json
+op-deployer inspect rollup --workdir .deployer <l2-chain-id> > rollup.json
 ```
 
 Now that you have your `genesis.json` and `rollup.json` you can spin up a node on your network. You can also use the following inspect subcommands to get additional data:
 
 ```
-op-deployer --workdir .deployer inspect l1 <l2-chain-id> # outputs all L1 contract addresses for an L2 chain
-op-deployer --workdir .deployer inspect deploy-config <l2-chain-id> # outputs the deploy config for an L2 chain
-op-deployer --workdir .deployer inspect l2-semvers <l2-chain-id> # outputs the semvers for all L2 chains
+op-deployer inspect l1 --workdir .deployer <l2-chain-id> # outputs all L1 contract addresses for an L2 chain
+op-deployer inspect deploy-config --workdir .deployer <l2-chain-id> # outputs the deploy config for an L2 chain
+op-deployer inspect l2-semvers --workdir .deployer <l2-chain-id> # outputs the semvers for all L2 chains
 ```
 </Steps>
 


### PR DESCRIPTION
This PR fixes the wrong command line for op-deployer:

```
# ./bin/op-deployer  --workdir .deployer inspect genesis $L2_CHAIN_ID
Incorrect Usage: flag provided but not defined: -workdir

NAME:
   op-deployer - Tool to configure and deploy OP Chains.

USAGE:
   op-deployer [global options] command [command options]

```