### PR TITLE
Fix typos and remove duplicate entries Changes Made

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_audit_results.md
+++ b/.github/ISSUE_TEMPLATE/docs_audit_results.md
@@ -104,7 +104,7 @@ op-conductor
 fp-contracts
 cannon
 op-program
-asterisc
+asterisk
 kona
 superchain-registry
 supersim
@@ -125,7 +125,6 @@ devops-tooling
 artifacts-packaging
 sequencer-in-a-box
 devnets
-op-supervisor
 performance-tooling
 peer-management-service
 proxyd

--- a/notes/resources.md
+++ b/notes/resources.md
@@ -1,6 +1,6 @@
 # Public Resources Folder
 
-Non-text resources like JSON files that are designed to be made available publicly should sit within the [public/resourcs](/public/resources/) folder at the root of this repository.
+Non-text resources like JSON files that are designed to be made available publicly should sit within the [public/resources](/public/resources/) folder at the root of this repository.
 Files within this folder can be referenced by linking to `/resources/path/to/file` as if the `resources` folder existed at the root level of the project, similar to the way that images are referenced by linking to `/img/path/to/image`.
 Nextra will automatically handle the translation of these links to the `/resources` folder to point to the actual `/public/resources` folder.
 The [Lychee](./lychee.md) configuration file found at [lychee.toml](/lychee.toml) includes a remapping that will allow Lychee to correctly check for these resources during the link checking CI step.


### PR DESCRIPTION
1. .github/ISSUE_TEMPLATE/docs_audit_results.md
- Fixed spelling: asterisc → asterisk
- Removed duplicate component tag entry: op-supervisor (listed twice in component tags section)
2. notes/resources.md
- Fixed typo: resourcs → resources in the file path
