### PR TITLE
Correct MIPS architecture version

### DIFF
--- a/pages/stack/fault-proofs/cannon.mdx
+++ b/pages/stack/fault-proofs/cannon.mdx
@@ -188,7 +188,7 @@ certain syscalls. The full list of instructions supported can be found [here](mi
 
 #### `mips.go` vs. `MIPS.sol`
 
-The offchain `mips.go` and the onchain Cannon `MIPS.sol` behave similarly when it comes to executing 32-bit, MIPS III instructions.
+The offchain `mips.go` and the onchain Cannon `MIPS.sol` behave similarly when it comes to executing MIPS32 R1 instructions.
 In fact, they must produce **exactly the same results** given the same instruction, memory, and register state.
 Consequently, the [witness data](#witness-data) is essential to reproduce the same instruction onchain and offchain.
 However, there are differences between the two:

--- a/pages/stack/fault-proofs/mips.mdx
+++ b/pages/stack/fault-proofs/mips.mdx
@@ -9,7 +9,7 @@ import { Callout } from 'nextra/components'
 
 # Fault proof VM: MIPS.sol
 
-The `MIPS.sol` smart contract is an onchain implementation of a virtual machine (VM) that encompasses the 32-bit, Big-Endian, MIPS III Instruction Set Architecture (ISA).
+The `MIPS.sol` smart contract is an onchain implementation of a virtual machine (VM) that encompasses the MIPS32 R1 Instruction Set Architecture (ISA).
 This smart contract is the counterpart to the off-chain MIPSEVM golang implementation of the same ISA. Together, the onchain and off-chain VM implementations make up [Cannon](cannon),
 Optimism's Fault Proof Virtual Machine (FPVM). Cannon is a singular instance of a FPVM that can be used as part of the Dispute Game for Optimism's (and Base's) optimistic rollup L2 blockchain.
 The Dispute Game itself is modular, allowing for any FPVM to be used in a dispute; however, Cannon is currently the only FPVM implemented and thus will be used in all disputes.

--- a/pages/stack/smart-contracts.mdx
+++ b/pages/stack/smart-contracts.mdx
@@ -396,7 +396,7 @@ This mechanism ensures participants are financially committed and disputes are f
 
 #### MIPS
 
-The `MIPS` contract provides an on-chain implementation of a 32-bit, Big-Endian MIPS III virtual machine, 
+The `MIPS` contract provides an on-chain implementation of a MIPS32 R1 virtual machine, 
 designed to execute fault proofs for disputes by processing a standardized instruction set. 
 This enables instances of `FaultDisputeGame` and `PermissionedDisputeGame` to resolve disputes
  over state transitions accurately and consistently. 


### PR DESCRIPTION
Cannon is actually MIPS32 R1, not MIPS III.