### PR TITLE
Remove superchain duplicate link

### DIFF
--- a/pages/stack/_meta.json
+++ b/pages/stack/_meta.json
@@ -1,7 +1,6 @@
 {
   "getting-started": "Getting started: OP Stack",
   "differences": "Differences between Ethereum and OP Stack chains",
-  "explainer": "Superchain explainer",
   "design-principles": "Design philosophy & principles",
   "components": "OP Stack components",
   "smart-contracts": "Smart contracts",


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Remove the superchain explainer link from the `meta.json` page.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

- Fixes #1214 