### PR TITLE
Fix typo for ENV version of the flag l1.beacon.ignore

### DIFF
--- a/pages/builders/node-operators/configuration/consensus-config.mdx
+++ b/pages/builders/node-operators/configuration/consensus-config.mdx
@@ -86,7 +86,7 @@ When false, halts op-node startup if the healthcheck to the Beacon-node endpoint
 <Tabs items={['Syntax', 'Example', 'Environment Variable']}>
   <Tabs.Tab>`--l1.beacon.ignore=<boolean>`</Tabs.Tab>
   <Tabs.Tab>`--l1.beacon.ignore=false`</Tabs.Tab>
-  <Tabs.Tab>`OP_NODE_L1_BEACON=false`</Tabs.Tab>
+  <Tabs.Tab>`OP_NODE_L1_BEACON_IGNORE=false`</Tabs.Tab>
 </Tabs>
 
 ### l1.epoch-poll-interval


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Fixing typo for ENV var equivalent of `--l1.beacon.ignore`
