### PR TITLE
Update SuperchainContractTable to pull from superchain.toml instead

### DIFF
--- a/components/SuperchainContractTable.tsx
+++ b/components/SuperchainContractTable.tsx
@@ -23,7 +23,7 @@ export function SuperchainContractTable({
         if (!response.ok) {
           throw new Error('Failed to fetch config');
         }
-        const text = await response.json();
+        const text = await response.text();
         const data = toml.parse(text);
         setConfig(data);
       } catch (err) {

--- a/components/SuperchainContractTable.tsx
+++ b/components/SuperchainContractTable.tsx
@@ -1,58 +1,64 @@
-import type { ReactElement } from 'react'
-import { useEffect, useState } from 'react'
-import { AddressTable, TableAddresses } from '@/components/AddressTable'
+import type { ReactElement } from 'react';
+import { useEffect, useState } from 'react';
+import { AddressTable, TableAddresses } from '@/components/AddressTable';
+import toml from 'toml';
 
-const CONFIG_URL = 'https://raw.githubusercontent.com/ethereum-optimism/superchain-registry/main/superchain/configs/configs.json';
+const CONFIG_URL = 'https://raw.githubusercontent.com/ethereum-optimism/superchain-registry/main/superchain/configs/mainnet/superchain.toml';
 
 export function SuperchainContractTable({
   chain,
   explorer,
 }: {
-  chain: string,
-  explorer: string,
+  chain: string;
+  explorer: string;
 }): ReactElement {
-  const [config, setConfig] = useState<Record<string, any> | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [config, setConfig] = useState<Record<string, any> | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     async function fetchAddresses() {
       try {
-        const response = await fetch(CONFIG_URL)
+        const response = await fetch(CONFIG_URL);
         if (!response.ok) {
-          throw new Error('Failed to fetch config')
+          throw new Error('Failed to fetch config');
         }
-        const data = await response.json()
-        setConfig(data)
+        const text = await response.text();
+        const data = toml.parse(text);
+        setConfig(data);
       } catch (err) {
-        setError(err.message)
-        console.error('Error fetching config:', err)
+        setError(err.message);
+        console.error('Error fetching or parsing config:', err);
       } finally {
-        setLoading(false)
+        setLoading(false);
       }
     }
 
-    fetchAddresses()
-  }, [])
+    fetchAddresses();
+  }, []);
 
   if (loading) {
-    return <div>Loading...</div>
+    return <div>Loading...</div>;
   }
 
   if (error) {
-    return <div>Error: {error}</div>
+    return <div>Error: {error}</div>;
   }
 
-  // Find the superchain config for the given chain.
-  const superchain = config?.superchains.find(
-    (sc: any) => sc.config.L1.ChainID.toString() === chain
-  )
+  // Helper function to recursively extract Ethereum addresses
+  function extractAddresses(obj: Record<string, any>, prefix = ''): TableAddresses {
+    const addresses: TableAddresses = {};
+    for (const [key, value] of Object.entries(obj)) {
+      if (typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value)) {
+        addresses[`${prefix}${key}`] = value; // Add key with optional prefix
+      } else if (typeof value === 'object' && value !== null) {
+        Object.assign(addresses, extractAddresses(value, `${key}.`)); // Recurse into nested objects
+      }
+    }
+    return addresses;
+  }
 
-  // Create a TableAddresses object with the ProtocolVersions and SuperchainConfig addresses.
-  const addresses: TableAddresses | undefined = superchain && {
-    ProtocolVersions: superchain.config.ProtocolVersionsAddr,
-    SuperchainConfig: superchain.config.SuperchainConfigAddr,
-  };
+  const addresses = extractAddresses(config || {});
 
   return (
     <AddressTable
@@ -61,5 +67,5 @@ export function SuperchainContractTable({
       legacy={false}
       addresses={addresses}
     />
-  )
+  );
 }

--- a/components/SuperchainContractTable.tsx
+++ b/components/SuperchainContractTable.tsx
@@ -23,7 +23,7 @@ export function SuperchainContractTable({
         if (!response.ok) {
           throw new Error('Failed to fetch config');
         }
-        const text = await response.text();
+        const text = await response.json();
         const data = toml.parse(text);
         setConfig(data);
       } catch (err) {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "search-insights": "^2.15.0",
+    "toml": "^3.0.0",
     "viem": "^2.21.18"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       search-insights:
         specifier: ^2.15.0
         version: 2.15.0
+      toml:
+        specifier: ^3.0.0
+        version: 3.0.0
       viem:
         specifier: ^2.21.18
         version: 2.21.37(typescript@5.3.2)(zod@3.22.4)
@@ -3490,6 +3493,9 @@ packages:
 
   to-vfile@7.2.4:
     resolution: {integrity: sha512-2eQ+rJ2qGbyw3senPI0qjuM7aut8IYXK6AEoOWb+fJx/mQYzviTckm1wDjq91QYHAPBTYzmdJXxMFA6Mk14mdw==}
+
+  toml@3.0.0:
+    resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -8363,6 +8369,8 @@ snapshots:
     dependencies:
       is-buffer: 2.0.5
       vfile: 5.3.7
+
+  toml@3.0.0: {}
 
   tr46@0.0.3: {}
 


### PR DESCRIPTION
Updates `SuperchainContractTable` to pull from [superchain.toml](https://raw.githubusercontent.com/ethereum-optimism/superchain-registry/refs/heads/main/superchain/configs/mainnet/superchain.toml) instead of [configs.json](https://raw.githubusercontent.com/ethereum-optimism/superchain-registry/refs/heads/gk/update-mode/superchain/configs/configs.json)

Preview page: https://deploy-preview-1298--docs-optimism.netlify.app/chain/addresses