### PR TITLE
fix: Wrong op-node p2p port in base-config.mdx

### DIFF
--- a/pages/operators/node-operators/configuration/base-config.mdx
+++ b/pages/operators/node-operators/configuration/base-config.mdx
@@ -185,7 +185,7 @@ Unlike the previous system, the `op-node` participates in a peer-to-peer network
 
 For best results, run `op-node` with a static IP address that is accessible from the public Internet. For Kubernetes deployments, this can be achieved by configuring a dedicated `Ingress` with an external IP, and using the `--p2p.advertise.ip` flag to specify the IP address of the load balancer when advertising IP addresses to peers.
 
-The default port for the peer-to-peer network is `9003`. You will need to open this port on your firewall to receive unsubmitted blocks. For your node to be discoverable, this port must be accessible via both TCP and UDP protocols.
+The default port for the peer-to-peer network is `9222`. You will need to open this port on your firewall to receive unsubmitted blocks. For your node to be discoverable, this port must be accessible via both TCP and UDP protocols.
 
 ## Legacy Geth
 


### PR DESCRIPTION
**Description**

The `op-node` p2p port on this page is incorrect. It should be `9222`, not `9003` as on the [Consensus layer configuration options (op-node)](https://docs.optimism.io/operators/node-operators/configuration/consensus-config#p2plistentcp) page.

@zviadm discovered this issue and pointed it out in the @celo-org validator discord channel, since it also affects the peering of the op-node in the [celo-l2-docker-stack](https://github.com/celo-org/celo-l2-node-docker-compose).

Context:
[fix: change op-node p2p port in docker-compose.yml to default port and fix peering issues #54](https://github.com/celo-org/celo-l2-node-docker-compose/pull/54)
