### PR TITLE
chore: fix typo in results table

### DIFF
--- a/components/calculator/ResultsTable.tsx
+++ b/components/calculator/ResultsTable.tsx
@@ -134,7 +134,7 @@ export function ResultsTable({
             </thead>
             <tbody>
               <tr>
-                <td>l1BlobBaseBaseScalar</td>
+                <td>l1BlobBaseFeeScalar</td>
                 <td>{l1BlobBaseFeeScalar}</td>
                 <td>{convertToMillionUnits(l1BlobBaseFeeScalar)}</td>
               </tr>


### PR DESCRIPTION
**Description**

Spotted a small typo—`l1BlobBaseBaseScalar` had an extra "Base." Fixed it to match the correct name.