### PR TITLE
Wrong function name in deposit-flow.mdx

### DIFF
--- a/pages/stack/transactions/deposit-flow.mdx
+++ b/pages/stack/transactions/deposit-flow.mdx
@@ -25,7 +25,7 @@ Information is encapsulated in lower layer packets on the sending side and then 
     *   `_message`, the L2 transaction's calldata, formatted as per the [ABI](https://docs.soliditylang.org/en/v0.8.19/abi-spec.html) of the target account.
     *   `_minGasLimit`, the minimum gas limit allowed for the transaction on L2. Note that this is a *minimum* and the actual amount provided on L2 may be higher (but never lower) than the specified gas limit. The actual amount provided on L2 is often higher because the portal contract on L2 performs some processing before submitting the call to `_target`.
 
-2.  The L1 cross domain messenger calls [its own `_send` function](https://github.com/ethereum-optimism/optimism/blob/62c7f3b05a70027b30054d4c8974f44000606fb7/packages/contracts-bedrock/contracts/L1/L1CrossDomainMessenger.sol#L42-L52).
+2.  The L1 cross domain messenger calls [its own `_sendMessage` function](https://github.com/ethereum-optimism/optimism/blob/62c7f3b05a70027b30054d4c8974f44000606fb7/packages/contracts-bedrock/contracts/L1/L1CrossDomainMessenger.sol#L42-L52).
     It uses these parameters:
 
     *   `_to`, the destination address, is the messenger on the other side.


### PR DESCRIPTION
There is no `_send` in L1CrossDomainMessenger, it should be `_sendMessage`.

Link to [relevant code](https://github.com/ethereum-optimism/optimism/blob/62c7f3b05a70027b30054d4c8974f44000606fb7/packages/contracts-bedrock/contracts/universal/CrossDomainMessenger.sol#L249-L289), from the docs themselves.