### PR TITLE
holocene-changes: Link to latest upgrade script

### DIFF
--- a/pages/builders/notices/holocene-changes.mdx
+++ b/pages/builders/notices/holocene-changes.mdx
@@ -31,12 +31,14 @@ For more information on the Holocene implementation details, please review [Holo
 
 Chain operators should upgrade their nodes ahead of the activation times to a release that contains the Holocene changes and has the activation times for their chains baked in, or set the activation times manually via overrides.
 
-Besides this, chain operators must upgrade their chain's `SystemConfig` to the latest OP Contracts [v1.8.0-rc.2 release](https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.8.0-rc.2) to utilize the EIP-1559 configurability. The updated `SystemConfig` implementations are deployed at addresses:
+Besides this, several L1 contract updates must be performed, some before and some after Holocene activation. We have prepared an [upgrade script](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts-bedrock/scripts/upgrades/holocene) to automate most of the deployments and superchain-ops task generation or Safe multi-sig input bundle generation.
+
+Chain operators must upgrade their chain's `SystemConfig` to the latest OP Contracts [v1.8.0-rc.2 release](https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.8.0-rc.2) to utilize the EIP-1559 configurability. The updated `SystemConfig` implementations are deployed at addresses:
 
 *   Sepolia: `0x29d06Ed7105c7552EFD9f29f3e0d250e5df412CD`
 *   Mainnet: TBD
 
-Chain operators need to update their proxy contracts to point to these new implementations. An upgrade script in the monorepo can be used to facilitate the upgrade, please follow the instructions in this [README](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.8.0-rc.2/packages/contracts-bedrock/scripts/upgrades/holocene/README.md). Note that it is recommended to upgrade the SystemConfig after the Holocene activation. You need to upgrade if you want to reconfigure your EIP-1559 parameters.
+Chain operators need to update their proxy contracts to point to these new implementations. The upgrade script in the monorepo can be used to facilitate the upgrade, please follow the instructions in this [README](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts-bedrock/scripts/upgrades/holocene/README.md). Note that it is recommended to upgrade the `SystemConfig` after the Holocene activation. You need to upgrade if you want to reconfigure your EIP-1559 parameters.
 
 ### For fault proof enabled chains
 
@@ -47,7 +49,7 @@ The `FaultDisputeGame` and `PermissionedDisputeGame` contracts must be deployed 
 *   Sepolia: `0x62254B31DBC258aD27472aB08A7920B410734791`
 *   Mainnet: TBD
 
-Chain operators need to update the `DisputeGameFactory` to use the new `FaultDisputeGame` and `PermissionedDisputeGame` contracts by calling `DisputeGameFactory.setImplementation`. The same upgrade script in the monorepo can be used to facilitate the upgrade, please follow the instructions in this [README](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.8.0-rc.2/packages/contracts-bedrock/scripts/upgrades/holocene/README.md).
+Chain operators need to update the `DisputeGameFactory` to use the new `FaultDisputeGame` and `PermissionedDisputeGame` contracts by calling `DisputeGameFactory.setImplementation`. The same upgrade script in the monorepo can be used to facilitate the upgrade, please follow the instructions in this [README](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts-bedrock/scripts/upgrades/holocene/README.md).
 
 ## For node operators
 


### PR DESCRIPTION
The linked upgrade script was at the contracts tag. But we've actively developing the script, so we should always point to the latest script. The script itself checks out the contracts tag, so it's fine to always use the latest script.
