### PR TITLE
docs: Remove duplicated `op-batcher` replacing with `op-deployer`

### DIFF
--- a/pages/builders/chain-operators/architecture.mdx
+++ b/pages/builders/chain-operators/architecture.mdx
@@ -45,7 +45,7 @@ its view of the world from `op-geth`.
 for verifiers. To reduce the cost of writing to the L1, it only posts the minimal
 amount of data required to reproduce L2 blocks.
 
-### op-batcher
+### op-deployer
 
 `op-deployer` is a tool that simplifies the process of deploying standardized OP Stack chains that comply with Superchain specifications. 
 It compares the state of your chain against the intent, 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

I found a small typo while reading the documentation, so I quickly created a PR which replace  duplicated `op-batcher` with correct word `op-deployer` in architecture page 👇🏻 

<img width="869" alt="Screenshot 2025-01-16 at 14 45 02" src="https://github.com/user-attachments/assets/a60645e4-64e2-40ff-91b4-cf44fe6d3a26" />

ref: https://docs.optimism.io/builders/chain-operators/architecture#op-batcher-1


<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
