### PR TITLE
Move USDC Section to OP Mainnet-Specific

### DIFF
--- a/pages/builders/app-developers/bridging/standard-bridge.mdx
+++ b/pages/builders/app-developers/bridging/standard-bridge.mdx
@@ -239,13 +239,12 @@ The address of this entry is the address of the bridged representation of the to
 
 ## Special considerations
 
-### USDC
+### USDC on OP Mainnet
 
-[Circle](https://www.circle.com/en/), the issuer of [USDC](https://www.circle.com/en/usdc?gad_source=1), natively issues USDC on OP Mainnet [as of September 2023](https://www.circle.com/blog/what-you-need-to-know-native-usdc-on-op-mainnet).
-Before this service was made available, USDC had to be bridged to OP Mainnet via the Standard Bridge.
-This bridged representation of USDC is referred to as `USDC.e`.
-
-Circle recommends that users and developers make use of the native version of USDC issued by Circle over the bridged `USDC.e` token.  Please note that the bridged `USDC.e` token will be deprecated in the near future.
+<Callout type="warning">
+The legacy bridged version of USDC (USDC.e) at address `0x7f5c764cbc14f9669b88837ca1490cca17c31607` is being deprecated on OP Mainnet. 
+Users and developers should migrate to using the native USDC token issued directly by [Circle](https://www.circle.com/en/), the issuer of [USDC](https://www.circle.com/en/usdc?gad_source=1).
+</Callout>
 
 Information about the bridged `USDC.e` token and native USDC token can be found below.
 

--- a/pages/builders/app-developers/bridging/standard-bridge.mdx
+++ b/pages/builders/app-developers/bridging/standard-bridge.mdx
@@ -236,19 +236,3 @@ Find the entry that matches the name and symbol of the token you want to bridge 
 The address of this entry is the address of the bridged representation of the token you want to bridge.
 
 </Steps>
-
-## Special considerations
-
-### USDC on OP Mainnet
-
-<Callout type="warning">
-The legacy bridged version of USDC (USDC.e) at address `0x7f5c764cbc14f9669b88837ca1490cca17c31607` is being deprecated on OP Mainnet. 
-Users and developers should migrate to using the native USDC token issued directly by [Circle](https://www.circle.com/en/), the issuer of [USDC](https://www.circle.com/en/usdc?gad_source=1).
-</Callout>
-
-Information about the bridged `USDC.e` token and native USDC token can be found below.
-
-| Symbol   | Description                  | Address                                                                                                                          |
-| -------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `USDC.e` | Bridged USDC from Ethereum   | [`0x7f5c764cbc14f9669b88837ca1490cca17c31607`](https://optimistic.etherscan.io/token/0x7f5c764cbc14f9669b88837ca1490cca17c31607) |
-| `USDC`   | Native USDC issued by Circle | [`0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85`](https://optimistic.etherscan.io/token/0x0b2c639c533813f4aa9d7837caf62653d097ff85) |

--- a/pages/builders/app-developers/bridging/standard-bridge.mdx
+++ b/pages/builders/app-developers/bridging/standard-bridge.mdx
@@ -191,11 +191,11 @@ The Standard Bridge contracts can also be used to bridge ETH from Ethereum to OP
 The ETH bridging process is generally less complex than the ERC-20 bridging process.
 Users simply need to trigger and send ETH to the [`bridgeETH`](https://github.com/ethereum-optimism/optimism/blob/2e647210882d961f04055e656590d90ad98c9934/packages/contracts-bedrock/src/universal/StandardBridge.sol#L143-L150) or [`bridgeETHTo`](https://github.com/ethereum-optimism/optimism/blob/2e647210882d961f04055e656590d90ad98c9934/packages/contracts-bedrock/src/universal/StandardBridge.sol#L152-L166) functions on either blockchain.
 
-  <Callout>
-    Users can also deposit ETH from Ethereum to OP Mainnet by sending a basic ETH transfer from an EOA to the `L1StandardBridgeProxy`. 
-    This works because the `L1StandardBridgeProxy` contains a [`receive`](https://github.com/ethereum-optimism/optimism/blob/2e647210882d961f04055e656590d90ad98c9934/packages/contracts-bedrock/src/universal/StandardBridge.sol#L119-L121) function.
-    You can find the mainnet and testnet addresses on the [Contract Addresses](/chain/addresses) page.
-  </Callout>
+<Callout>
+  Users can also deposit ETH from Ethereum to OP Mainnet by sending a basic ETH transfer from an EOA to the `L1StandardBridgeProxy`.
+  This works because the `L1StandardBridgeProxy` contains a [`receive`](https://github.com/ethereum-optimism/optimism/blob/2e647210882d961f04055e656590d90ad98c9934/packages/contracts-bedrock/src/universal/StandardBridge.sol#L119-L121) function.
+  You can find the mainnet and testnet addresses on the [Contract Addresses](/chain/addresses) page.
+</Callout>
 
 ## Tutorials
 
@@ -221,18 +221,16 @@ You can easily find the bridged representation of a token for OP Mainnet on the 
 If you want to find the bridged representation of a token for another chain, use the following steps.
 
 <Steps>
+  {<h3>Find the token you want to bridge</h3>}
 
-{<h3>Find the token you want to bridge</h3>}
+  The Superchain Token List is organized by the token's address and native blockchain.
+  [Search the token list](https://github.com/ethereum-optimism/ethereum-optimism.github.io/blob/master/optimism.tokenlist.json) for the token you want to bridge to confirm that it's included in the list.
+  Make sure that the chain ID in the entry matches the chain ID of the blockchain you're bridging from.
+  Retrieve the token's name and symbol from the list.
 
-The Superchain Token List is organized by the token's address and native blockchain.
-[Search the token list](https://github.com/ethereum-optimism/ethereum-optimism.github.io/blob/master/optimism.tokenlist.json) for the token you want to bridge to confirm that it's included in the list.
-Make sure that the chain ID in the entry matches the chain ID of the blockchain you're bridging from.
-Retrieve the token's name and symbol from the list.
+  {<h3>Find the bridged representation of the token</h3>}
 
-{<h3>Find the bridged representation of the token</h3>}
-
-Once you've found the token you want to bridge, look for the token's name and symbol in the list.
-Find the entry that matches the name and symbol of the token you want to bridge and where the chain ID matches the chain ID of the blockchain you're bridging to.
-The address of this entry is the address of the bridged representation of the token you want to bridge.
-
+  Once you've found the token you want to bridge, look for the token's name and symbol in the list.
+  Find the entry that matches the name and symbol of the token you want to bridge and where the chain ID matches the chain ID of the blockchain you're bridging to.
+  The address of this entry is the address of the bridged representation of the token you want to bridge.
 </Steps>

--- a/pages/chain/tokenlist.mdx
+++ b/pages/chain/tokenlist.mdx
@@ -18,6 +18,21 @@ This page is automatically generated from the Superchain Token List.
   **The presence of a token on this page does not imply any endorsement of the token or its minter.**
 </Callout>
 
+### USDC on OP Mainnet
+
+<Callout type="warning">
+The legacy bridged version of USDC (USDC.e) at address `0x7f5c764cbc14f9669b88837ca1490cca17c31607` is being deprecated on OP Mainnet. 
+Users and developers should migrate to using the native USDC token issued directly by [Circle](https://www.circle.com/en/), the issuer of [USDC](https://www.circle.com/en/usdc?gad_source=1).
+</Callout>
+
+Information about the bridged `USDC.e` token and native USDC token can be found below.
+
+| Symbol   | Description                  | Address                                                                                                                          |
+| -------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `USDC.e` | Bridged USDC from Ethereum   | [`0x7f5c764cbc14f9669b88837ca1490cca17c31607`](https://optimistic.etherscan.io/token/0x7f5c764cbc14f9669b88837ca1490cca17c31607) |
+| `USDC`   | Native USDC issued by Circle | [`0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85`](https://optimistic.etherscan.io/token/0x0b2c639c533813f4aa9d7837caf62653d097ff85) |
+
+
 ## OP Mainnet
 
 <TokenListTable l1="1" l2="10" />

--- a/pages/chain/tokenlist.mdx
+++ b/pages/chain/tokenlist.mdx
@@ -20,7 +20,7 @@ This page is automatically generated from the Superchain Token List.
 
 ### USDC on OP Mainnet
 
-<Callout type="warning">
+<Callout>
 The legacy bridged version of USDC (USDC.e) at address `0x7f5c764cbc14f9669b88837ca1490cca17c31607` is being deprecated on OP Mainnet. 
 Users and developers should migrate to using the native USDC token issued directly by [Circle](https://www.circle.com/en/), the issuer of [USDC](https://www.circle.com/en/usdc?gad_source=1).
 </Callout>


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR reorganizes the standard bridge section to improve clarity around USDC usage on OP Mainnet. The existing section on USDC in the Standard Bridge documentation has been moved to a dedicated "USDC on OP Mainnet" subsection to reduce confusion for chain operators.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
