### PR TITLE
Fix grammatical errors in documentation

### DIFF
--- a/pages/404.mdx
+++ b/pages/404.mdx
@@ -1,7 +1,7 @@
 ---
 title: Page Not Found
 lang: en-US
-description: 404 page not found and directs users to submit an git issue.
+description: 404 page not found and directs users to submit a git issue.
 ---
 
 # Page Not Found

--- a/pages/chain/addresses.mdx
+++ b/pages/chain/addresses.mdx
@@ -15,7 +15,7 @@ This reference guide lists all the contract addresses for Mainnet and Testnet, a
 See the [Smart Contracts Overview](/stack/smart-contracts) for high-level details and access to the source code.
 
 <Callout>
-This page is automatically generated from packages in the [superchain-registry](https://github.com/ethereum-optimism/superchain-registry/tree/main) which keeps the content synched and up-to-date.
+This page is automatically generated from packages in the [superchain-registry](https://github.com/ethereum-optimism/superchain-registry/tree/main) which keeps the content synced and up-to-date.
 </Callout>
 
 ## Mainnet

--- a/pages/chain/security/security-policy.mdx
+++ b/pages/chain/security/security-policy.mdx
@@ -11,7 +11,7 @@ import { Callout } from 'nextra/components'
 This page describes general best practices for reporting bugs and provides specific reporting guidelines for OP Stack and OP Mainnet code contained within the [ethereum-optimism](https://github.com/ethereum-optimism) GitHub organization.
 
 <Callout type="error">
-  **Do not** disclose vulnerabilities publicly or by executing them against a production network. If you do, will you not only be putting users at risk, but you will forfeit your right to a reward. Always follow the appropriate reporting pathways as described below.
+  **Do not** disclose vulnerabilities publicly or by executing them against a production network. If you do, you will not only be putting users at risk, but you will forfeit your right to a reward. Always follow the appropriate reporting pathways as described below.
 
   *   **Do not** disclose the vulnerability publicly, for example by filing a public ticket.
   *   **Do not** test the vulnerability on a publicly available network, either the testnet or the mainnet.
@@ -28,7 +28,7 @@ Optimism has a very detailed [Bug Bounty Page on Immunefi](https://immunefi.com/
 
 ### Unscoped bugs
 
-If you think you have found a significant bug or vulnerabilities in OP Stack smart contracts, infrastructure, etc., even if that component is not covered by an existing bug bounty, please report it to via the [OP Mainnet Immunefi program](https://immunefi.com/bounty/optimism/). The impact of any and all reported issues will be considered and the program has previously rewarded security researchers for bugs not within its stated scope.
+If you think you have found a significant bug or vulnerabilities in OP Stack smart contracts, infrastructure, etc., even if that component is not covered by an existing bug bounty, please report it via the [OP Mainnet Immunefi program](https://immunefi.com/bounty/optimism/). The impact of any and all reported issues will be considered and the program has previously rewarded security researchers for bugs not within its stated scope.
 
 ## Reporting other vulnerabilities
 

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -13,7 +13,7 @@ Information about the Optimism Collective's governance, community, and mission c
 
 ## Guides for builders
 
-Whether you're a developer building a app on OP Mainnet, a node operator running an OP Mainnet node, or a chain operator launching your own OP Stack chain, you'll find everything you need to get started right here.
+Whether you're a developer building an app on OP Mainnet, a node operator running an OP Mainnet node, or a chain operator launching your own OP Stack chain, you'll find everything you need to get started right here.
 
 <Cards>
   <Card title="App developers" href="/builders/app-developers/overview" icon={<img src="img/icons/terminal-window-line.svg" />} />


### PR DESCRIPTION
Article corrections:
 "submit an git issue" → "submit a git issue"
 "building a app" → "building an app"
Word spelling fixes:
 "synched" → "synced"
Sentence structure improvements:
 Removed redundant "to" in "report it to via" → "report it via"
 Fixed conditional clause: "If you do, will you not only" → "If you do, you will not only"

These changes improve readability and maintain professional quality of the documentation without affecting any technical content.