### PR TITLE
feat : add and update rpc-providers

### DIFF
--- a/pages/app-developers/tools/connect/rpc-providers.mdx
+++ b/pages/app-developers/tools/connect/rpc-providers.mdx
@@ -51,6 +51,17 @@ Moreover, Ankr offers access to developer tooling on OP Mainnet (and testnets) l
 *   OP Mainnet
 *   OP Sepolia
 
+## All That Node
+
+### Description and pricing
+
+[All That Node](https://www.allthatnode.com/protocol/optimism.dsrv) is a high-performance and reliable RPC provider offering full and archive nodes on both Optimism Mainnet and Sepolia Testnet. We provide flexible access through HTTPS and WebSocket protocols, supporting a wide range of use cases with free plans, paid plans, and dedicated nodes, perfect for developers and enterprises alike.
+
+### Supported networks
+
+*   OP Mainnet
+*   OP Sepolia
+
 ## Blockdaemon
 
 ### Description and pricing

--- a/pages/app-developers/tools/connect/rpc-providers.mdx
+++ b/pages/app-developers/tools/connect/rpc-providers.mdx
@@ -55,7 +55,7 @@ Moreover, Ankr offers access to developer tooling on OP Mainnet (and testnets) l
 
 ### Description and pricing
 
-[All That Node](https://www.allthatnode.com/protocol/optimism.dsrv) is a high-performance and reliable RPC provider offering full and archive nodes on both Optimism Mainnet and Sepolia Testnet. We provide flexible access through HTTPS and WebSocket protocols, supporting a wide range of use cases with free plans, paid plans, and dedicated nodes, perfect for developers and enterprises alike.
+[All That Node](https://www.allthatnode.com/protocol/optimism.dsrv) is a high-performance and reliable RPC provider offering full and archive nodes on both Optimism Mainnet and Sepolia Testnet. It provides flexible access through HTTPS and WebSocket protocols, supporting a wide range of use cases with free plans, paid plans, and dedicated nodes, ideal for developers and enterprises alike.
 
 ### Supported networks
 


### PR DESCRIPTION
**Description**

This PR adds All That Node (https://allthatnode.com) to the list of node providers in the Optimism ecosystem documentation. It’s a reliable RPC service compatible with Optimism, offering developers an additional endpoint for building on the network.

**Tests**

No tests were added since this is a documentation update.

**Additional context**

All That Node is a trusted provider supporting multiple blockchains, and adding it to the Optimism docs will give developers more options for reliable node access, enhancing the ecosystem’s accessibility.

**Metadata**

None