### PR TITLE
Upnode Alt DA for local filestore, IPFS and Arweave using Keccak256 commitment

### DIFF
--- a/pages/builders/chain-operators/features/alt-da-mode.mdx
+++ b/pages/builders/chain-operators/features/alt-da-mode.mdx
@@ -46,7 +46,7 @@ You should use at least the following compatible op\* versions when running your
   *   Avail's docs on how to run the [AvailDA DA Server](https://docs.availproject.org/docs/build-with-avail/Optimium/op-stack/op-stack#setup-avail-da-server)
   *   0gDA's docs on how to run the [0gDA DA Server](https://github.com/0glabs/0g-da-op-plasma)
   *   Near DA's docs on how to run the [Near DA Server](https://github.com/Nuffle-Labs/data-availability/blob/84b484de98f58a91bf12c8abe8df27f5e753f63a/docs/OP-Alt-DA.md)
-  *   Upnode has provided an [Alt DA server for local filestore, IPFS and Arweave using Keccak256 commitment](https://github.com/upnodedev/op-alt-da)
+  *   Upnode has provided an [Alt-DA Server for Local FileStore, IPFS, and Arweave Using Keccak256 Commitment](https://github.com/upnodedev/op-alt-da)
 
   ### Configure your `op-node`
 

--- a/pages/builders/chain-operators/features/alt-da-mode.mdx
+++ b/pages/builders/chain-operators/features/alt-da-mode.mdx
@@ -46,6 +46,7 @@ You should use at least the following compatible op\* versions when running your
   *   Avail's docs on how to run the [AvailDA DA Server](https://docs.availproject.org/docs/build-with-avail/Optimium/op-stack/op-stack#setup-avail-da-server)
   *   0gDA's docs on how to run the [0gDA DA Server](https://github.com/0glabs/0g-da-op-plasma)
   *   Near DA's docs on how to run the [Near DA Server](https://github.com/Nuffle-Labs/data-availability/blob/84b484de98f58a91bf12c8abe8df27f5e753f63a/docs/OP-Alt-DA.md)
+  *   Upnode has provided an [Alt DA server for local filestore, IPFS and Arweave using Keccak256 commitment](https://github.com/upnodedev/op-alt-da)
 
   ### Configure your `op-node`
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

An Optimism Alt-DA server enables OP Stack chains to use third-party data availability providers with an on-chain translation system that converts Keccak256 commitments into provider-specific CIDs (content identifier hashes).

This Alt-DA server uses Keccak256 commitments instead of generic commitments, providing a security advantage. The challenging contract for Keccak256 commitments is well-implemented, audited, and battle-tested, whereas generic commitments often lack an approved challenging logic. This Keccak256 commitments approach is approved for joining the Superchain, as seen in the Redstone chain.

Current supported data availability providers:
- Celestia
- IPFS
- Arweave
- Local Filesystem

If it conflicts with the new generic commitment schema, it may not be merged. However, we have to submit this pull request is a critical milestone on our grant proposal. It’s worth considering this as an alternative option.

**Additional context**

Grant proposal: https://app.charmverse.io/op-grants/plasmada-translation-hub-1014033406866528
