### PR TITLE
Fix a typo and add a sanity check

### DIFF
--- a/pages/app-developers/starter-kit.mdx
+++ b/pages/app-developers/starter-kit.mdx
@@ -77,7 +77,7 @@ Here's a breakdown of what's under the hood:
 
     <summary>Sanity check</summary>
 
-    blah
+    Browse to [the console](http://localhost:5173/), mint some tokens and transfer them.
 
   </details>
 </Steps>

--- a/pages/app-developers/starter-kit.mdx
+++ b/pages/app-developers/starter-kit.mdx
@@ -43,7 +43,7 @@ Here's a breakdown of what's under the hood:
   Next, you need to clone and navigate to the repo:
 
   ```sh
-  git clone git@github.com:ethereum-optimism/superchainerc20-starter.git
+  git clone https://github.com/ethereum-optimism/superchainerc20-starter.git
   cd superchainerc20-starter
   ```
 
@@ -72,6 +72,14 @@ Here's a breakdown of what's under the hood:
   ```sh
   pnpm dev
   ```
+
+  <details>
+
+    <summary>Sanity check</summary>
+
+    blah
+
+  </details>
 </Steps>
 
 ## Deploy SuperchainERC20s


### PR DESCRIPTION
**Description**

- The provided git command, 
  ```
  git clone git@github.com:ethereum-optimism/superchainerc20-starter.git
  ```
  
  Didn't work for me, so I replaced it with a command that should always work,
  ```
  git clone https://ethereum-optimism/superchainerc20-starter.git
  ```

- I added a sanity check at the end of the setup phase so people can *see* it works.

**Tests**

N/A

**Additional context**

N/A

**Metadata**

N/A