### PR TITLE
Add description for admin_sequencerActive RPC endpoint

### DIFF
--- a/pages/operators/node-operators/json-rpc.mdx
+++ b/pages/operators/node-operators/json-rpc.mdx
@@ -967,7 +967,7 @@ todo: add Sample success output
 
 #### `admin_sequencerActive`
 
-Returns whether the sequencer is currently active. This endpoint can be used to check the current state of the sequencer process.
+Returns the status of the sequencer. This endpoint provides real-time information about whether the sequencer is actively processing transactions.
 
 <Tabs items={['curl', 'cast']}>
   <Tabs.Tab>

--- a/pages/operators/node-operators/json-rpc.mdx
+++ b/pages/operators/node-operators/json-rpc.mdx
@@ -967,7 +967,7 @@ todo: add Sample success output
 
 #### `admin_sequencerActive`
 
-TODO: add description
+Returns whether the sequencer is currently active. This endpoint can be used to check the current state of the sequencer process.
 
 <Tabs items={['curl', 'cast']}>
   <Tabs.Tab>


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Added a clear description for the admin_sequencerActive JSON-RPC endpoint in the node operators documentation. The description explains that this endpoint returns the current status of the sequencer process and its purpose. This completes the documentation for the admin namespace endpoints.