### PR TITLE
Remove extraneous 'Optimism' from predeploy section

### DIFF
--- a/pages/stack/interop/predeploy.mdx
+++ b/pages/stack/interop/predeploy.mdx
@@ -58,7 +58,7 @@ This contract is the `Beacon` part, which provides the implementation address fo
 
 ## SuperchainTokenBridge
 
-The `SuperchainTokenBridge` is an abstraction on top of the `L2ToL2CrossDomainMessenger` that facilitates token bridging using interop. It has mint and burn rights over `OptimismSuperchainERC20` tokens, as described in the [token bridging spec](https://specs.optimism.io/interop/token-bridging.html).
+The `SuperchainTokenBridge` is an abstraction on top of the `L2ToL2CrossDomainMessenger` that facilitates token bridging using interop. It has mint and burn rights over `SuperchainERC20` tokens, as described in the [token bridging spec](https://specs.optimism.io/interop/token-bridging.html).
 
 *   **Address:** `0x4200000000000000000000000000000000000028`
 *   **Specs:** [`SuperchainTokenBridge`](https://specs.optimism.io/interop/predeploys.html#superchainerc20bridge)


### PR DESCRIPTION
Fixing typo, should be called `SuperchainERC20`

