### PR TITLE
Update chain deployment overview page

### DIFF
--- a/pages/builders/chain-operators/deploy/overview.mdx
+++ b/pages/builders/chain-operators/deploy/overview.mdx
@@ -1,18 +1,18 @@
 ---
 title: OP Stack deployment overview
 lang: en-US
-description: Learn about the different components of deploying the OP Stack.
+description: Learn about the different components of deploying a standard OP Stack chain.
 ---
 
 import { Callout } from 'nextra/components'
 
 # OP Stack deployment overview
 
-When deploying an OP Stack chain, you'll be setting up four different
+When deploying a **standard OP Stack chain**, you'll be setting up several key
 components. It's useful to understand what each of these components does before
-you start deploying your chain. The OP Stack can be deployed as a L3, which
-includes additional considerations. The following information assumes you're
-deploying a L2 Rollup on Ethereum.
+you start deploying your chain. The following information assumes you're
+deploying a Rollup on Ethereum, but most concepts apply generally to any
+standard OP Stack deployment.
 
 ## Smart contracts
 
@@ -24,7 +24,7 @@ contracts that are deployed when the chain is created.
   Standard OP Stack chains should only use governance approved and audited
   smart contracts. The monorepo has them tagged with the following pattern
   `op-contracts/vX.X.X` and you can review the release notes for details on the
-  changes. Read more about the details on our [Smart Contract Release Section](/stack/smart-contracts#official-releases).
+  changes. Read more about the details in our [Smart Contract Release Section](/stack/smart-contracts#official-releases).
 </Callout>
 
 ## Sequencer node
@@ -48,9 +48,9 @@ a16z) and [`hildr`](https://github.com/optimism-java/hildr) (maintained by Optim
 OP Stack nodes, like Ethereum nodes, also have an execution client. The
 execution client is responsible for executing transactions and maintaining the
 state of the blockchain. Various implementations of the OP Stack execution
-client exist, including `op-geth` (maintained by Optimism Foundation),
-[`op-erigon`](https://github.com/testinprod-io/op-erigon)
-(maintained by Test in Prod), and [`op-nethermind`](https://docs.nethermind.io/get-started/installing-nethermind/#supported-networks).
+client exist, including `op-geth` (maintained by the Optimism Foundation),
+[`op-erigon`](https://github.com/testinprod-io/op-erigon) (maintained by Test
+in Prod), and [`op-nethermind`](https://docs.nethermind.io/get-started/installing-nethermind/#supported-networks).
 
 ## Batcher
 
@@ -65,6 +65,13 @@ the form of L2 state roots) to the L1 blockchain. This allows smart contracts
 on L1 to read the state of the L2, which is necessary for cross-chain
 communication and reconciliation between state changes.
 
+## Challenger
+
+The Challenger enforces network security by disputing invalid state roots (if
+any) that have been posted by the Proposer. It monitors on-chain data and, in
+the event of a suspected fraud, triggers a fault proof or another dispute
+mechanism to invalidate the erroneous data.
+
 ## Software dependencies
 
 | Dependency                                                    | Version  | Version Check Command |
@@ -76,7 +83,6 @@ communication and reconciliation between state changes.
 | [foundry](https://github.com/foundry-rs/foundry#installation) | `^0.2.0` | `forge --version`     |
 | [make](https://linux.die.net/man/1/make)                      | `^3`     | `make --version`      |
 | [jq](https://github.com/jqlang/jq)                            | `^1.6`   | `jq --version`        |
-| [direnv](https://direnv.net)                                  | `^2`     | `direnv --version`    |
 
 ### Notes on specific dependencies
 
@@ -93,26 +99,6 @@ It's recommended to use the scripts in the monorepo's `package.json` for
 managing `foundry` to ensure you're always working with the correct version.
 This approach simplifies the installation, update, and version checking
 process.
-
-#### `direnv`
-
-Parts of our tutorial use [`direnv`](https://direnv.net) as a way of loading
-environment variables from `.envrc` files into your shell. This means you won't
-have to manually export environment variables every time you want to use them.
-`direnv` only ever has access to files that you explicitly allow it to see.
-
-After [installing `direnv`](https://direnv.net/docs/installation.html), you
-will need to **make sure that [`direnv` is hooked into your shell](https://direnv.net/docs/hook.html)**.
-Make sure you've followed [the guide on the `direnv` website](https://direnv.net/docs/hook.html),
-then **close your terminal and reopen it** so that the changes take effect (or
-`source` your config file if you know how to do that).
-
-<Callout>
-  Make sure that you have correctly hooked `direnv` into your shell by modifying
-  your shell configuration file (like `~/.bashrc` or `~/.zshrc`). If you haven't
-  edited a config file then you probably haven't configured `direnv` properly
-  (and things might not work later).
-</Callout>
 
 ## Next steps
 


### PR DESCRIPTION
**Description**
• Updated the OP Stack deployment overview to remove any mention of L3 deployments, clarified it is for standard OP Stack chains
• Removed the direnv dependency (since we'll use op-deployer)
• Added a subsection describing the Challenger component.

Fixes #991 
