### PR TITLE
Docs Update: Add Reown to the "Account Abstraction" doc page

### DIFF
--- a/pages/builders/tools/build/account-abstraction.mdx
+++ b/pages/builders/tools/build/account-abstraction.mdx
@@ -48,8 +48,7 @@ Ready to enable account abstraction experiences in your app? Here's some helpful
 
 *   [Pimlico](https://docs.pimlico.io/): provides an infrastructure platform that makes building smart accounts simpler. If you are developing, an ERC-4337 smart account, they provide bundlers, verifying paymasters, ERC-20 paymasters, and much more.
 
-*   [Reown](https://reown.com/?utm_source=optimism&utm_medium=docs&utm_campaign=backlinks)** gives developers the tools to build user experiences that make digital ownership effortless, intuitive, and secure. Using Reown's AppKit SDK, you can enable your users to create a smart wallet using their social logins. 
-
+*   [Reown](https://reown.com/?utm_source=optimism&utm_medium=docs&utm_campaign=backlinks) gives developers the tools to build user experiences that make digital ownership effortless, intuitive, and secure. Using Reown's AppKit SDK, you can enable your users to create a smart wallet using their social logins.
 *   [Safe](https://docs.safe.global/home/what-is-safe): provides modular smart account infrastructure and account abstraction stack via their Safe\{Core\} Account Abstraction SDK, API, and Protocol.
 
 *   [Stackup](https://docs.stackup.sh/docs): provides smart account tooling for building account abstraction within your apps. They offer Paymaster and Bundler APIs for sponsoring gas and sending account abstraction transactions.

--- a/pages/builders/tools/build/account-abstraction.mdx
+++ b/pages/builders/tools/build/account-abstraction.mdx
@@ -48,6 +48,8 @@ Ready to enable account abstraction experiences in your app? Here's some helpful
 
 *   [Pimlico](https://docs.pimlico.io/): provides an infrastructure platform that makes building smart accounts simpler. If you are developing, an ERC-4337 smart account, they provide bundlers, verifying paymasters, ERC-20 paymasters, and much more.
 
+*   [Reown](https://reown.com/?utm_source=optimism&utm_medium=docs&utm_campaign=backlinks)** gives developers the tools to build user experiences that make digital ownership effortless, intuitive, and secure. Using Reown's AppKit SDK, you can enable your users to create a smart wallet using their social logins. 
+
 *   [Safe](https://docs.safe.global/home/what-is-safe): provides modular smart account infrastructure and account abstraction stack via their Safe\{Core\} Account Abstraction SDK, API, and Protocol.
 
 *   [Stackup](https://docs.stackup.sh/docs): provides smart account tooling for building account abstraction within your apps. They offer Paymaster and Bundler APIs for sponsoring gas and sending account abstraction transactions.

--- a/pages/builders/tools/build/account-abstraction.mdx
+++ b/pages/builders/tools/build/account-abstraction.mdx
@@ -48,7 +48,8 @@ Ready to enable account abstraction experiences in your app? Here's some helpful
 
 *   [Pimlico](https://docs.pimlico.io/): provides an infrastructure platform that makes building smart accounts simpler. If you are developing, an ERC-4337 smart account, they provide bundlers, verifying paymasters, ERC-20 paymasters, and much more.
 
-*   [Reown](https://reown.com/?utm_source=optimism&utm_medium=docs&utm_campaign=backlinks) gives developers the tools to build user experiences that make digital ownership effortless, intuitive, and secure. Using Reown's AppKit SDK, you can enable your users to create a smart wallet using their social logins.
+*   [Reown](https://reown.com/?utm_source=optimism&utm_medium=docs&utm_campaign=backlinks) gives developers the tools to build user experiences that make digital ownership effortless, intuitive, and secure. Using Reown's AppKit SDK, you can enable your users to create a smart wallet using their social logins, configure a paymaster to sponsor gas fees, enable chain abstraction and a lot more.
+
 *   [Safe](https://docs.safe.global/home/what-is-safe): provides modular smart account infrastructure and account abstraction stack via their Safe\{Core\} Account Abstraction SDK, API, and Protocol.
 
 *   [Stackup](https://docs.stackup.sh/docs): provides smart account tooling for building account abstraction within your apps. They offer Paymaster and Bundler APIs for sponsoring gas and sending account abstraction transactions.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR adds adds Reown to the account abstraction doc page.

**Tests**

N/A

