### PR TITLE
Add detail on how to finalize a withdrawal

### DIFF
--- a/pages/stack/transactions/withdrawal-flow.mdx
+++ b/pages/stack/transactions/withdrawal-flow.mdx
@@ -79,6 +79,8 @@ The next step is to wait the fault challenge period, to ensure that the L2 outpu
 
 Finally, once the fault challenge period passes, the withdrawal can be finalized and executed on L1.
 
+To do so, a user, either an externally owned account (EOA) directly or a contract acting on behalf of an EOA, calls the [`finalizeWithdrawalTransaction`](https://github.com/ethereum-optimism/optimism/blob/62c7f3b05a70027b30054d4c8974f44000606fb7/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol#L320-L420) function of the [`OptimismPortal`](https://github.com/ethereum-optimism/optimism/blob/62c7f3b05a70027b30054d4c8974f44000606fb7/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol) contract.
+
 ## Expected internal reverts in withdrawal transactions
 
 During the withdrawal process, users may observe internal reverts when viewing the transaction on **Etherscan**. This is a common point of confusion but is expected behavior.


### PR DESCRIPTION
**Description**

The docs don't include exactly how to finalize a withdrawal transaction in the same way that they specify other steps. Fixed that by including a link to the function that is called to do so.
