### PR TITLE
Fix spelling error in `security.mdx`

### DIFF
--- a/pages/stack/interop/security.mdx
+++ b/pages/stack/interop/security.mdx
@@ -62,7 +62,7 @@ L2 blocks start as unsafe, meaning that there's no L1 evidence for them, and the
 Sending out incorrect information, for example that a certain transaction is included in a block when it isn't, is called *equivocation*.
 A sequencer that builds blocks with interop can choose to accept messages from unsafe blocks (received through the gossip protocol), for minimal latency.
 
-However, because of equivocation risk, a block that is written to L1 (*local safe*) can only be considered truly safe (the techincal term is *cross safe*), for itself and the previous blocks in its blockchain are also written to L1.
+However, because of equivocation risk, a block that is written to L1 (*local safe*) can only be considered truly safe (the technical term is *cross safe*), for itself and the previous blocks in its blockchain are also written to L1.
 
 ```mermaid
 


### PR DESCRIPTION
- Fixed "techincal" to "technical" in `security.mdx`.

