### PR TITLE
Fix Deploy SuperchainERC20 Tutorial link

### DIFF
--- a/pages/stack/interop/superchain-erc20.mdx
+++ b/pages/stack/interop/superchain-erc20.mdx
@@ -96,4 +96,4 @@ For step-by-step information on implementing SuperchainERC20, see [Deploy assets
 *   Watch the [ERC20 to SuperchainERC20 video walkthrough](https://www.youtube.com/watch?v=Gb8glkyBdBA) to learn how to modify an existing ERC20 contract to make it interoperable within the Superchain.
 *   Explore the [SuperchainERC20 specifications](https://specs.optimism.io/interop/token-bridging.html) for in-depth implementation details.
 *   Check out the [SuperchainERC20 starter kit](https://github.com/ethereum-optimism/superchainerc20-starter) to get started with implementation.
-*   Review the [Deploy SuperchainERC20 tutorial](../assets/deploy-superchain-erc20) to learn how to deploy a SuperchainERC20.
+*   Review the [Deploy SuperchainERC20 tutorial](./tutorials/deploy-superchain-erc20) to learn how to deploy a SuperchainERC20.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Fix Deploy SuperchainERC20 Tutorial link

On the bottom of the page https://docs.optimism.io/stack/interop/superchain-erc20

Review the [Deploy SuperchainERC20 tutorial](https://docs.optimism.io/stack/assets/deploy-superchain-erc20) to learn how to deploy a SuperchainERC20.

Deploy SuperchainERC20 tutorial is currently linked to wrong page leading to 404 error

I fix it by linking to `./tutorials/deploy-superchain-erc20` instead

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
