### PR TITLE
Updating title of Reading logs explainer

### DIFF
--- a/pages/stack/interop/_meta.json
+++ b/pages/stack/interop/_meta.json
@@ -2,7 +2,7 @@
     "explainer": "Superchain interop explainer",
     "predeploy": "Superchain interop predeploys",
     "message-passing": "Superchain interop message passing",
-    "reading-logs": "Superchain interop logs",
+    "reading-logs": "Reading logs",
     "op-supervisor": "OP Supervisor",
     "superchain-weth": "Superchain ETH",
     "superchain-erc20": "SuperchainERC20",


### PR DESCRIPTION
Updating title of explainer for easier discoverability

Previous name also wasn't accurate, as it indicated this functionality is only possible w/ Superchain interop txs but this can be applied to any log using Superchain interop

