### PR TITLE
Improve wording for clarity in `event-reads.mdx`

### DIFF
--- a/pages/stack/interop/tutorials/event-reads.mdx
+++ b/pages/stack/interop/tutorials/event-reads.mdx
@@ -34,7 +34,7 @@ This contract relies on a **CREATE2** deployment to ensure a consistent address 
 <Steps>
   ### Intent to play
 
-  A game is uniquely identified by the chain it was started from with a unqiue nonce. This identifier is included in all event fields such that each player can uniquely reference it locally.
+  A game is uniquely identified by the chain it was started from with a unique nonce. This identifier is included in all event fields such that each player can uniquely reference it locally.
 
   To start a game, a player invokes `newGame` which broadcasts a `NewGame` event that any opponent **on any chain** can react to.
 
@@ -86,7 +86,7 @@ This contract relies on a **CREATE2** deployment to ensure a consistent address 
 
   ### Starting the game
 
-  As `AcceptedGame` events are emmited, the player must pick one opponent to play. The opponent's `AcceptedGame` event is used to instantiate the game and play the starting move via the `MovePlayed` event.
+  As `AcceptedGame` events are emitted, the player must pick one opponent to play. The opponent's `AcceptedGame` event is used to instantiate the game and play the starting move via the `MovePlayed` event.
 
   ```solidity
   event MovePlayed(uint256 chainId, uint256 gameId, address player, uint8 _x, uint8 _y);
@@ -103,7 +103,7 @@ This contract relies on a **CREATE2** deployment to ensure a consistent address 
       emit MovePlayed(chainId, gameId, game.player, _x, _y);
   ```
 
-  The event fields contain the information required to perform the neccessary validation.
+  The event fields contain the information required to perform the necessary validation.
 
   *   The game identifier for lookup
   *   The caller is the appropriate player


### PR DESCRIPTION
- **Updated terminology for better clarity:**  
  - "a unqiue nonce" → "a unique nonce"  
  - "events are emmited" → "events are emitted"  
  - "perform the neccessary validation" → "perform the necessary validation"  

#### Modified File:  
- `pages/stack/interop/tutorials/event-reads.mdx`  

### Why are these changes needed?  
These changes improve the documentation’s accuracy, ensuring that developers working with the event-reads tutorial have a clearer understanding of the concepts being presented. 
