### PR TITLE
Minor fix typo key-management.mdx

### DIFF
--- a/pages/builders/chain-operators/management/key-management.mdx
+++ b/pages/builders/chain-operators/management/key-management.mdx
@@ -28,7 +28,7 @@ RPC method.
 
 <Callout type="info">
   You can take a look at the signer client [source code](https://github.com/ethereum-optimism/optimism/blob/develop/op-service/signer/client.go)
-  if you're interested in whats happening under the hood.
+  if you're interested in what's happening under the hood.
 </Callout>
 
 ## Cold wallets 


### PR DESCRIPTION
## Typo Fix 

### File Changed:
1. **pages/builders/chain-operators/management/key-management.mdx**:
   - Corrected "whats" to **"what's"** in the sentence
 