### PR TITLE
Clarify Comment on Removing Duplicate L1 Tokens Update TokenListTable…

### DIFF
--- a/components/TokenListTable.tsx
+++ b/components/TokenListTable.tsx
@@ -39,7 +39,7 @@ export function TokenListTable({
               return a.symbol.localeCompare(b.symbol)
             })
             .reduce((acc, token) => {
-              // Remove any duplicate L1 tokens
+              // Remove duplicate L1 tokens by address
               if (acc.some((other) => {
                 return other.address === token.address
               })) {


### PR DESCRIPTION
**Description:**

This pull request addresses a small but important improvement in the clarity of a comment in the code.

In the original code, the comment:

```ts
// Remove any duplicate L1 tokens
```

Can be made more specific. To enhance readability and precision, the comment has been updated to:

```ts
// Remove duplicate L1 tokens by address
```

**Why this is important:**
The updated comment clarifies that duplicates are being removed based on the token's address, rather than a vague reference to "any duplicate." This improvement ensures that the code's behavior is more clearly communicated, making it easier for developers to understand the intent of the logic and maintain the code effectively.