### PR TITLE
Update link and fix typo

### DIFF
--- a/pages/stack/fault-proofs/explainer.mdx
+++ b/pages/stack/fault-proofs/explainer.mdx
@@ -85,7 +85,7 @@ Assuming OP Mainnet parameters, where proposals will be posted hourly, that's 0.
 Assuming a 7 day dispute window, you'll need roughly 14 ETH (including gas costs) to make proposals.
 If chains are using the similar FP deploy configs as OP Mainnet, it's recommended to stick to a 0.08 ETH initial bond.
 
-However, the capital requirements for operating an FP chain in itself is much larger than 14 ETH.
+However, the capital requirements for operating a FP chain in itself is much larger than 14 ETH.
 An operator that secures their chain using FPs must be willing to stake a lot of ETH to secure the chain.
 One may decide the capital requirements aren't worth it, and use only a Permissioned FP system.
 The capital requirements will be improved in the later stages of Fault Proofs to make it more feasible for smaller chains.

--- a/pages/stack/fault-proofs/explainer.mdx
+++ b/pages/stack/fault-proofs/explainer.mdx
@@ -85,7 +85,7 @@ Assuming OP Mainnet parameters, where proposals will be posted hourly, that's 0.
 Assuming a 7 day dispute window, you'll need roughly 14 ETH (including gas costs) to make proposals.
 If chains are using the similar FP deploy configs as OP Mainnet, it's recommended to stick to a 0.08 ETH initial bond.
 
-However, the capital requirements for operating a FP chain in itself is much larger than 14 ETH.
+However, the capital requirements for operating an FP chain in itself is much larger than 14 ETH.
 An operator that secures their chain using FPs must be willing to stake a lot of ETH to secure the chain.
 One may decide the capital requirements aren't worth it, and use only a Permissioned FP system.
 The capital requirements will be improved in the later stages of Fault Proofs to make it more feasible for smaller chains.

--- a/pages/stack/smart-contracts.mdx
+++ b/pages/stack/smart-contracts.mdx
@@ -18,7 +18,7 @@ valid state root of the layer 2.
 
 ### Official releases
 
-The full smart contract release process is documented in the [monorepo](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/VERSIONING.md).
+The full smart contract release process is documented in the [monorepo](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/meta/VERSIONING.md).
 All production releases are always tagged, versioned as `<component-name>/v<semver>`.
 Contract releases have a component name of `op-contracts` and therefore are tagged as `op-contract/vX.Y.Z`.
 


### PR DESCRIPTION
This pull request addresses the following updates:
1. Fixed a grammatical error in `explainer.mdx` by correcting the usage of the article:
   - Changed "a FP chain" to "an FP chain."
2. Updated a broken link in `smart-contracts.mdx`:
   - Changed the reference to `VERSIONING.md` from the incorrect path to the correct path in the `contracts-bedrock/meta` directory.

## Tests

- No new tests were added as these changes are documentation updates.
- These changes were manually reviewed for accuracy.

## Additional Context

- These improvements ensure better readability and accuracy in the documentation for contributors and users.
