### PR TITLE
Update chain configuration overview page

### DIFF
--- a/pages/builders/chain-operators/configuration/overview.mdx
+++ b/pages/builders/chain-operators/configuration/overview.mdx
@@ -18,6 +18,10 @@ documentation for details on configuring each piece.
   
   Deploying your OP Stack contracts requires creating a deployment configuration
   JSON file. This defines the behavior of your network at its genesis.
+  *   **Important Notes:**
+      *   The Rollup Configuration sets parameters for the L1 smart contracts upon deployment. These parameters govern the behavior of your chain and are critical to its operation.
+      *   Be aware that many of these values cannot be changed after deployment or require a complex process to update.
+          Carefully consider and validate all settings during configuration to avoid issues later.
 
   *   [Rollup Configuration Documentation](/builders/chain-operators/configuration/rollup)
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Updated the OP Docs overview page for Chain Operator Configurations to clarify the purpose and implications of the Rollup Configuration. Specifically emphasized that the Rollup Configuration sets parameters for the L1 smart contracts at deployment and noted that many values cannot be changed afterwards or require a complex update process.

**Metadata**

Include a link to any github issues that this may close in the following form:
- Fixes #919
