### PR TITLE
Fix directly use aa

### DIFF
--- a/components/ScrollDispatcher/index.tsx
+++ b/components/ScrollDispatcher/index.tsx
@@ -15,7 +15,7 @@ export default function ScrollDispatcher({
       document.documentElement.scrollHeight;
 
     if (bottom && queryID && objectID) {
-      aa.default("convertedObjectIDsAfterSearch", {
+      aa("convertedObjectIDsAfterSearch", {
         index: "docs",
         eventName: "Converted Search",
         queryID: queryID,


### PR DESCRIPTION
**Description**

I noticed that `aa.default` was being used unnecessarily. Since `aa` is already a default export, we can directly call `aa` without accessing `.default`. This change simplifies the code and aligns with proper usage of default exports.  

Here's the updated code:  
```typescript
aa("convertedObjectIDsAfterSearch", {
  index: "docs",
  eventName: "Converted Search",
  queryID: queryID,
  objectIDs: [objectID],
});
```  

This fix ensures cleaner and more idiomatic code.