### PR TITLE
Add op-deployer flow to OP Stack genesis creation

### DIFF
--- a/pages/builders/chain-operators/deploy/genesis.mdx
+++ b/pages/builders/chain-operators/deploy/genesis.mdx
@@ -71,15 +71,11 @@ Once you have `genesis.json` and `rollup.json`:
 2. Configure op-node with rollup.json.
 3. Set up additional off-chain infrastructure as needed (block explorer, indexers, etc.). For more on architecture, see [Architecture overview](/builders/chain-operators/architecture).
 
-4.  ### Step 3: Get data
+### Step 3: Get data
 
 Now that you have your `genesis.json` and `rollup.json` you can spin up a node on your network.
 You can also use the following inspect subcommands to get additional data:
 
-```bash
-./bin/op-deployer inspect l1 --workdir .deployer <l2-chain-id> # outputs all L1 contract addresses for an L2 chain
-./bin/op-deployer inspect deploy-config --workdir .deployer <l2-chain-id> # outputs the deploy config for an L2 chain
-```
 
 ## Legacy method: using foundry script
 

--- a/pages/builders/chain-operators/deploy/genesis.mdx
+++ b/pages/builders/chain-operators/deploy/genesis.mdx
@@ -8,9 +8,13 @@ import { Callout } from 'nextra/components'
 
 # OP Stack genesis creation
 
-<Callout type="warning">
-This page has been **updated** to use <strong>op-deployer</strong> for genesis file creation. The foundry-script-based method (described below as "legacy") is no longer recommended for production.
+<Callout type="info">
+The recommended way to generate genesis and rollup configuration files is using `op-deployer`.
+  This ensures standardization and compatibility with the Superchain.
 </Callout>
+
+The `op-deployer` tool simplifies the creation of genesis and rollup configuration files (`genesis.json` and `rollup.json`).
+These files are crucial for initializing the execution client (`op-geth`) and consensus client (`op-node`) for your network.
 
 The recommended flow for creating a genesis file and rollup configuration file on the OP Stack is as follows:
 
@@ -22,18 +26,22 @@ The recommended flow for creating a genesis file and rollup configuration file o
 
 ### Prerequisites
 
-1. You have installed the `op-deployer` binary following the instructions in [Deployer docs](/builders/chain-operators/tools/op-deployer).
+1. You have installed the `op-deployer` binary following the instructions in [deployer docs](/builders/chain-operators/tools/op-deployer#installation).
+After installation, extract the `op-deployer` into your `PATH` and `cd op-deployer`.
 2. You have created and customized an intent file in a `.deployer` directory, typically by running:
    ```bash
-   op-deployer init --l1-chain-id <YOUR_L1_CHAIN_ID> --l2-chain-ids <YOUR_L2_CHAIN_ID> --workdir .deployer
+   ./bin/op-deployer init --l1-chain-id <YOUR_L1_CHAIN_ID> --l2-chain-ids <YOUR_L2_CHAIN_ID> --workdir .deployer
     ```
+
+    Replace `<YOUR_L1_CHAIN_ID>` and `<YOUR_L2_CHAIN_ID>` with their respective values, see a list of [`chainIds`](https://chainid.network/).
+
 3. You have edited that intent file to your liking (roles, addresses, etc.).
 
 ### Step 1: Deploy the L1 contracts
 
 To deploy your chain to L1, run:
 ```bash
-op-deployer apply --workdir .deployer \
+./bin/op-deployer apply --workdir .deployer \
   --l1-rpc-url <RPC_URL_FOR_L1> \
   --private-key <DEPLOYER_PRIVATE_KEY_HEX>
 ```
@@ -48,8 +56,8 @@ This command:
 
 After your L1 contracts have been deployed, generate the L2 genesis and rollup configuration files by inspecting the deployer’s `state.json.`
 ```bash
-op-deployer inspect genesis --workdir .deployer <L2_CHAIN_ID> > .deployer/genesis.json
-op-deployer inspect rollup --workdir .deployer <L2_CHAIN_ID> > .deployer/rollup.json
+./bin/op-deployer inspect genesis --workdir .deployer <L2_CHAIN_ID> > .deployer/genesis.json
+./bin/op-deployer inspect rollup --workdir .deployer <L2_CHAIN_ID> > .deployer/rollup.json
 ```
 
 * genesis.json is the file you will provide to your execution client (e.g. op-geth).
@@ -57,11 +65,21 @@ op-deployer inspect rollup --workdir .deployer <L2_CHAIN_ID> > .deployer/rollup.
 
 ### Step 3: Initialize your off-chain components
 
-Once you have genesis.json and rollup.json:
+Once you have `genesis.json` and `rollup.json`:
 
 1. Initialize op-geth using genesis.json.
-1. Configure op-node with rollup.json.
-1. Set up additional off-chain infrastructure as needed (block explorer, indexers, etc.). For more on architecture, see [Architecture overview](/builders/chain-operators/architecture).
+2. Configure op-node with rollup.json.
+3. Set up additional off-chain infrastructure as needed (block explorer, indexers, etc.). For more on architecture, see [Architecture overview](/builders/chain-operators/architecture).
+
+4.  ### Step 3: Get data
+
+Now that you have your `genesis.json` and `rollup.json` you can spin up a node on your network.
+You can also use the following inspect subcommands to get additional data:
+
+```bash
+./bin/op-deployer inspect l1 --workdir .deployer <l2-chain-id> # outputs all L1 contract addresses for an L2 chain
+./bin/op-deployer inspect deploy-config --workdir .deployer <l2-chain-id> # outputs the deploy config for an L2 chain
+```
 
 ## Legacy method: using foundry script
 
@@ -70,10 +88,16 @@ file that represents the L2 genesis. You will provide this file to the
 execution client (op-geth) to initialize your network. There is also the rollup configuration file, `rollup.json`, which will be
 provided to the consensus client (op-node).
 
-## Solidity script
+<Callout type="warning">
+  The following genesis creation information is the legacy method for creating OP Stack configuration files.
+  This method is not recommended. It's preserved here for historical context.
+</Callout>
 
-At the time of this writing, the preferred method for genesis generation is to use the foundry script 
-located in the monorepo to generate an "L2 state dump" and then pass this into the op-node genesis subcommand. 
+
+## Solidity script (Legacy)
+
+You can also use the foundry script
+located in the monorepo to generate an "L2 state dump" and then pass this into the op-node genesis subcommand.
 The foundry script can be found at
 [packages/contracts-bedrock/scripts/L2Genesis.s.sol](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/scripts/L2Genesis.s.sol).
 

--- a/pages/builders/chain-operators/deploy/genesis.mdx
+++ b/pages/builders/chain-operators/deploy/genesis.mdx
@@ -76,6 +76,10 @@ Once you have `genesis.json` and `rollup.json`:
 Now that you have your `genesis.json` and `rollup.json` you can spin up a node on your network.
 You can also use the following inspect subcommands to get additional data:
 
+```bash
+./bin/op-deployer inspect l1 --workdir .deployer <l2-chain-id> # outputs all L1 contract addresses for an L2 chain
+./bin/op-deployer inspect deploy-config --workdir .deployer <l2-chain-id> # outputs the deploy config for an L2 chain
+
 
 ## Legacy method: using foundry script
 

--- a/pages/builders/chain-operators/deploy/genesis.mdx
+++ b/pages/builders/chain-operators/deploy/genesis.mdx
@@ -9,9 +9,61 @@ import { Callout } from 'nextra/components'
 # OP Stack genesis creation
 
 <Callout type="warning">
-This page is out of date and shows the legacy method for genesis file creation.
-For the latest recommended method, use [op-deployer](/builders/chain-operators/tools/op-deployer).
+This page has been **updated** to use <strong>op-deployer</strong> for genesis file creation. The foundry-script-based method (described below as "legacy") is no longer recommended for production.
 </Callout>
+
+The recommended flow for creating a genesis file and rollup configuration file on the OP Stack is as follows:
+
+1. **Deploy the L1 contracts** using [op-deployer](/builders/chain-operators/tools/op-deployer).
+2. **Generate** both the L2 genesis file (`genesis.json`) and the rollup configuration file (`rollup.json`) using op-deployer’s `inspect` commands.
+3. **Initialize** your off-chain components (e.g., execution client, consensus client).
+
+## Recommended method: using op-deployer
+
+### Prerequisites
+
+1. You have installed the `op-deployer` binary following the instructions in [Deployer docs](/builders/chain-operators/tools/op-deployer).
+2. You have created and customized an intent file in a `.deployer` directory, typically by running:
+   ```bash
+   op-deployer init --l1-chain-id <YOUR_L1_CHAIN_ID> --l2-chain-ids <YOUR_L2_CHAIN_ID> --workdir .deployer
+    ```
+3. You have edited that intent file to your liking (roles, addresses, etc.).
+
+### Step 1: Deploy the L1 contracts
+
+To deploy your chain to L1, run:
+```bash
+op-deployer apply --workdir .deployer \
+  --l1-rpc-url <RPC_URL_FOR_L1> \
+  --private-key <DEPLOYER_PRIVATE_KEY_HEX>
+```
+
+This command:
+
+* Reads your intent file in `.deployer/.`
+* Deploys the OP Stack contracts to the specified L1.
+* Updates a local `state.json` file with the results of the deployment.
+
+### Step 2: Generate your L2 genesis file and rollup file
+
+After your L1 contracts have been deployed, generate the L2 genesis and rollup configuration files by inspecting the deployer’s `state.json.`
+```bash
+op-deployer inspect genesis --workdir .deployer <L2_CHAIN_ID> > .deployer/genesis.json
+op-deployer inspect rollup --workdir .deployer <L2_CHAIN_ID> > .deployer/rollup.json
+```
+
+* genesis.json is the file you will provide to your execution client (e.g. op-geth).
+* rollup.json is the file you will provide to your consensus client (e.g. op-node).
+
+### Step 3: Initialize your off-chain components
+
+Once you have genesis.json and rollup.json:
+
+1. Initialize op-geth using genesis.json.
+1. Configure op-node with rollup.json.
+1. Set up additional off-chain infrastructure as needed (block explorer, indexers, etc.). For more on architecture, see [Architecture overview](/builders/chain-operators/architecture).
+
+## Legacy method: using foundry script
 
 The following guide shows you how to generate the L2 genesis file `genesis.json`. This is a JSON
 file that represents the L2 genesis. You will provide this file to the


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
1. **New op-deployer flow added**  
   - Instructions on how to generate `genesis.json` and `rollup.json` using `op-deployer` (`op-deployer inspect genesis` / `op-deployer inspect rollup`).

2. **Legacy foundry-based flow moved to the bottom**  


**Metadata**

Include a link to any github issues that this may close in the following form:
- Fixes #993