### PR TITLE
op-deployer: fix inspect commands

### DIFF
--- a/pages/builders/chain-operators/tools/op-deployer.mdx
+++ b/pages/builders/chain-operators/tools/op-deployer.mdx
@@ -111,12 +111,11 @@ address as other chains on the Superchain.
   To add your chain to the [Superchain Registry](https://github.com/ethereum-optimism/superchain-registry) you will need to provide the chain artifacts. To get these chain artifacts, you will need to write the output of these commands to new files.
 </Callout>
 
-Inspect the `state.json` file by navigating to your working directory. With the contracts deployed, generate the genesis and rollup configuration files by running the following commands:"
+Inspect the `state.json` file by navigating to your working directory. With the contracts deployed, generate the genesis and rollup configuration files by running the following commands:
 
 ```
-cd .deployer
-op-deployer inspect genesis --workdir .deployer <l2-chain-id> > genesis.json
-op-deployer inspect rollup --workdir .deployer <l2-chain-id> > rollup.json
+op-deployer inspect genesis --workdir .deployer <l2-chain-id> > .deployer/genesis.json
+op-deployer inspect rollup --workdir .deployer <l2-chain-id> > .deployer/rollup.json
 ```
 
 Now that you have your `genesis.json` and `rollup.json` you can spin up a node on your network. You can also use the following inspect subcommands to get additional data:


### PR DESCRIPTION
The `op-deployer inspect` subcommand doesn't expect to be run from inside the `workdir`, so this removes the instruction to change to the working directory before running the subcommand. 