### PR TITLE
Fixing broken proxyd link

### DIFF
--- a/pages/builders/chain-operators/architecture.mdx
+++ b/pages/builders/chain-operators/architecture.mdx
@@ -56,7 +56,7 @@ requests from your users. The Sequencer node has the important job of working wi
 the batcher to handle block creation. To allow the Sequencer to focus on that job,
 you can peer replica nodes to handle the rest of the work.
 
-An example of this would be to configure [proxyd](https://github.com/ethereum-optimism/optimism/tree/develop/proxyd)
+An example of this would be to configure [proxyd](https://github.com/ethereum-optimism/infra/tree/main/proxyd)
 to route RPC methods, retry failed requests, load balance, etc. Users sending
 `eth_sendRawTransaction` requests can have their requests forwarded directly to the
 Sequencer. All other RPC requests can be forwarded to replica nodes.


### PR DESCRIPTION
Updating broken proxyd link

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

It looks like the linked proxyd path was moved a few weeks ago by https://github.com/ethereum-optimism/optimism/pull/12826

This small change links to the updated infra repo.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
