### PR TITLE
docs: Update superchain_level for Standard chain status to 2

### DIFF
--- a/pages/superchain/blockspace-charter.mdx
+++ b/pages/superchain/blockspace-charter.mdx
@@ -18,7 +18,7 @@ The components work in unison to form a cohesive governance and technical framew
 
 *   **Blockspace Charters:** A type of framework that establishes criteria, governing policies, and precommitments for blockspace in the Optimism ecosystem, ensuring security, uptime, and alignment with the [Law of Chains](https://github.com/ethereum-optimism/OPerating-manual/blob/main/Law%20of%20Chains.md).
 *   **Standard Rollup Charter:** The Standard Rollup Charter is the first blockspace charter, defining the technical and governance requirements for our highest-security blockspace. By adhering to the Standard Rollup Charter, chains can achieve "Standard" status, ensuring consistency, high security, and operational reliability.
-*   **Superchain Registry:** The Superchain Registry is an index of chains which serves as the source of truth for who's in the Superchain ecosystem and the chain's configuration. The registry checks for compliance with the Standard Rollup Charter. Chains with `superchain_level = 1` meet all the criteria to be classified as a Standard Rollup.
+*   **Superchain Registry:** The Superchain Registry is an index of chains which serves as the source of truth for who's in the Superchain ecosystem and the chain's configuration. The registry checks for compliance with the Standard Rollup Charter. Chains with `superchain_level = 2` meet all the criteria to be classified as a Standard Rollup.
 
 Together, these components ensure a robust, scalable, and transparent ecosystem. Blockspace Charters provide the vision and principles, the Standard Rollup Charter translates these into concrete requirements, and the Superchain Registry certifies compliance.
 
@@ -107,6 +107,6 @@ Chains must meet strict requirements to qualify as "Standard." Below are answers
 The Superchain Registry serves as the source of truth for who's in the Superchain Ecosystem and what modifications they've made. The Superchain Registry has two main tasks:
 
 *   **Validates version and configuration:** The registry validates that chains align with governance-approved standards in the form of the Standard Rollup Charter.
-*   **Indicates adherence to the Standard Rollup Charter:** Once the registry validates that a chain meets the standard criteria, it promotes it to "Standard" by setting its `superchain_level` value to `1`.
+*   **Indicates adherence to the Standard Rollup Charter:** Once the registry validates that a chain meets the standard criteria, it promotes it to "Standard" by setting its `superchain_level` value to `2`.
 
 By integrating with the Standard Rollup Charter, the registry offers an automated and transparent validation system. This ensures chains can independently demonstrate compliance. For additional details, refer to the [Superchain Registry documentation](/superchain/superchain-registry).

--- a/pages/superchain/superchain-registry.mdx
+++ b/pages/superchain/superchain-registry.mdx
@@ -12,7 +12,7 @@ The Superchain Registry serves as the source of truth for who's in the Superchai
 
 *   A step-by-step process new chains can follow to join the Registry
 *   Validation checks to ensure standard chains comply with the Standard Rollup Charter and non-standard chains pass baseline validation before joining the Superchain Registry
-*   A Superchain Registry repository that shows who's in the registry and the chain's configuration. Chains with `superchain_level = 1` have proven that they follow the Standard Rollup Charter, and can be classified as a Standard Rollup.
+*   A Superchain Registry repository that shows who's in the registry and the chain's configuration. Chains with `superchain_level = 2` have proven that they follow the Standard Rollup Charter, and can be classified as a Standard Rollup.
 
 ## The Standard Rollup
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR updates the documentation to align with [the new superchain_level definition](https://github.com/ethereum-optimism/superchain-registry/pull/860). 

The change only updates references where level 1 was previously specified as the Standard chain status to now correctly show level 2. This is a minimal change focusing only on the Standard chain definition, without addressing levels 0 and 1.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
