### PR TITLE
fix: Fix incorrect usage of "signup" Update WipCallout.tsx

### DIFF
--- a/components/WipCallout.tsx
+++ b/components/WipCallout.tsx
@@ -31,7 +31,7 @@ export function WipCallout({ context }: Props): ReactElement {
               href="https://github.com/ethereum-optimism/docs/issues"
               className="callout-link"
             >
-              signup to help us revise this page
+              sign up to help us revise this page
             </a>
             . We welcome your contribution! ❤️
           </div>


### PR DESCRIPTION
**Description**

I noticed that the phrase "signup to help us revise this page" uses "signup" incorrectly. In this context, it should be "sign up" (separated) since it functions as a verb meaning "to register." This change ensures grammatical accuracy and clarity.

**Additional context**

Explanation:

"**Sign up**" is the correct spelling of the verb meaning "to register."
"Signup" is a noun used to refer to the registration process (e.g., "the signup process"), but in this context, a verb is required.

