### PR TITLE
Add signer-proxy as a recommended solution for AWS KMS or YubiHSM key management

### DIFF
--- a/pages/builders/chain-operators/management/key-management.mdx
+++ b/pages/builders/chain-operators/management/key-management.mdx
@@ -26,6 +26,10 @@ Key Management Systems (KMS) that can work with your developer operations
 configurations. This can be used in conjunction with the `eth_signTransaction`
 RPC method.
 
+If you intend to manage your keys using AWS KMS or YubiHSM2, you can use [signer-proxy](https://github.com/upnodedev/signer-proxy).
+
+[signer-proxy](https://github.com/upnodedev/signer-proxy) is an open-source tool that connects to your AWS KMS or YubiHSM2 backend and exposes an endpoint compatible with the `eth_signTransaction` RPC method.
+
 <Callout type="info">
   You can take a look at the signer client [source code](https://github.com/ethereum-optimism/optimism/blob/develop/op-service/signer/client.go)
   if you're interested in what's happening under the hood.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

We have developed [signer-proxy](https://github.com/upnodedev/signer-proxy), an open-source tool that connects AWS KMS or YubiHSM2 backend and exposes an endpoint compatible with the `eth_signTransaction` RPC method.

This enables OP Stack chain operators to easily use AWS KMS or YubiHSM2 to secure their key for privileged roles by just launching the [signer-proxy](https://github.com/upnodedev/signer-proxy) server and configure OP Stack services according to use signer-proxy RPC server instead.

This pull request add recommendation to use [signer-proxy](https://github.com/upnodedev/signer-proxy) in the [Key Management](https://docs.optimism.io/builders/chain-operators/management/key-management#hot-wallets) page.

**Additional context**

Our grant proposal: https://app.charmverse.io/op-grants/research-on-using-yubihsm-and-aws-kms-hardware-signer-on-op-stack-41211765826072866

Retro Funding 5: https://round5.retrolist.app/project/0xd4ed99cc6aaf73ca63b32f7a03b5427ac1d2955bf9efc31eb14f5773016988d0

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
