### PR TITLE
Remove crosschain guides from stack nav

### DIFF
--- a/pages/stack/_meta.json
+++ b/pages/stack/_meta.json
@@ -15,7 +15,6 @@
   "transactions": "Transactions",
   "features": "Features",
   "security": "Security",
-  "cross-chain": "Crosschain guides",
   "+++ Experimental": {
     "title": "",
     "type": "separator"


### PR DESCRIPTION
Removes the empty crosschain guide link from the OP Stack nav