### PR TITLE
making improvements on the node release information

### DIFF
--- a/pages/builders/node-operators/management/blobs.mdx
+++ b/pages/builders/node-operators/management/blobs.mdx
@@ -22,7 +22,7 @@ These steps are necessary for EVERY node operator:
 <Steps>
 ### Update to the latest release
 
-See the [Software Releases](/builders/node-operators/releases) page for the minimum release version.
+See the latest release notes for the OP Stack components can be found on GitHub [here](https://github.com/ethereum-optimism/optimism/releases) and `op-geth` can be found on GitHub [here](https://github.com/ethereum-optimism/op-geth/releases). To understand how the node release versioning works, see the [Node software releases](/builders/node-operators/releases#releases-versioning) section.
 
 ### Configure the Ecotone activation date
 

--- a/pages/builders/node-operators/network-upgrades.mdx
+++ b/pages/builders/node-operators/network-upgrades.mdx
@@ -72,5 +72,5 @@ then the software is deployed on production networks.
 
 ## More information
 
-*   To check for the latest node software, see the [Software Releases](/builders/node-operators/releases).
+*   To learn how node relases are versioned see our [node software release documention](/builders/node-operators/releases).
 *   For more information on the governance process see the [governance documentation](https://community.optimism.io/docs/governance/).

--- a/pages/builders/node-operators/releases.mdx
+++ b/pages/builders/node-operators/releases.mdx
@@ -8,36 +8,10 @@ import { Callout } from 'nextra/components'
 
 # Node software releases
 
-This page gives information on the off chain node software release information.
+This page gives information about the node software releases and how they're versioned. Our latest releases, notes, and changelogs can be found on GitHub. `op-node` releases can be found [here](https://github.com/ethereum-optimism/optimism/releases) and `op-geth` releases can be found [here](https://github.com/ethereum-optimism/op-geth/releases). We always recommend you run the latest release versions of the node software.
 
-<Callout type="info">
-  Our latest releases, notes, and changelogs can be found on GitHub. `op-node` releases can be found [here](https://github.com/ethereum-optimism/optimism/releases)
-  and `op-geth` releases can be found [here](https://github.com/ethereum-optimism/op-geth/releases).
-</Callout>
+## Releases versioning
 
-## Production releases
-
-Chain and node operators should always run the latest production releases of the OP Stack's off-chain components. Production releases are always tags, versioned as `<component-name>/v<semver>`. For example, an `op-node` release might be versioned as `op-node/v1.7.5`. Tags of the form `v<semver>`, such as `v1.7.6`, indicate releases of all Go code only and DO NOT include smart contracts. This naming scheme is required by Golang. In the above list, these `v<semver>` releases contain all `op-*` components and exclude all `contracts-*` components.
+Production releases are always tags, versioned as `<component-name>/v<semver>`. For example, an `op-node` release might be versioned as `op-node/v1.10.3`. Tags of the form `v<semver>`, such as `v1.10.3`, indicate releases of all Go code only and DO NOT include smart contracts. This naming scheme is required by Golang. In the above list, these `v<semver>` releases contain all `op-*` components and exclude all `contracts-*` components.
 
 `op-geth` embeds upstream geth's version inside its own version as follows: `vMAJOR.GETH_MAJOR GETH_MINOR GETH_PATCH.PATCH`. Basically, geth's version is our minor version. For example, if geth is at `v1.12.0`, the corresponding `op-geth` version would be `v1.101200.0`. Note that we pad out to three characters for the geth minor version and two characters for the geth patch version. Since we cannot left-pad with zeroes, the geth major version is not padded.
-
-### Docker images
-
-To make it easier to find and use our Docker images, each release entry below provides links to the corresponding Docker images:
-
-*   **op-node**: Docker images can be found [here](https://hub.docker.com/r/ethereumoptimism/op-node/tags).
-*   **op-geth**: Docker images can be found [here](https://hub.docker.com/r/ethereumoptimism/op-geth/tags).
-
-### Example Docker image tags
-
-We follow a consistent tagging convention to make it easier to find the right image. Here are some examples:
-
-*   `optimism/op-node:<version>`
-*   `optimism/op-geth:<version>`
-
-## Release entries
-
-| Network    | op-node                                                                     | op-geth                                                                              |
-| ---------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| OP Mainnet | [v1.9.1](https://github.com/ethereum-optimism/optimism/releases/tag/v1.9.1) | [v1.101408.0](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101408.0) |
-| OP Sepolia | [v1.9.1](https://github.com/ethereum-optimism/optimism/releases/tag/v1.9.1) | [v1.101408.0](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101408.0) |

--- a/pages/builders/node-operators/rollup-node.mdx
+++ b/pages/builders/node-operators/rollup-node.mdx
@@ -103,7 +103,6 @@ It is important to regularly monitor your node, and you can optionally configure
 ## Follow node updates
 
 *   It's important to keep your node software up to date. Software updates can also include important bug fixes and patches that can help keep your node stable.
-*   Refer to the [Software Releases](/builders/node-operators/releases) page for a detailed look at the latest releases of various rollup node and execution client implementations.
 *   Notifications are also posted to the Optimism Upgrade Announcement Channels on [**Discord**](https://discord.com/channels/667044843901681675/754090866435424270) and [**Telegram**](https://t.me/+LtAJL1Mt1PYyNjBh).
 
 ## Node operator tutorials


### PR DESCRIPTION
- I deleted the section with references to the release versions and instead provided guidance to always use the latest release versions.
- I linked the github release pages for the op stack components + op-geth which is in its own repo
- I removed the docker section that was out of date. The docker images are linked in the release pages on GitHub