### PR TITLE
docs: Fix grammatical issues Update glossary.mdx

### DIFF
--- a/pages/connect/resources/glossary.mdx
+++ b/pages/connect/resources/glossary.mdx
@@ -115,7 +115,7 @@ derivation then acts as a sanity check and a way to detect L1 chain re-orgs.
 
 #### Time slot
 
-On L2, there is a block every 2 second (this duration is known as the [block time](#block-time)).
+On L2, there is a block every 2 seconds (this duration is known as the [block time](#block-time)).
 We say that there is a "time slot" every multiple of 2s after the timestamp of the [L2 genesis block](#l2-genesis-block).
 On L1, post-merge, the time slots are every 12s. However, an L1 block may not be produced for every time slot, in case
 of even benign consensus issues.
@@ -265,7 +265,7 @@ pre-confirm the transactions before the L1 confirms the data.
 
 #### Sequencer
 
-The specific entity or smart contract which has priority when submitting transactions to an OP Chain, can be either a [rollup node](#rollup-node) ran in sequencer mode or the operator of this rollup node.
+The specific entity or smart contract which has priority when submitting transactions to an OP Chain, can be either a [rollup node](#rollup-node) run in sequencer mode or the operator of this rollup node.
 The sequencer receives L2 transactions from L2 users, creates L2 blocks using them, which it then submits to [data availability provider](#data-availability-provider) (via a [batcher](#batcher)).
 It also submits [output roots](#l2-output-root) to L1.
 
@@ -359,7 +359,7 @@ of the channel are seen, or else these frames are ignored.)
 
 Guarantee that some data will be "available" (i.e. *retrievable*) during a reasonably long time
 window. In Optimism's case, the data in question are [sequencer batches](#sequencer-batch) that [validators](#validator)
-needs in order to verify the sequencer's work and validate the L2 chain. The [finalization period](#finalization-period)
+need in order to verify the sequencer's work and validate the L2 chain. The [finalization period](#finalization-period)
 should be taken as the lower bound on the availability window, since that is when data availability is the most crucial,
 as it is needed to perform a [fault proof](#fault-proof). "Availability" **does not** mean guaranteed long-term storage of the data.
 


### PR DESCRIPTION
**Description**

I’ve fixed a few grammatical errors in the documentation:

- "every 2 second" → corrected to "every 2 seconds" for proper plural form.
- "ran in sequencer mode" → changed to "run in sequencer mode" for grammatical consistency.
- "validators needs" → updated to "validators need" to fix subject-verb agreement.

Thanks!