### PR TITLE
fix variable name $PRIVATE_KEY

### DIFF
--- a/pages/builders/app-developers/tutorials/standard-bridge-standard-token.mdx
+++ b/pages/builders/app-developers/tutorials/standard-bridge-standard-token.mdx
@@ -88,7 +88,7 @@ Use the `cast` command to trigger the deployment function on the factory contrac
 This example command creates a token with the name "My Standard Demo Token" and the symbol "L2TKN".
 The resulting L2 ERC-20 token address is printed to the console.
 
-```bash file=<rootDir>/public/tutorials/standard-bridge-standard-token.sh#L6 hash=9380086a28ce906ab47d6c1b1e2c8688
+```bash file=<rootDir>/public/tutorials/standard-bridge-standard-token.sh#L6 hash=1ecfdc6106e0c5179b182d66b5171c2c
 ```
 
 </Steps>

--- a/public/tutorials/standard-bridge-standard-token.sh
+++ b/public/tutorials/standard-bridge-standard-token.sh
@@ -3,4 +3,4 @@ export TUTORIAL_RPC_URL=https://sepolia.optimism.io
 # Replace this with your L1 ERC-20 token if not using the testing token!
 export TUTORIAL_L1_ERC20_ADDRESS=0x5589BB8228C07c4e15558875fAf2B859f678d129
 
-cast send 0x4200000000000000000000000000000000000012 "createOptimismMintableERC20(address,string,string)" $TUTORIAL_L1_ERC20_ADDRESS "My Standard Demo Token" "L2TKN" --private-key $PRIVATE_KEY --rpc-url $TUTORIAL_RPC_URL --json | jq -r '.logs[0].topics[2]' | cast parse-bytes32-address
+cast send 0x4200000000000000000000000000000000000012 "createOptimismMintableERC20(address,string,string)" $TUTORIAL_L1_ERC20_ADDRESS "My Standard Demo Token" "L2TKN" --private-key $TUTORIAL_PRIVATE_KEY --rpc-url $TUTORIAL_RPC_URL --json | jq -r '.logs[0].topics[2]' | cast parse-bytes32-address


### PR DESCRIPTION



<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->
Before this fix, the script referred to the private key in variable named $PRIVATE_KEY while it's declared as $TUTORIAL_PRIVATE_KEY at the beginning of the tutorial.

Hence, the code snippet won't work for someone following the whole tutorial from beginning to end.

This change replaces the variable in the snippet to be $TUTORIAL_PRIVATE_KEY so it can be copy-pasted and work.


**Additional context**

<!--
Add any other context about the problem you're solving.
-->
- tutorial : https://docs.optimism.io/builders/app-developers/tutorials/standard-bridge-standard-token

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
-->
- Fixes #1163
