### PR TITLE
docs: fix duplicate op-batcher section header

### DIFF
--- a/pages/builders/chain-operators/architecture.mdx
+++ b/pages/builders/chain-operators/architecture.mdx
@@ -45,7 +45,7 @@ its view of the world from `op-geth`.
 for verifiers. To reduce the cost of writing to the L1, it only posts the minimal
 amount of data required to reproduce L2 blocks.
 
-### op-batcher
+### op-deployer
 
 `op-deployer` is a tool that simplifies the process of deploying standardized OP Stack chains that comply with Superchain specifications. 
 It compares the state of your chain against the intent, 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

There was a duplicate section header for op-batcher where it should have been op-deployer. This PR fixes the incorrect header to match its content description.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
