### PR TITLE
docs: Fix redundant phrase Update custom-gas-token.mdx

### DIFF
--- a/pages/stack/beta-features/custom-gas-token.mdx
+++ b/pages/stack/beta-features/custom-gas-token.mdx
@@ -49,7 +49,7 @@ This is the general flow of how custom gas tokens work on the OP Stack:
 Chain operators get the following benefits by using custom gas tokens:
 
 *   can use an L1 ERC-20 token as the custom gas token for L2 OP Stack chain deployment
-*   can use an ERC-20 token on an existing L2 OP Stack chain as as the custom gas token for an L3 OP Stack chain deployment
+*   can use an ERC-20 token on an existing L2 OP Stack chain as the custom gas token for an L3 OP Stack chain deployment
 *   can use custom gas tokens with other configurations of the OP Stack, including Plasma Mode.
 
 ## Considerations


### PR DESCRIPTION
**Description**

I’ve fixed a minor typo in the doc where the phrase "as as" appeared. It’s now corrected to "as" in the sentence: 

"can use an ERC-20 token on an existing L2 OP Stack chain as the custom gas token for an L3 OP Stack chain deployment."  
