### PR TITLE
Add RC-alpha for testing purposes

### DIFF
--- a/pages/app-developers/tutorials/bridging/standard-bridge-custom-token.mdx
+++ b/pages/app-developers/tutorials/bridging/standard-bridge-custom-token.mdx
@@ -88,7 +88,7 @@ This is just one example of the endless ways in which you could customize your L
 
   Copy the following example contract into your new file:
 
-  ```solidity file=<rootDir>/public/tutorials/standard-bridge-custom-token.sol#L1-L189 hash=07ca2fe7fcbbbe2dc06c07cb1fb72d91
+  ```solidity file=<rootDir>/public/tutorials/standard-bridge-custom-token.sol#L1-L189 hash=087b70cdb85338a213497a64dd049322
   ```
 
   {<h3>Review the example contract</h3>}

--- a/pages/stack/interop/tools.mdx
+++ b/pages/stack/interop/tools.mdx
@@ -26,4 +26,6 @@ Documentation covering Interop devnet, Supersim in the Interop section of the OP
 
   <Card title="Interop devnet" href="/stack/interop/tools/devnet" icon={<img src="/img/icons/shapes.svg" />} />
 
+  <Card title="Release Candidate Alpha devnet" href="/stack/interop/tools/rc-alpha" icon={<img src="/img/icons/shapes.svg" />} />
+
 </Cards>

--- a/pages/stack/interop/tools/_meta.json
+++ b/pages/stack/interop/tools/_meta.json
@@ -1,5 +1,5 @@
 {
-    "devnet": "Superchain interop devnet" 
+    "devnet": "Superchain interop devnet", 
     "supersim": "Supersim Multichain Development Environment",
     "rc-alpha": "Release Candidate Alpha devnet" 
 }

--- a/pages/stack/interop/tools/_meta.json
+++ b/pages/stack/interop/tools/_meta.json
@@ -1,4 +1,5 @@
 {
+    "devnet": "Superchain interop devnet" 
     "supersim": "Supersim Multichain Development Environment",
-    "devnet": "Interop devnet" 
+    "rc-alpha": "Release Candidate Alpha devnet" 
 }

--- a/pages/stack/interop/tools/devnet.mdx
+++ b/pages/stack/interop/tools/devnet.mdx
@@ -1,6 +1,6 @@
 ---
-title: Interop devnet
-description: Details on the public interoperability devnet
+title: Superchain interop devnet
+description: Details on the public Superchain interoperability devnet
 lang: en-US
 content_type: guide
 topic: interop-devnet
@@ -20,13 +20,13 @@ is_imported_content: 'false'
 
 import { Callout, Tabs, Steps } from 'nextra/components'
 
-# Interop devnet
+# Superchain interop devnet
 
 <Callout>
-  Interop devnet is currently in active development and may experience periods of instability, including potential outages, as the networks are regularly updated and improved. Developers should expect some level of unreliability when interacting with the devnet. The devnet is intended for testing and development purposes only, and should not be relied upon for mission-critical applications.
+  Superchain interop devnet is currently in active development and may experience periods of instability, including potential outages, as the networks are regularly updated and improved. Developers should expect some level of unreliability when interacting with the devnet. The devnet is intended for testing and development purposes only, and should not be relied upon for mission-critical applications.
 </Callout>
 
-The Interop devnet is a temporary public network of two OP Stack Sepolia instances that support Superchain interop enabling native ETH and SuperchainERC20 cross-chain token transfers. As we iterate on Superchain interop, these networks will be deprecated once the next devnets are released.
+The Superchain interop devnet is a temporary public network of two OP Stack Sepolia instances that support Superchain interop enabling native ETH and SuperchainERC20 cross-chain token transfers. As we iterate on Superchain interop, these networks will be deprecated once the next devnets are released.
 
 ## Interop devnet 0
 

--- a/pages/stack/interop/tools/rc-alpha.mdx
+++ b/pages/stack/interop/tools/rc-alpha.mdx
@@ -30,53 +30,48 @@ import { Callout, Tabs, Steps } from 'nextra/components'
   Release Candidate - Alpha is meant only for protocol testing. If you're an application developer looking to test your interop-enabled application we recommend using the [Superchain interop devnet](https://docs.optimism.io/stack/interop/tools/devnet).
 </Callout>
 
-
 ## Interop RC Alpha 0
 
-| Parameter                   | Value                                                                                                                                                                                    |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Network Name                | `interop-rc-alpha-0`                                                                                                                                                                     |
-| Chain ID                    | `420120003`                                                                                                                                                                              |
-| Currency Symbol<sup>1</sup> | ETH                                                                                                                                                                                      |
-| Block Explorer              | n/a  |
-| Public RPC URL              | [https://interop-rc-alpha-0.optimism.io](https://interop-rc-alpha-0.optimism.io)                                                                                                               |
-| Sequencer URL               | [https://interop-rc-alpha-0.optimism.io](https://interop-rc-alpha-0.optimism.io)                                                                                                               |
-| OptimismPortal<sup>2</sup>  | `0xbd80b66b60a6c6580aa0a92783bdb4c42b1405c4`                                                                                                                                             |
+| Parameter                   | Value                                                                            |
+| --------------------------- | -------------------------------------------------------------------------------- |
+| Network Name                | `interop-rc-alpha-0`                                                             |
+| Chain ID                    | `420120003`                                                                      |
+| Currency Symbol<sup>1</sup> | ETH                                                                              |
+| Block Explorer              | n/a                                                                              |
+| Public RPC URL              | [https://interop-rc-alpha-0.optimism.io](https://interop-rc-alpha-0.optimism.io) |
+| Sequencer URL               | [https://interop-rc-alpha-0.optimism.io](https://interop-rc-alpha-0.optimism.io) |
+| OptimismPortal<sup>2</sup>  | `0xbd80b66b60a6c6580aa0a92783bdb4c42b1405c4`                                     |
 
 ## Interop RC Alpha 1
 
-| Parameter                   | Value                                                                                                                                                                                    |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Network Name                | `interop-rc-alpha-1`                                                                                                                                                                        |
-| Chain ID                    | `420120004`                                                                                                                                                                              |
-| Currency Symbol<sup>1</sup> | ETH                                                                                                                                                                                      |
-| Block Explorer              | n/a |
-| Public RPC URL              | [https://interop-rc-alpha-1.optimism.io](https://interop-rc-alpha-1.optimism.io)                                                                                                               |
-| Sequencer URL               | [https://interop-rc-alpha-1.optimism.io](https://interop-rc-alpha-1.optimism.io)                                                                                                               |
-| OptimismPortal<sup>2</sup>  | `0x92b3b2d4032492cd177fefa20e67c64826ccbc70`                                                                                                                                             |
+| Parameter                   | Value                                                                            |
+| --------------------------- | -------------------------------------------------------------------------------- |
+| Network Name                | `interop-rc-alpha-1`                                                             |
+| Chain ID                    | `420120004`                                                                      |
+| Currency Symbol<sup>1</sup> | ETH                                                                              |
+| Block Explorer              | n/a                                                                              |
+| Public RPC URL              | [https://interop-rc-alpha-1.optimism.io](https://interop-rc-alpha-1.optimism.io) |
+| Sequencer URL               | [https://interop-rc-alpha-1.optimism.io](https://interop-rc-alpha-1.optimism.io) |
+| OptimismPortal<sup>2</sup>  | `0x92b3b2d4032492cd177fefa20e67c64826ccbc70`                                     |
 
 1.  The "currency symbol" is required by some wallets like MetaMask.
 2.  The `OptimismPortal` is a low-level contract responsible for passing messages between L1 and L2. You can send `ETH` directly to the portal to receive it to the sender address on the L2.
 
-
-
 ## Bridging ETH to the Release Candidate - Alpha devnet
 
 <Steps>
-  
   ### Get Sepolia ETH from the Superchain Faucet
 
   You can utilize the [Superchain Faucet](https://console.optimism.io/faucet) to get `ETH` on Sepolia.
 
   ### Send the Sepolia ETH to the devnet
 
-  You can send `ETH` directly to the `OptimismPortal` address and it will go to the same sender address on the devnet. 
+  You can send `ETH` directly to the `OptimismPortal` address and it will go to the same sender address on the devnet.
 
   ### Wait for bridging to complete
 
   It'll take approximately 2 minutes for the bridging process from Sepolia to L2 to complete and the `ETH` to appear in your wallet.
 </Steps>
-
 
 ## Next steps
 

--- a/pages/stack/interop/tools/rc-alpha.mdx
+++ b/pages/stack/interop/tools/rc-alpha.mdx
@@ -1,0 +1,84 @@
+---
+title: Release candidate - Alpha
+description: Details on the public Release candidate - Alpha devnet
+lang: en-US
+content_type: guide
+topic: interop-devnet
+personas:
+  - protocol-developer
+  - app-developer
+categories:
+  - testnet
+  - protocol
+  - interoperability
+  - cross-chain-messaging
+  - devnet
+  - standard-bridge
+  - superchain-registry
+is_imported_content: 'false'
+---
+
+import { Callout, Tabs, Steps } from 'nextra/components'
+
+# Release Candidate - Alpha
+
+<Callout>
+  Release candidate - Alpha devnet is currently in active development and may experience periods of instability, including potential outages, as the networks are regularly updated and improved. Developers should expect some level of unreliability when interacting with the devnet. The devnet is intended for protocol testing only, and should not be relied upon for mission-critical applications.
+</Callout>
+
+<Callout>
+  Release Candidate - Alpha is meant only for protocol testing. If you're an application developer looking to test your interop-enabled application we recommend using the [Superchain interop devnet](https://docs.optimism.io/stack/interop/tools/devnet).
+</Callout>
+
+
+## Interop RC Alpha 0
+
+| Parameter                   | Value                                                                                                                                                                                    |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Network Name                | `interop-rc-alpha-0`                                                                                                                                                                     |
+| Chain ID                    | `420120003`                                                                                                                                                                              |
+| Currency Symbol<sup>1</sup> | ETH                                                                                                                                                                                      |
+| Block Explorer              | n/a  |
+| Public RPC URL              | [https://interop-rc-alpha-0.optimism.io](https://interop-rc-alpha-0.optimism.io)                                                                                                               |
+| Sequencer URL               | [https://interop-rc-alpha-0.optimism.io](https://interop-rc-alpha-0.optimism.io)                                                                                                               |
+| OptimismPortal<sup>2</sup>  | `0xbd80b66b60a6c6580aa0a92783bdb4c42b1405c4`                                                                                                                                             |
+
+## Interop RC Alpha 1
+
+| Parameter                   | Value                                                                                                                                                                                    |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Network Name                | `interop-rc-alpha-1`                                                                                                                                                                        |
+| Chain ID                    | `420120004`                                                                                                                                                                              |
+| Currency Symbol<sup>1</sup> | ETH                                                                                                                                                                                      |
+| Block Explorer              | n/a |
+| Public RPC URL              | [https://interop-rc-alpha-1.optimism.io](https://interop-rc-alpha-1.optimism.io)                                                                                                               |
+| Sequencer URL               | [https://interop-rc-alpha-1.optimism.io](https://interop-rc-alpha-1.optimism.io)                                                                                                               |
+| OptimismPortal<sup>2</sup>  | `0x92b3b2d4032492cd177fefa20e67c64826ccbc70`                                                                                                                                             |
+
+1.  The "currency symbol" is required by some wallets like MetaMask.
+2.  The `OptimismPortal` is a low-level contract responsible for passing messages between L1 and L2. You can send `ETH` directly to the portal to receive it to the sender address on the L2.
+
+
+
+## Bridging ETH to the Release Candidate - Alpha devnet
+
+<Steps>
+  ### Get Sepolia ETH from the Superchain Faucet
+
+  You can utilize the [Superchain Faucet](https://console.optimism.io/faucet) to get `ETH` on Sepolia.
+
+  ### Send the Sepolia ETH to the devnet
+
+  You can send `ETH` directly to the `OptimismPortal` address and it will go to the same sender address on the devnet. 
+
+  ### Wait for bridging to complete
+
+  It'll take approximately 2 minutes for the bridging process from Sepolia to L2 to complete and the `ETH` to appear in your wallet.
+</Steps>
+
+
+## Next steps
+
+*   Build a [revolutionary app](/app-developers/get-started) that uses multiple blockchains within the Superchain
+*   Deploy a [SuperchainERC20](/stack/interop/tutorials/deploy-superchain-erc20) to the Superchain
+*   View more [interop tutorials](/stack/interop/tutorials)

--- a/pages/stack/interop/tools/rc-alpha.mdx
+++ b/pages/stack/interop/tools/rc-alpha.mdx
@@ -63,6 +63,7 @@ import { Callout, Tabs, Steps } from 'nextra/components'
 ## Bridging ETH to the Release Candidate - Alpha devnet
 
 <Steps>
+  
   ### Get Sepolia ETH from the Superchain Faucet
 
   You can utilize the [Superchain Faucet](https://console.optimism.io/faucet) to get `ETH` on Sepolia.


### PR DESCRIPTION
Adding devnet docs page for RC-alpha, for testing purposes only.

## Context
We are trying to run benchmarking to inform Executing Message Pricing and plan to use RC Alpha to uncover this info. 

> I'm trying to get to a metric of what is the max amount of compute time that e.g. 1m gas can cause, without anything to do with interop. For example, we'd found previously that XEN transactions that do a ton of SSTORES and SLOADs take up significantly more time per gas used than other transactions. Basically if we find something like (most time taken by spending 1m gas = 0.5s), and if a lookup takes 0.1s, then that gives us an estimate for how much we should be charging: 1m/5 = 200k gas charged per lookup - @K-Ho 