### PR TITLE
Update explainer.mdx

### DIFF
--- a/pages/stack/interop/explainer.mdx
+++ b/pages/stack/interop/explainer.mdx
@@ -34,10 +34,8 @@ This means ETH and ERC-20s can seamlessly and securely move across L2s, and inte
 ## Low latency
 Interoperability allows for horizontally scalable blockchains, a key feature of the Superchain. With Superchain interop, latency can be 1-block (~2 seconds) by optimistically accepting cross-chain messages. 
 
-## Permissionless dependency set
-The interop protocol works via a dependency set which is configured on a per-chain basis and is a unidirectional relationship that defines the set of chains that a chain will accept incoming messages from. 
-
-This gives the OP Stack an unopinionated and flexible foundation, so chain operators can choose which chains their chains depend on, and it is not a requirement that chains are in each other's dependency set. 
+## Interop clusters
+The interop protocol works via a dependency set which is configured on a per-chain basis. The dependency set defines the set of chains that a chain will accept incoming messages from. To prevent tokens from being sent to a chain that doesn't accept incoming messages, the protocol enforces that messages can only be sent to chains within its dependency set.
 
 ## Superchain interop cluster
 The Superchain builds on top of the interop protocol and implements a single mesh network with complete dependencies. In this model, each blockchain in the Superchain interop cluster would have direct connections to every other blockchain, creating a fully connected mesh network. Compared to a hub and spoke model, this provides the highest level of interoperability, as any blockchain can transact directly with any other.


### PR DESCRIPTION
1-way dependencies were removed via https://github.com/ethereum-optimism/specs/issues/460 to prevent assets from being stuck