### PR TITLE
Add links for ERC-7802

### DIFF
--- a/pages/app-developers/starter-kit.mdx
+++ b/pages/app-developers/starter-kit.mdx
@@ -33,7 +33,7 @@ The [SuperchainERC20 Starter Kit](https://github.com/ethereum-optimism/superchai
 
 Here's a breakdown of what's under the hood:
 
-*   **Cross-Chain Interoperability**: SuperchainERC20 tokens can move across multiple chains. This is possible by using the IERC7802 interface, which lets tokens be minted on one chain and burned on another to maintain a consistent supply.
+*   **Cross-Chain Interoperability**: SuperchainERC20 tokens can move across multiple chains. This is possible by using the [IERC-7802](https://eips.ethereum.org/EIPS/eip-7802) interface, which lets tokens be minted on one chain and burned on another to maintain a consistent supply.
 
 *   **Superchain Network**: The Superchain is a network of connected blockchains, allowing smooth data and asset flow. By using Optimism's scaling solutions, the Superchain reduces gas fees and speeds up transactions.
 

--- a/pages/stack/interop/compatible-tokens.mdx
+++ b/pages/stack/interop/compatible-tokens.mdx
@@ -56,7 +56,7 @@ If a 3rd party interop solution is providing faster-than-Ethereum L1 finality (1
 While the `SuperchainERC20` is a trust-minimized way to enable for giving your token Superchain interop capabilities, other token implementations can also benefit from Superchain interop. If you choose a token standard other than SuperchainERC20 here are a few things to consider:
 
 #### ERC-7802
-[`ERC-7802`](https://ethereum-magicians.org/t/erc-7802-crosschain-token-interface/21508) is a minimal cross-chain mint/burn interface designed to establish a common standard across the EVM ecosystem for tokens to communicate cross-chain. Adding this interface to your token ensures downstream integrators can easily support your token.
+[`ERC-7802`](https://eips.ethereum.org/EIPS/eip-7802) is a minimal cross-chain mint/burn interface designed to establish a common standard across the EVM ecosystem for tokens to communicate cross-chain. Adding this interface to your token ensures downstream integrators can easily support your token.
 
 #### SuperchainTokenBridge and L2ToL2CrossDomainMessenger
 Tokens can benefit from Superchain interop by either giving cross-chain mint/burn permissions to the `SuperchainTokenBridge` or the `L2ToL2CrossDomainMessenger`. 
@@ -113,7 +113,7 @@ NTT is a token standard used to send, receive, and compose tokens across chains 
 
 *   `SuperchainERC20` is a simple and trust-minimized way for token issuers to make their token available across the Superchain interop cluster.
 *   Token issuers can use other token standards (xERC20, OFT, NTT) and give  `crosschainMint` and `crosschainBurn` permissions to the `SuperchainTokenBridge` or `L2ToL2CrossDomainMessenger` to benefit from Superchain interop. 
-*   Token issuers should include a `ERC-7802` interface on their token to simplify downstream integrations.
+*   Token issuers should include a [ERC-7802](https://eips.ethereum.org/EIPS/eip-7802) interface on their token to simplify downstream integrations.
 
 ## Next steps
 

--- a/pages/stack/interop/superchain-erc20.mdx
+++ b/pages/stack/interop/superchain-erc20.mdx
@@ -17,7 +17,7 @@ SuperchainERC20s can be deployed on any chain, but will only be interoperable wi
 
 # SuperchainERC20
 
-The [`SuperchainERC20`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/SuperchainERC20.sol) contract implements [ERC-7802](https://ethereum-magicians.org/t/erc-7802-crosschain-token-interface/21508) to enable asset interoperability within the Superchain.
+The [`SuperchainERC20`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/SuperchainERC20.sol) contract implements [ERC-7802](https://eips.ethereum.org/EIPS/eip-7802) to enable asset interoperability within the Superchain.
 
 Asset interoperability allows tokens to move securely across the Superchain by burning tokens on the source chain and minting an equivalent amount on the destination chain. This approach addresses issues such as liquidity fragmentation and poor user experiences caused by asset wrapping or reliance on liquidity pools.
 
@@ -27,7 +27,7 @@ Additional features:
 
 *   **Simplified deployments**: Zero infrastructure cost to make your token cross-chain.
     Provides a consistent, unified implementation for tokens across all Superchain-compatible networks and a common cross-chain interface for the EVM ecosystem at large.
-*   **Common standard**: Implements ERC-7802, a unified interface that can be used across all of Ethereum to enable cross-chain mint/burn functionality.
+*   **Common standard**: Implements [ERC-7802](https://eips.ethereum.org/EIPS/eip-7802), a unified interface that can be used across all of Ethereum to enable cross-chain mint/burn functionality.
 
 ## How it works
 

--- a/pages/stack/interop/tutorials/custom-superchain-erc20.mdx
+++ b/pages/stack/interop/tutorials/custom-superchain-erc20.mdx
@@ -31,7 +31,7 @@ Here we will use the [SuperchainERC20 Starter Kit](/app-developers/starter-kit).
 
 ### How does this work?
 
-To benefit from Superchain Interoperability, an ERC-20 token has to implement ERC-7802. You can either use the SuperchainERC20 implementation, or write your own.
+To benefit from Superchain Interoperability, an ERC-20 token has to implement [ERC-7802](https://eips.ethereum.org/EIPS/eip-7802). You can either use the SuperchainERC20 implementation, or write your own.
 
 At a high level you will:
 
@@ -60,7 +60,7 @@ contract MyERC20 is ERC20, Ownable {
 
 ### Add the new SuperchainERC20 interface 
 
-The first step is simply to implement `IERC7802` and `IERC165`. Note that we've renamed the contract at this point:
+The first step is simply to implement [`IERC7802`](https://eips.ethereum.org/EIPS/eip-7802) and `IERC165`. Note that we've renamed the contract at this point:
 
 ```solidity
 // SPDX-License-Identifier: MIT


### PR DESCRIPTION
This pull request includes several updates to documentation files to standardize references to the ERC-7802 interface by linking to the official Ethereum Improvement Proposal (EIP) page. The most important changes are listed below:

Standardization of ERC-7802 references:
