### PR TITLE
Remove legacy legacy deployment script from docs

### DIFF
--- a/pages/operators/chain-operators/deploy/smart-contracts.mdx
+++ b/pages/operators/chain-operators/deploy/smart-contracts.mdx
@@ -35,67 +35,12 @@ The recommended way to deploy the L1 smart contracts is with the `op-deployer` t
 Follow the steps in this [section](/operators/chain-operators/tutorials/create-l2-rollup#using-op-deployer) to learn how it works.
 
 
-## Deployment script (Legacy method)
-
-<Callout type="warning">
-  The following deployment information outlines the legacy method for deploying the OP Stack L1 contracts.
-  This method is not recommended and is provided only for historical context.
-</Callout>
-
-The legacy method for deploying smart contracts uses [foundry](https://github.com/foundry-rs) and the deployment script located in the monorepo at
-[packages/contracts-bedrock/scripts/deploy/Deploy.s.sol](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol).
-
-### State diff
-
-You can verify the state diff before deploying the contracts by using the `runWithStateDiff()` function in the deployment script.
-This produces outputs in [`snapshots/state-diff/`](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts-bedrock/snapshots/state-diff).
-Run the deployment with state diffs using the following command:
-
-```bash
-forge script -vvv scripts/deploy/Deploy.s.sol:Deploy --sig 'runWithStateDiff()' --rpc-url $ETH_RPC_URL --broadcast --private-key $PRIVATE_KEY
-```
-
-### Execution
-
-*   Set the `ETHERSCAN_API_KEY` and add the `--verify` flag to verify your
-    contracts.
-*   `DEPLOYMENT_OUTFILE` will determine the filepath that the deployment
-    artifact is written to on disk after the deployment. It comes in the form of a
-    JSON file where keys are the names of the contracts and the values are the
-    addresses the contract was deployed to.
-*   `DEPLOY_CONFIG_PATH` is the path on the filesystem that points to a deployment
-    config. The same deployment config JSON file should be used for L1 contracts
-    deployment as when generating the L2 genesis allocs. See the [deploy-config](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts-bedrock/deploy-config)
-    directory for examples and the [rollup configuration page](/operators/chain-operators/configuration/rollup)
-    for descriptions of the values.
-*   `IMPL_SALT` env var can be used to set the create2 salt for deploying the
-    implementation contracts.
-
-This will deploy an entire new system of L1 smart contracts, including a new
-SuperchainConfig. In the future, there will be an easy way to deploy only
-proxies and use shared implementations for each of the contracts as well as a
-shared SuperchainConfig contract.
-
-```
-DEPLOYMENT_OUTFILE=deployments/artifact.json \
-DEPLOY_CONFIG_PATH=<PATH_TO_MY_DEPLOY_CONFIG> \
-  forge script scripts/deploy/Deploy.s.sol:Deploy \
-  --broadcast --private-key $PRIVATE_KEY \
-  --rpc-url $ETH_RPC_URL
-```
-
-### Deploying a single contract
-
-All functions for deploying a single contract are public, meaning that
-the `--sig` argument to forge script can be used to target the deployment of a
-single contract.
-
 ## Best practices
 
 Production users should deploy their L1 contracts from a contracts release.
 All contracts releases are on git tags with the following format:
 `op-contracts/vX.Y.Z`. If you're deploying a new standard chain, you should
-deploy the [Fault Proof Fixes release](https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.6.0) with the permissioned game type
+deploy the [Fault Proof Fixes release](https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv2.0.0-rc.1) with the permissioned game type
 enabled.
 Starting with permissioned fault proofs gives chain operators time to get comfortable
 running the additional infrastructure requirements: [op-challenger](https://github.com/ethereum-optimism/optimism/tree/develop/op-challenger) and

--- a/pages/operators/chain-operators/deploy/smart-contracts.mdx
+++ b/pages/operators/chain-operators/deploy/smart-contracts.mdx
@@ -40,7 +40,7 @@ Follow the steps in this [section](/operators/chain-operators/tutorials/create-l
 Production users should deploy their L1 contracts from a contracts release.
 All contracts releases are on git tags with the following format:
 `op-contracts/vX.Y.Z`. If you're deploying a new standard chain, you should
-deploy the [Fault Proof Fixes release](https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv2.0.0-rc.1) with the permissioned game type
+deploy the latest Optimism Governance approved release of the L1 smart contracts with [op-deployer](/operators/chain-operators/tools/op-deployer). This will only initially deploy with permissioned dispute games
 enabled.
 Starting with permissioned fault proofs gives chain operators time to get comfortable
 running the additional infrastructure requirements: [op-challenger](https://github.com/ethereum-optimism/optimism/tree/develop/op-challenger) and

--- a/pages/operators/chain-operators/tutorials/create-l2-rollup.mdx
+++ b/pages/operators/chain-operators/tutorials/create-l2-rollup.mdx
@@ -422,11 +422,6 @@ Once you've configured your network, it's time to deploy the L1 contracts necess
 The `op-deployer` tool simplifies the creation of genesis and rollup configuration files (`genesis.json` and `rollup.json`).
 These files are crucial for initializing the execution client (`op-geth`) and consensus client (`op-node`) for your network.
 
-```bash
-
-forge script scripts/deploy/Deploy.s.sol:Deploy --private-key $GS_ADMIN_PRIVATE_KEY --broadcast --rpc-url $L1_RPC_URL --slow
-
-```
 The recommended flow for creating a genesis file and rollup configuration file on the OP Stack is as follows:
 
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**


Remove all instructions in the docs that shows how to use the legacy deployment script.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

- Fixes: https://github.com/ethereum-optimism/devrel/issues/572
