### PR TITLE
op-deployer: Remove source build instructions

### DIFF
--- a/pages/builders/chain-operators/tools/op-deployer.mdx
+++ b/pages/builders/chain-operators/tools/op-deployer.mdx
@@ -18,29 +18,6 @@ The recommended way to install `op-deployer` is to download the latest release f
 for your platform then extract it somewhere on your `PATH`. The rest of this tutorial will assume that you have
 installed `op-deployer` using this method.
 
-To alternatively install from source, follow the steps below. You will need to install the Go toolchain and `just` as prerequisites.
-
-<Steps>
-    ### **Clone the monorepo**:
-
-    Run the following command to clone the monorepo:
-
-    ```bash
-    git clone https://github.com/ethereum-optimism/optimism.git
-    ```
-
-    ### **Build the binary**:
-
-    Run the following commands to build the binary:
-
-    ```bash
-    cd op-deployer
-    just build
-    ```
-
-    The binary will be in the `bin` directory.
-</Steps>
-
 ## Deployment usage
 
 The base use case for `op-deployer` is deploying new OP Chains. This process is broken down into three steps:


### PR DESCRIPTION
These were causing confusion, since the source build instructions were much bigger than the (recommended) binary build instructions.
