### PR TITLE
Typo: The ".nx-bg-primary-800" class is declared twice with different values.

### DIFF
--- a/styles/theme.css
+++ b/styles/theme.css
@@ -102,7 +102,7 @@
         background-color:var(--op-blue-600);
     }
     
-    .nx-bg-primary-800 {
+    .nx-bg-primary-700 {
         background-color:var(--op-blue-700);
     }
     


### PR DESCRIPTION

**Description**
Rename or remove the duplicated block