### PR TITLE
Typo Update OpProposerDescriptionShort.md

### DIFF
--- a/content/OpProposerDescriptionShort.md
+++ b/content/OpProposerDescriptionShort.md
@@ -1,1 +1,1 @@
-`op-proposer` is the service that submits the output roots to the L1. This is to enable trustless execution of L2-to-L1 messaging and creates the view into the L2 state from the L1's perspective.
+`op-proposer` is the service that submits the output roots to the L1. This is to enable trustless execution of L2-to-L1 messaging and creates the view of the L2 state from the L1's perspective.


### PR DESCRIPTION
### Issue:  
The original sentence uses the preposition **"into"** where **"of"** is more appropriate:  
> "...and creates the view into the L2 state from the L1's perspective."  

### Fix:  
The corrected version replaces **"into"** with **"of"**:  
> **"...and creates the view of the L2 state from the L1's perspective."**  

### Why this fix is important:  
1. **Grammatical accuracy:** The preposition "into" implies movement or direction, which is not appropriate in this context. The correct preposition, "of," properly conveys the idea of a "view of the state."  
2. **Semantic clarity:** Using "of" ensures that the meaning is clear and accurately describes the relationship between the L1 and L2 states.  
3. **Professional documentation:** Correct grammar and precise language improve the quality and readability of technical documentation, fostering trust and professionalism.  

### Changes made:  
- Updated the preposition in the sentence to improve grammatical and semantic accuracy.  

Thank you for reviewing this improvement!