### PR TITLE
holocene-changes: Update Sepolia MIPS address

### DIFF
--- a/pages/builders/notices/holocene-changes.mdx
+++ b/pages/builders/notices/holocene-changes.mdx
@@ -44,7 +44,7 @@ Since the Holocene upgrade changes the execution and derivation rules, the versi
 
 The `FaultDisputeGame` and `PermissionedDisputeGame` contracts must be deployed separately for each chain. The `MIPS` contract implementation can be shared by all chains and is deployed at:
 
-*   Sepolia: `0x6f86b56d26F60a86Ccd13048993C1cE410565DC1`
+*   Sepolia: `0x62254B31DBC258aD27472aB08A7920B410734791`
 *   Mainnet: TBD
 
 Chain operators need to update the `DisputeGameFactory` to use the new `FaultDisputeGame` and `PermissionedDisputeGame` contracts by calling `DisputeGameFactory.setImplementation`. The same upgrade script in the monorepo can be used to facilitate the upgrade, please follow the instructions in this [README](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.8.0-rc.2/packages/contracts-bedrock/scripts/upgrades/holocene/README.md).


### PR DESCRIPTION
The existing MIPS was only useable for the devnet because testnet chains use a different preimage oracle. This new MIPS address uses the existing preimage oracle for Sepolia OP Chains.
