### PR TITLE
Added new page for Data Indexers under pages/builders/tools/monitor

### DIFF
--- a/pages/builders/tools/monitor.mdx
+++ b/pages/builders/tools/monitor.mdx
@@ -16,4 +16,6 @@ This section provides information on analytics tools and accessing pre regenesis
   <Card title="Analytics tools" href="/builders/tools/monitor/analytics-tools" />
 
   <Card title="Accessing pre Regenesis history" href="/builders/tools/monitor/regenesis-history" />
+
+  <Card title="Data Indexers" href="/builders/tools/monitor/data-indexers" />
 </Cards>

--- a/pages/builders/tools/monitor/data-indexers.mdx
+++ b/pages/builders/tools/monitor/data-indexers.mdx
@@ -1,0 +1,34 @@
+---
+title: Data Indexers
+lang: en-US
+description: Learn about data indexers you can use to easily read blockchain data from your dapp. 
+---
+
+# Data Indexers
+
+Data indexing is essential for enabling your dApp to efficiently read blockchain data. While blockchains are designed for seamless data writing, reading data can be challenging—especially when dealing with large volumes or requiring data transformation.
+
+Below is a list of indexing providers that can help you index data for your smart contract on Optimism.
+
+## Decentralized Providers
+
+### The Graph
+
+[The Graph](https://thegraph.com/) is an indexing protocol that provides an easy way to query blockchain data through APIs known as subgraphs.
+
+With The Graph, you can benefit from:
+
+*   Decentralized Indexing: Improves redundancy and query speed. Lets you eliminate any single point of failure.
+*   GraphQL Queries: Provides a powerful GraphQL interface for querying indexed data, making data retrieval super simple.
+*   Customization: Define your own logic for transforming & storing blockchain data. Reuse subgraphs published by other developers on The Graph Network.
+
+Follow this [quick-start](https://thegraph.com/docs/en/quick-start/) guide to create, deploy, and query a subgraph within 5 minutes.
+
+**Supported Networks**
+
+*   Optimism Mainnet
+*   Optimism Sepolia
+
+## SaaS Providers
+
+(Coming soon)

--- a/words.txt
+++ b/words.txt
@@ -10,6 +10,7 @@ Allnodes
 Allocs
 allocs
 ANDI
+Ankr
 Apeworx
 Arweave
 authrpc
@@ -76,7 +77,6 @@ datadir
 Devnet
 devnet
 devnets
-Devnode
 devx
 direnv
 DISABLETXPOOLGOSSIP
@@ -148,6 +148,7 @@ holesky
 IERC
 IGNOREPRICE
 ignoreprice
+Immunefi
 implicity
 Inator
 inator
@@ -195,6 +196,7 @@ minsuggestedpriorityfee
 Mintable
 Mintplex
 MIPSEVM
+Mitigations
 Monitorism
 Moralis
 Mordor
@@ -289,6 +291,8 @@ Proxied
 Proxyd
 proxyd
 pseudorandomly
+Pyth
+Pyth's
 QRNG
 Quicknode
 quicknode
@@ -321,6 +325,9 @@ runbooks
 RWAs
 safedb
 Schnorr
+SEPOLIA
+Sepolia
+sepolia
 seqnr
 SEQUENCERHTTP
 sequencerhttp
@@ -362,7 +369,7 @@ SYNCTARGET
 synctarget
 syscalls
 therealbytes
-Thirdweb
+thirdweb
 threadcreate
 tility
 timeseries
@@ -390,6 +397,7 @@ VMDEBUG
 vmdebug
 VMODULE
 vmodule
+voxel
 Warpcast
 xlarge
 XORI
@@ -398,12 +406,3 @@ ZKPs
 ZKVM
 Zora
 zora
-Sepolia
-voxel
-SEPOLIA
-sepolia
-Pyth
-Pyth's
-Ankr
-Mitigations
-Immunefi


### PR DESCRIPTION
**Description**

This adds a new page for "data indexers" under pages/builders/tools/monitor. 
It includes a short guide on The Graph. 
Other providers can easily contribute to the same page.

**Tests**

Sucessfully ran the following:

- pnpm fix
- pnpm spellcheck:lint

Was able to run locally with `pnpm dev`
