### PR TITLE
updating batcher and proposer releases

### DIFF
--- a/pages/notices/pectra-changes.mdx
+++ b/pages/notices/pectra-changes.mdx
@@ -75,9 +75,12 @@ The following sections are how chain operators can prepare the first part of the
 
   Follow the guidance outlined in the [Node Operator section](#update-to-the-latest-release) to update your nodes to the latest releases. 
 
-  ### Update your batcher
+  ### Update your batcher and proposer
 
-  Then update your batcher to [`op-batcher/v1.11.3`](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher%2Fv1.11.3).
+  Update your binaries to:
+
+  *   [`op-batcher/v1.11.4`](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher%2Fv1.11.4).
+  *   [`op-proposer/v1.10.0`](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer%2Fv1.10.0).
 
 </Steps>
 


### PR DESCRIPTION
Adding the latest releases of op-batcher and op-proposer to have chain operators update to the latest releases.

Technically the only version that is required for op-batcher is op-batcher/v1.11.0 but the minor releases add some important fixes to handle edge cases for a chain operator. op-proposer technically doesn't need to be updated but it has improvements in there too