### PR TITLE
docs: typo fix Update content-reuse.md

### DIFF
--- a/notes/content-reuse.md
+++ b/notes/content-reuse.md
@@ -23,7 +23,7 @@ import DescriptionShort from '@/content/DescriptionShort.md'
 ```
 Text before
 
-<OpProposerDescriptionShort />
+<DescriptionShort />
 
 Text after
 ```


### PR DESCRIPTION
**Description**

I noticed a discrepancy in the example code provided in the "How to Use a Single Reusable Content Component" section. Specifically, the example references `<OpProposerDescriptionShort />`, which isn't consistent with the preceding import statement. The import explicitly includes `DescriptionShort`, not `OpProposerDescriptionShort`.  

To resolve this, I’ve updated the code example to replace `<OpProposerDescriptionShort />` with `<DescriptionShort />`, ensuring alignment with the import instructions and avoiding potential confusion for readers.  
