### PR TITLE
Updated safedb env variable

### DIFF
--- a/pages/operators/node-operators/configuration/consensus-config.mdx
+++ b/pages/operators/node-operators/configuration/consensus-config.mdx
@@ -740,7 +740,7 @@ File path used to persist safe head update data. Disabled if not set.
 <Tabs items={['Syntax', 'Example', 'Environment Variable']}>
   <Tabs.Tab>`--safedb.path=<value>`</Tabs.Tab>
   <Tabs.Tab>`--safedb.path=/db`</Tabs.Tab>
-  <Tabs.Tab>`SAFEDB_PATH=/db`</Tabs.Tab>
+  <Tabs.Tab>`OP_NODE_SAFEDB_PATH=/db`</Tabs.Tab>
 </Tabs>
 
 ### sequencer.enabled


### PR DESCRIPTION
The change updates an environment variable 
* Updated environment variable name from `SAFEDB_PATH` to `OP_NODE_SAFEDB_PATH` in `pages/operators/node-operators/configuration/consensus-config.mdx`.