### PR TITLE
Fix callout as per @sbvegan

### DIFF
--- a/pages/stack/interop/tutorials/relay-messages-cast.mdx
+++ b/pages/stack/interop/tutorials/relay-messages-cast.mdx
@@ -8,7 +8,7 @@ import { Callout } from 'nextra/components'
 import { Steps } from 'nextra/components'
 
 <Callout>
-The SuperchainERC20 standard is ready for production use with active Mainnet deployments. 
+The SuperchainERC20 standard is ready for production deployments. 
 Please note that the OP Stack interoperability upgrade, required for crosschain messaging, is currently still in active development.
 </Callout>
 

--- a/pages/stack/interop/tutorials/relay-messages-viem.mdx
+++ b/pages/stack/interop/tutorials/relay-messages-viem.mdx
@@ -8,7 +8,7 @@ import { Callout } from 'nextra/components'
 import { Steps } from 'nextra/components'
 
 <Callout>
-The SuperchainERC20 standard is ready for production use with active Mainnet deployments. 
+The SuperchainERC20 standard is ready for production deployments. 
 Please note that the OP Stack interoperability upgrade, required for crosschain messaging, is currently still in active development.
 </Callout>
 


### PR DESCRIPTION
**Description**

@sbvegan asked for changes in the "SuperchainERC20 is ready, but Interop is not" callout, which is also in these two pages.

**Tests**

N/A

**Additional context**

N/A

**Metadata**

N/A