### PR TITLE
Update RPC ports in op-conductor.mdx examples

### DIFF
--- a/pages/builders/chain-operators/tools/op-conductor.mdx
+++ b/pages/builders/chain-operators/tools/op-conductor.mdx
@@ -373,13 +373,13 @@ manually started sequencer.
     ```sh
     curl -X POST -H "Content-Type: application/json" --data \
         '{"jsonrpc":"2.0","method":"conductor_overrideLeader","params":[],"id":1}'  \
-        http://127.0.0.1:50050
+        http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 
   <Tabs.Tab>
     ```sh
-    cast rpc conductor_overrideLeader --rpc-url http://127.0.0.1:50050
+    cast rpc conductor_overrideLeader --rpc-url http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 </Tabs>
@@ -393,13 +393,13 @@ manually started sequencer.
     ```sh
     curl -X POST -H "Content-Type: application/json" --data \
         '{"jsonrpc":"2.0","method":"conductor_pause","params":[],"id":1}'  \
-        http://127.0.0.1:50050
+        http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 
   <Tabs.Tab>
     ```sh
-    cast rpc conductor_pause --rpc-url http://127.0.0.1:50050
+    cast rpc conductor_pause --rpc-url http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 </Tabs>
@@ -413,13 +413,13 @@ manually started sequencer.
     ```sh
     curl -X POST -H "Content-Type: application/json" --data \
         '{"jsonrpc":"2.0","method":"conductor_resume","params":[],"id":1}'  \
-        http://127.0.0.1:50050
+        http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 
   <Tabs.Tab>
     ```sh
-    cast rpc conductor_resume --rpc-url http://127.0.0.1:50050
+    cast rpc conductor_resume --rpc-url http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 </Tabs>
@@ -433,13 +433,13 @@ Paused returns true if the op-conductor is paused.
     ```sh
     curl -X POST -H "Content-Type: application/json" --data \
         '{"jsonrpc":"2.0","method":"conductor_paused","params":[],"id":1}'  \
-        http://127.0.0.1:50050
+        http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 
   <Tabs.Tab>
     ```sh
-    cast rpc conductor_paused --rpc-url http://127.0.0.1:50050
+    cast rpc conductor_paused --rpc-url http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 </Tabs>
@@ -453,13 +453,13 @@ Stopped returns true if the op-conductor is stopped.
     ```sh
     curl -X POST -H "Content-Type: application/json" --data \
         '{"jsonrpc":"2.0","method":"conductor_stopped","params":[],"id":1}'  \
-        http://127.0.0.1:50050
+        http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 
   <Tabs.Tab>
     ```sh
-    cast rpc conductor_stopped --rpc-url http://127.0.0.1:50050
+    cast rpc conductor_stopped --rpc-url http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 </Tabs>
@@ -473,13 +473,13 @@ SequencerHealthy returns true if the sequencer is healthy.
     ```sh
     curl -X POST -H "Content-Type: application/json" --data \
         '{"jsonrpc":"2.0","method":"conductor_sequencerHealthy","params":[],"id":1}'  \
-        http://127.0.0.1:50050
+        http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 
   <Tabs.Tab>
     ```sh
-    cast rpc conductor_sequencerHealthy --rpc-url http://127.0.0.1:50050
+    cast rpc conductor_sequencerHealthy --rpc-url http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 </Tabs>
@@ -497,13 +497,13 @@ Leader returns true if the server is the leader.
     ```sh
     curl -X POST -H "Content-Type: application/json" --data \
         '{"jsonrpc":"2.0","method":"conductor_leader","params":[],"id":1}'  \
-        http://127.0.0.1:50050
+        http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 
   <Tabs.Tab>
     ```sh
-    cast rpc conductor_leader --rpc-url http://127.0.0.1:50050
+    cast rpc conductor_leader --rpc-url http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 </Tabs>
@@ -521,13 +521,13 @@ LeaderWithID returns the current leader's server info.
     ```sh
     curl -X POST -H "Content-Type: application/json" --data \
         '{"jsonrpc":"2.0","method":"conductor_leaderWithID","params":[],"id":1}'  \
-        http://127.0.0.1:50050
+        http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 
   <Tabs.Tab>
     ```sh
-    cast rpc conductor_leaderWithID --rpc-url http://127.0.0.1:50050
+    cast rpc conductor_leaderWithID --rpc-url http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 </Tabs>
@@ -535,7 +535,7 @@ LeaderWithID returns the current leader's server info.
 #### conductor_addServerAsVoter
 
 <Callout type="info">
-  API related to consensus. The address parameter is the raft consensus address, not the RPC address.
+  API related to consensus.
 </Callout>
 
 AddServerAsVoter adds a server as a voter to the cluster. 
@@ -544,14 +544,14 @@ AddServerAsVoter adds a server as a voter to the cluster.
   <Tabs.Tab>
     ```sh
     curl -X POST -H "Content-Type: application/json" --data \
-        '{"jsonrpc":"2.0","method":"conductor_addServerAsVoter","params":[<id>, <addr>, <version>],"id":1}'  \
-        http://127.0.0.1:50050
+        '{"jsonrpc":"2.0","method":"conductor_addServerAsVoter","params":[<id>, <raft-consensus-addr>, <version>],"id":1}'  \
+        http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 
   <Tabs.Tab>
     ```sh
-    cast rpc conductor_addServerAsVoter --rpc-url http://127.0.0.1:50050 <id> <raft-consensus-addr> <version>
+    cast rpc conductor_addServerAsVoter --rpc-url http://127.0.0.1:8547 <id> <raft-consensus-addr> <version>
     ```
   </Tabs.Tab>
 </Tabs>
@@ -570,13 +570,13 @@ The non-voter will not participate in the leader election.
     ```sh
     curl -X POST -H "Content-Type: application/json" --data \
         '{"jsonrpc":"2.0","method":"conductor_addServerAsNonvoter","params":[],"id":1}'  \
-        http://127.0.0.1:50050
+        http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 
   <Tabs.Tab>
     ```sh
-    cast rpc conductor_addServerAsNonvoter --rpc-url http://127.0.0.1:50050
+    cast rpc conductor_addServerAsNonvoter --rpc-url http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 </Tabs>
@@ -594,13 +594,13 @@ RemoveServer removes a server from the cluster.
     ```sh
     curl -X POST -H "Content-Type: application/json" --data \
         '{"jsonrpc":"2.0","method":"conductor_removeServer","params":[],"id":1}'  \
-        http://127.0.0.1:50050
+        http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 
   <Tabs.Tab>
     ```sh
-    cast rpc conductor_removeServer --rpc-url http://127.0.0.1:50050
+    cast rpc conductor_removeServer --rpc-url http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 </Tabs>
@@ -618,13 +618,13 @@ TransferLeader transfers leadership to another server.
     ```sh
     curl -X POST -H "Content-Type: application/json" --data \
         '{"jsonrpc":"2.0","method":"conductor_transferLeader","params":[],"id":1}'  \
-        http://127.0.0.1:50050
+        http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 
   <Tabs.Tab>
     ```sh
-    cast rpc conductor_transferLeader --rpc-url http://127.0.0.1:50050
+    cast rpc conductor_transferLeader --rpc-url http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 </Tabs>
@@ -642,13 +642,13 @@ TransferLeaderToServer transfers leadership to a specific server.
     ```sh
     curl -X POST -H "Content-Type: application/json" --data \
         '{"jsonrpc":"2.0","method":"conductor_transferLeaderToServer","params":[],"id":1}'  \
-        http://127.0.0.1:50050
+        http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 
   <Tabs.Tab>
     ```sh
-    cast rpc conductor_transferLeaderToServer --rpc-url http://127.0.0.1:50050
+    cast rpc conductor_transferLeaderToServer --rpc-url http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 </Tabs>
@@ -662,13 +662,13 @@ ClusterMembership returns the current cluster membership configuration.
     ```sh
     curl -X POST -H "Content-Type: application/json" --data \
         '{"jsonrpc":"2.0","method":"conductor_clusterMembership","params":[],"id":1}'  \
-        http://127.0.0.1:50050
+        http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 
   <Tabs.Tab>
     ```sh
-    cast rpc conductor_clusterMembership --rpc-url http://127.0.0.1:50050
+    cast rpc conductor_clusterMembership --rpc-url http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 </Tabs>
@@ -686,13 +686,13 @@ Active returns true if the op-conductor is active (not paused or stopped).
     ```sh
     curl -X POST -H "Content-Type: application/json" --data \
         '{"jsonrpc":"2.0","method":"conductor_active","params":[],"id":1}'  \
-        http://127.0.0.1:50050
+        http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 
   <Tabs.Tab>
     ```sh
-    cast rpc conductor_active --rpc-url http://127.0.0.1:50050
+    cast rpc conductor_active --rpc-url http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 </Tabs>
@@ -711,13 +711,13 @@ layer.
     ```sh
     curl -X POST -H "Content-Type: application/json" --data \
         '{"jsonrpc":"2.0","method":"conductor_commitUnsafePayload","params":[],"id":1}'  \
-        http://127.0.0.1:50050
+        http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 
   <Tabs.Tab>
     ```sh
-    cast rpc conductor_commitUnsafePayload --rpc-url http://127.0.0.1:50050
+    cast rpc conductor_commitUnsafePayload --rpc-url http://127.0.0.1:8547
     ```
   </Tabs.Tab>
 </Tabs>


### PR DESCRIPTION
**Description**

The RPC examples for op-conductor currently have the default consensus port as the RPC port, which is confusing. This changes the port to line up with the RPC port in the "suggested conductor configs" in the [op-conductor docs](https://docs.optimism.io/builders/chain-operators/tools/op-conductor#spin-up-op-conductor)

+ adds some clarity in describing params in the `conductor_addServerAsVoter` example

**Tests**

Manually tested hitting local op-conductor instances' RPC ports with several examples leads to OK responses:
- `cast rpc conductor_leader --rpc-url http://127.0.0.1:8547`
- `cast conductor_paused --rpc-url http://127.0.0.1:8547`
- `cast rpc conductor_stopped --rpc-url http://127.0.0.1:8547`
- `cast rpc conductor_sequencerHealthy --rpc-url http://127.0.0.1:8547`
- `cast rpc conductor_leaderWithID --rpc-url http://127.0.0.1:8547`
