### PR TITLE
fix: correct spelling of 'OptimismPortal' in upgrade-13 notice

### DIFF
--- a/pages/notices/upgrade-13.mdx
+++ b/pages/notices/upgrade-13.mdx
@@ -67,7 +67,7 @@ Several components have been updated to improve incident response capabilities:
 
 **OptimismPortal**
 
-*   `OptimsimPortal.setRespectedGameType(...)` no longer sets the respected game type and retirement timestamp simultaneously
+*   `OptimismPortal.setRespectedGameType(...)` no longer sets the respected game type and retirement timestamp simultaneously
 *   A special reserved input value can be used to set the retirement timestamp
 *   `OptimismPortal.checkWithdrawal(...)` now asserts that a FaultDisputeGame was the respected game type at the time of creation
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR corrects the spelling error by replacing "OptimsimPortal" with "OptimismPortal" in the upgrade-13 notice.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
