### PR TITLE
devnets: reduce duplicate info and point to the devnets website instead

### DIFF
--- a/pages/stack/public-devnets.mdx
+++ b/pages/stack/public-devnets.mdx
@@ -46,12 +46,6 @@ Features must be included on a betanet before they can be deployed on a testnet.
 | Feature activation | Included and activated at genesis          | Activated through a network upgrade    |
 | Lifecycle          | 5 weeks                                    | Until replaced by the next betanet     |
 
-## Current devnets
+## Current devnets 
 
-**Alpaca**
-
-*   Launch date: 2025-01-15
-*   Anticipated end-of-life: 2025-02-19
-*   Scope: Adds updates to the L1 contracts to support upgrades via OP Contracts Manager.
-*   RPC endpoint: `<https://alpaca-0.optimism.io>`
-*   `manifest.yaml`: `<https://github.com/ethereum-optimism/devnets/blob/main/alphanets/alpaca/manifest.yaml>`
+A full list of active alpha- and betanets is available at <https://devnets.optimism.io/>.


### PR DESCRIPTION
We now have https://devnets.optimism.io/, and we should point to this in the docs rather than manually duplicating info about each devnet.