### PR TITLE
Supersim install clarification

### DIFF
--- a/pages/app-developers/tutorials/supersim/getting-started/installation.mdx
+++ b/pages/app-developers/tutorials/supersim/getting-started/installation.mdx
@@ -21,7 +21,7 @@ This page provides installation instructions for `supersim`.
 <Steps>
   ### Prerequisites: `foundry`
 
-  `supersim` requires `anvil` to be installed.
+  `supersim` requires `anvil`, which is installed alongside the Foundry toolchain.
 
   Follow the [Foundry toolchain](https://book.getfoundry.sh/getting-started/installation) guide for detailed instructions.
 
@@ -30,7 +30,7 @@ This page provides installation instructions for `supersim`.
 
   *   Prerecompiled binaries: Download the executable for your platform from the [GitHub releases page](https://github.com/ethereum-optimism/supersim/releases).
 
-  *   Homebrew: Install [Homebrew](https://brew.sh/) (OS X, Linux).
+  *   Homebrew: Install [Homebrew](https://brew.sh/) (OS X, Linux), and then run:
 
   ```sh
   brew tap ethereum-optimism/tap
@@ -38,18 +38,20 @@ This page provides installation instructions for `supersim`.
   ```
 
   ### Start `supersim` in vanilla mode
+  Start `supersim` in vanilla mode by running:
 
-  ```sh
+    ```sh
   supersim
   ```
-
   Vanilla mode will start 3 chains, with the OP Stack contracts already deployed.
+  
+    *   (1) L1 Chain
+        *   Chain 900
+    *   (2) L2 Chains
+        *   Chain 901
+        *   Chain 902
 
-  *   (1) L1 Chain
-      *   Chain 900
-  *   (2) L2 Chains
-      *   Chain 901
-      *   Chain 902
+
 </Steps>
 
 ## Next steps

--- a/pages/app-developers/tutorials/supersim/getting-started/installation.mdx
+++ b/pages/app-developers/tutorials/supersim/getting-started/installation.mdx
@@ -26,10 +26,11 @@ This page provides installation instructions for `supersim`.
   Follow the [Foundry toolchain](https://book.getfoundry.sh/getting-started/installation) guide for detailed instructions.
 
   ### Install `supersim`
+  Either download precompiled binaries or install using Homebrew:
 
-  *   Get the precompiled binaries by downloading the executable for your platform from the [GitHub releases page](https://github.com/ethereum-optimism/supersim/releases).
+  *   Prerecompiled binaries: Download the executable for your platform from the [GitHub releases page](https://github.com/ethereum-optimism/supersim/releases).
 
-  *   Get Homebrew (OS X, Linux).
+  *   Homebrew: Install [Homebrew](https://brew.sh/) (OS X, Linux).
 
   ```sh
   brew tap ethereum-optimism/tap

--- a/words.txt
+++ b/words.txt
@@ -304,6 +304,7 @@ preimages
 preinstall
 Preinstalls
 preinstalls
+Prerecompiled
 Prestate
 prestate
 prestates


### PR DESCRIPTION
Clarifies that Supersim can be installed in two ways, and clarifies structure throughout