### PR TITLE
Fix Grammar, Formatting & Terminology

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -23,7 +23,7 @@ if [ -n "$(git status --porcelain)" ]; then
   git add .
   
   # Create a commit with a descriptive message
-  git commit -m "Auto-fix: Update breadcrumbs, spelling dictionary and other automated fixes"
+  git commit -m "Auto-fix: Updated breadcrumbs, spelling dictionary and other automated fixes"
   
   echo "✅ Changes committed automatically. Continuing with push..."
 else

--- a/lib/growthbook.ts
+++ b/lib/growthbook.ts
@@ -3,7 +3,7 @@ import { GrowthBook } from '@growthbook/growthbook-react';
 
 export const growthbook = new GrowthBook({
   apiHost: process.env.NEXT_PUBLIC_GROWTHBOOK_API_HOST || '',
-  clientKey: process.env.NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY || ''
+  clientKey: process.env.NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY || '',
 });
 
 if (process.env.NEXT_PUBLIC_GROWTHBOOK_API_HOST && process.env.NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY) {

--- a/notes/content-reuse.md
+++ b/notes/content-reuse.md
@@ -30,7 +30,7 @@ Text after
 
 ### How to Use Multiple Reusable Content Components
 
-1. You can create a `index.js` file in the `content` directories and export 
+1. You can create an `index.js` file in the `content` directory and export 
 the components like this:
 
 ```

--- a/pages/app-developers/tools/build/nft-tools.mdx
+++ b/pages/app-developers/tools/build/nft-tools.mdx
@@ -38,7 +38,7 @@ These tools are available on OP Mainnet:
 ## Feature comparison
 
 <Callout>
-  This list was last updated early February 2024, but new features are implemented all the time.
+  This list was last updated in early February 2024, but new features are implemented all the time.
 </Callout>
 
 |                    | NiftyKit                                                                   | NFT-Inator                                                                | Mintplex                                                      | Zero Code NFT                         | thirdweb                                                                                                            | Crossmint                                                                                                                                                                         |

--- a/pages/app-developers/tools/build/oracles.mdx
+++ b/pages/app-developers/tools/build/oracles.mdx
@@ -2,7 +2,7 @@
 title: Oracles
 description: >-
   Learn about different oracles and how you can use them to access offchain data
-  onchain as well as random number generation.
+  onchain as well as for random number generation.
 lang: en-US
 content_type: guide
 topic: oracles

--- a/pages/app-developers/tools/build/oracles.mdx
+++ b/pages/app-developers/tools/build/oracles.mdx
@@ -1,4 +1,4 @@
----
+RNG---
 title: Oracles
 description: >-
   Learn about different oracles and how you can use them to access offchain data
@@ -48,7 +48,7 @@ There are two types of oracles:
     2.  Single-transaction oracles, which only require one transaction. The way this works is that the transaction that requests the information includes a callback (address and the call data to provide it).
         When the oracle is updated (which also happens through a transaction, but one that is not sent by the user), the oracle uses the callback to inform a contract of the result.
 
-## Random number generation (RGN)
+## Random number generation (RNG)
 
 Random number generation in blockchain applications ensures that smart contracts can access unbiased random values. This is essential for certain use cases like generative NFTs, gaming, commit & reveal schemes and more. Various approaches include using a trusted third party, blockhash-based methods, Verifiable Random Functions (VRF), quantum random numbers to name a few. Each method has trade-offs between simplicity, security, and trust assumptions, allowing developers to select the most suitable option for their use case.
 


### PR DESCRIPTION
Changes Summary:
.husky/pre-push → Changed "Update" → "Updated" (past tense correction).
lib/growthbook.ts → Formatting fix for better readability.
notes/content-reuse.md → "directories" → "directory" (singular), "a" → "an" (vowel sound).
nft-tools.mdx → Added "in" before "early February" (grammar fix).
oracles.mdx →
Added "for" in "random number generation" (grammar fix).
Corrected "RGN" → "RNG" (correct abbreviation).
Purpose:
Fix minor grammar, terminology, and formatting issues for clarity and correctness. 