### PR TITLE
add soneium minato holocene timestamp to holocene notices

### DIFF
--- a/pages/builders/notices/holocene-changes.mdx
+++ b/pages/builders/notices/holocene-changes.mdx
@@ -16,6 +16,8 @@ If you experience difficulty at any stage of this process, please reach out to [
   
   The Holocene upgrade for the Unichain Sepolia will be activated at **Wed Dec 18 at 22:00:00 UTC** (`1734559200`).
 
+  The Holocene upgrade for the Soneium Minato (Sepolia) will be activated at **Fri Dec 20 at 09:00:00 UTC** (`1734685200`).
+
   The Holocene upgrade for the Mainnet Superchain is optimistically scheduled for **Thu 9 Jan 2025 18:00:01 UTC**, [pending governance approval](https://gov.optimism.io/t/upgrade-proposal-11-holocene-network-upgrade/9313).
 </Callout>
 

--- a/words.txt
+++ b/words.txt
@@ -10,6 +10,7 @@ Allnodes
 Allocs
 allocs
 ANDI
+Ankr
 Apeworx
 Arweave
 authrpc
@@ -147,6 +148,7 @@ holesky
 IERC
 IGNOREPRICE
 ignoreprice
+Immunefi
 implicity
 Inator
 inator
@@ -195,6 +197,7 @@ minsuggestedpriorityfee
 Mintable
 Mintplex
 MIPSEVM
+Mitigations
 Monitorism
 Moralis
 Mordor
@@ -289,6 +292,8 @@ Proxied
 Proxyd
 proxyd
 pseudorandomly
+Pyth
+Pyth's
 QRNG
 Quicknode
 quicknode
@@ -321,6 +326,9 @@ runbooks
 RWAs
 safedb
 Schnorr
+SEPOLIA
+Sepolia
+sepolia
 seqnr
 SEQUENCERHTTP
 sequencerhttp
@@ -392,6 +400,7 @@ VMDEBUG
 vmdebug
 VMODULE
 vmodule
+voxel
 Warpcast
 xlarge
 XORI

--- a/words.txt
+++ b/words.txt
@@ -10,7 +10,6 @@ Allnodes
 Allocs
 allocs
 ANDI
-Ankr
 Apeworx
 Arweave
 authrpc
@@ -148,7 +147,6 @@ holesky
 IERC
 IGNOREPRICE
 ignoreprice
-Immunefi
 implicity
 Inator
 inator
@@ -189,6 +187,7 @@ Merkle
 merkle
 MFHI
 MFLO
+Minato
 MINFREEDISK
 minfreedisk
 MINSUGGESTEDPRIORITYFEE
@@ -196,7 +195,6 @@ minsuggestedpriorityfee
 Mintable
 Mintplex
 MIPSEVM
-Mitigations
 Monitorism
 Moralis
 Mordor
@@ -291,8 +289,6 @@ Proxied
 Proxyd
 proxyd
 pseudorandomly
-Pyth
-Pyth's
 QRNG
 Quicknode
 quicknode
@@ -325,9 +321,6 @@ runbooks
 RWAs
 safedb
 Schnorr
-SEPOLIA
-Sepolia
-sepolia
 seqnr
 SEQUENCERHTTP
 sequencerhttp
@@ -339,6 +332,7 @@ SLTIU
 SLTU
 smartcard
 snapshotlog
+Soneium
 soulbound
 soyboy
 spacebar
@@ -398,7 +392,6 @@ VMDEBUG
 vmdebug
 VMODULE
 vmodule
-voxel
 Warpcast
 xlarge
 XORI


### PR DESCRIPTION
**Description**

Add Soneium Minato holocene timestamp to builder's notice page
https://github.com/ethereum-optimism/superchain-registry/pull/787
