### PR TITLE
Fix typos

### DIFF
--- a/pages/builders/chain-operators/architecture.mdx
+++ b/pages/builders/chain-operators/architecture.mdx
@@ -65,7 +65,7 @@ Sequencer. All other RPC requests can be forwarded to replica nodes.
 
 ### proxyd
 
-This tool is a RPC request router and proxy. It does the following things:
+This tool is an RPC request router and proxy. It does the following things:
 
 1.  Whitelists RPC methods.
 2.  Routes RPC methods to groups of backend services.

--- a/pages/builders/chain-operators/management/key-management.mdx
+++ b/pages/builders/chain-operators/management/key-management.mdx
@@ -1,7 +1,7 @@
 ---
 title: Key management
 lang: en-US
-description: A guide for chain operators on managing private keys on their chain, covering hot and cold wallets, and the use of a HSM.
+description: A guide for chain operators on managing private keys on their chain, covering hot and cold wallets, and the use of an HSM.
 ---
 
 import { Callout } from 'nextra/components'


### PR DESCRIPTION
This pull request fixes minor typographical errors in the following files:
- `architecture.mdx`: Corrected "a RPC" to "an RPC" for proper article usage.
- `key-management.mdx`: Corrected "a HSM" to "an HSM" for proper article usage.

## Tests:
No new tests have been added as these changes are purely grammatical and do not affect functionality.

## Additional context:
These changes ensure proper use of articles in English for improved readability and accuracy.
