### PR TITLE
Better explanation of what equivocation does

### DIFF
--- a/pages/stack/interop/security.mdx
+++ b/pages/stack/interop/security.mdx
@@ -62,7 +62,15 @@ L2 blocks start as unsafe, meaning that there's no L1 evidence for them, and the
 Sending out incorrect information, for example that a certain transaction is included in a block when it isn't, is called *equivocation*.
 A sequencer that builds blocks with interop can choose to accept messages from unsafe blocks (received through the gossip protocol), for minimal latency.
 
-However, because of equivocation risk, a block that is written to L1 (*local safe*) can only be considered truly safe (the technical term is *cross safe*), for itself and the previous blocks in its blockchain are also written to L1.
+Because of equivocation risk, a block that is written to L1 (*local safe*) can only be considered truly safe (the technical term is *cross safe*), for itself and the previous blocks in its blockchain are also written to L1.
+
+If the source block is written to L1 first, the destination sequencer can detect it. 
+If because of equivocation it is missing an initiating message that the sequencer relied upon, the sequencer can detect the error and recalculate the state.
+In this case, no significant harm is done.
+
+However, it is also possible that the destination block, the one with the executing message that relies on the initiating message, is written to L1 first (for example, because it is a chain with more traffic).
+In that case, if the source block that gets written to L1 does not have the initiating message, all the verifiers will see that the derivation of the destination block (and any block that depends on it) is wrong.
+In this case the destination block, and any block in any chain that depends upon it, become deposit only blocks.
 
 ```mermaid
 
@@ -71,14 +79,18 @@ sequenceDiagram
     participant src as Source Chain
     participant dst as Destination Chain
     participant l1 as Ethereum Mainnet
+    note over src,dst: ↓ Initiating message ↓
     src->>dst: Block src_n will have transaction txn_0 that emits log event evt_0
-    note over src,dst: Initiating message
-    app->>dst: Transaction txn_1: If you have evt_0, call contract C with the data in evt_0.
-    note over app,dst: Executing message
+    note over app,dst: ↓ Executing message ↓    
+    app->>dst: Transaction txn_1: If you have evt_0, call contract C with the data in evt_0. Otherwise, revert.
     note left of dst: Block dst_m will <br/> have the results of <br/> calling contract C <br/> with the data in evt_0.
     break
         note over app,l1: time passes
     end
+    dst->>l1: Write block dst_m, which includes a successful txn_1.
+    break
+        note over app,l1: time passes
+    end    
     src->>l1: Write block src_n without txn_0 (so no evt_0)
     l1->>dst: This is the safe block src_n
     note left of dst: No evt_0, so block dst_m is incorrect <br /> and so is every subsequent block. <br /> All those blocks are replaced with <br /> deposit only blocks.
@@ -102,10 +114,10 @@ sequenceDiagram
     participant src as Source Chain
     participant dst as Destination Chain
     participant l1 as Ethereum Mainnet
+    note over src,dst: ↓ Initiating message ↓
     src->>dst: Block src_n will have transaction txn_0 that emits log event evt_0
-    note over src,dst: Initiating message
-    app->>dst: Transaction txn_1: If you have evt_0, call contract C with the data in evt_0.
-    note over app,dst: Executing message
+    note over app,dst: ↓ Executing message ↓    
+    app->>dst: Transaction txn_1: If you have evt_0, call contract C with the data in evt_0, otherwise revert.
     note over dst: Block src_n is not safe yet,<br />txn_1 fails
     break
         note over app,l1: time passes


### PR DESCRIPTION
**Description**

Explain that equivocation results in deposit-only transactions *only* if the destination block is written to L1 before the source block.

**Tests**

N/A

**Additional context**

N/A

**Metadata**

N/A