### PR TITLE
fix: interop message passing

### DIFF
--- a/pages/stack/interop/message-passing.mdx
+++ b/pages/stack/interop/message-passing.mdx
@@ -43,7 +43,7 @@ sequenceDiagram
 
 1.  The application sends a transaction to a contract on the source chain.
 
-2.  The contract calls [`L2ToL2CrossDomainMessenger.SendMessage`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol#L127-L154).
+2.  The contract calls [`L2ToL2CrossDomainMessenger.SendMessage`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol#L125-L142).
     The call requires these parameters:
 
     *   `_destination`: The chain ID of the destination blockchain.
@@ -88,8 +88,8 @@ sequenceDiagram
 
 1.  Before the executing message is processed, the log event of the initiating message has to get to `op-supervisor` on the destination chain.
 
-2.  The autorelayer, the application, or a contract calling on the application's behalf calls [`L2ToL2CrossDomainMessenger.SendMessage.relayMessage`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol#L156-L216).
-    This call includes the message that was sent (`_sendMessage`), as well as the [fields required to find that message (`_id`)](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/interfaces/L2/ICrossL2Inbox.sol#L4-L10).
+2.  The autorelayer, the application, or a contract calling on the application's behalf calls [`L2ToL2CrossDomainMessenger.relayMessage`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol#L150-L203).
+    This call includes the message that was sent (`_sentMessage`), as well as the [fields required to find that message (`_id`)](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/interfaces/L2/ICrossL2Inbox.sol#L4-L10).
 
 3.  The `L2ToL2CrossDomainMessenger` uses `CrossL2Inbox` to verify the message was sent from the source.
 


### PR DESCRIPTION
1. Fix typos
2. Fix links to `L2ToL2CrossDomainMessenger.sol` since contract has changed via https://github.com/ethereum-optimism/optimism/pull/14790. Maybe pinning via commit hash is helpful.