### PR TITLE
Fix function name:

### DIFF
--- a/utils/calculator-helpers.ts
+++ b/utils/calculator-helpers.ts
@@ -52,7 +52,7 @@ function calculateAltDAOrL1TransactionCost(
 
 export function resultsFeeScalarsAssumed(
   comparableTxnType: string, // e15
-  transactionsPerDay: number, // e14
+  transactionsPerDay: number, // e14 
   dataAvailabilityType: string, // E16
   targetDataMargin: number, // E18
   isStateEnabled: string, // E24

--- a/utils/calculator-helpers.ts
+++ b/utils/calculator-helpers.ts
@@ -192,7 +192,7 @@ const getEstimatedSizeCalldataGasRatio = (comparableTxnType: string) => {
 }; // c13 done
 
 // =24/'Chain Estimator'!E22
-const calculateImpliedMinimumBlobsPerDay = (
+const calculateImpliedMinimumL1TxsPerDay = (
   maxChannelDuration: number
 ) => {
   const output = 24 / maxChannelDuration;


### PR DESCRIPTION
Corrects the function name to accurately reflect its purpose - calculating minimum L1 transactions per day rather than blobs per day. The function divides 24 by maxChannelDuration to determine transaction frequency, not blob count.