### PR TITLE
Fixed typoes in dev-node.mdx

### DIFF
--- a/pages/chain/testing/dev-node.mdx
+++ b/pages/chain/testing/dev-node.mdx
@@ -63,7 +63,7 @@ optimism_package:
           - el_type: op-reth
       network_params:
         name: rollup-1 # can be anything as long as it is unique
-        chain_id: 12345 # can be anything as long as it is unique
+        network_id: 12345 # can be anything as long as it is unique
 ```
 
 Save the above configuration to a file. For the rest of this tutorial, we'll assume you've saved it to `network-config.yaml`.
@@ -73,7 +73,7 @@ Save the above configuration to a file. For the rest of this tutorial, we'll ass
 Now that you've configured your network, you can start it up using the Kurtosis CLI. Run the command below:
 
 ```bash
-kurtosis run github.com/ethpandaops/ethereum-package --args-file ./network-config.yml
+kurtosis run github.com/ethpandaops/optimism-package --args-file ./network-config.yaml
 ```
 
 This command will start up your network and deploy the OP Stack based on the configuration you created. The command will


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Fixed typos and invalid network-config.yaml in [Running a Local Development Environment](https://docs.optimism.io/chain/testing/dev-node).



**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

I can confirm that the fixed `network-config.yaml` gave me the successful kurtosis result.



**Additional context**

<!--
Add any other context about the problem you're solving.
-->

I followed this guide and tried setting up a local optimism node, but encountered the following error.
https://docs.optimism.io/chain/testing/dev-node

```
$ kurtosis run github.com/ethpandaops/ethereum-package --args-file ./network-config.yaml
INFO[2024-11-26T16:58:45-08:00] Creating a new enclave for Starlark to run inside...
INFO[2024-11-26T16:58:47-08:00] Enclave 'muddy-canyon' created successfully
There was an error interpreting Starlark code 
Evaluation error: fail: Invalid parameter optimism_package, allowed fields ["participants", "participants_matrix", "network_params", "dora_params", "tx_spammer_params", "goomy_blob_params", "prometheus_params", "grafana_params", "assertoor_params", "mev_params", "xatu_sentry_params", "port_publisher", "wait_for_finalization", "global_log_level", "snooper_enabled", "ethereum_metrics_exporter_enabled", "parallel_keystore_generation", "disable_peer_scoring", "persistent", "mev_type", "xatu_sentry_enabled", "apache_port", "global_tolerations", "global_node_selectors", "keymanager_enabled", "checkpoint_sync_enabled", "checkpoint_sync_url", "additional_services"]
        at [github.com/ethpandaops/ethereum-package/main.star:83:57]: run
        at [github.com/ethpandaops/ethereum-package/src/package_io/input_parser.star:89:30]: input_parser
        at [github.com/ethpandaops/ethereum-package/src/package_io/sanity_check.star:359:17]: sanity_check
        at [0:0]: fail

Error encountered running Starlark code.
```

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->

none