### PR TITLE
Correct CLI flag name from throttle-interval to throttle-threshold

### DIFF
--- a/pages/operators/chain-operators/configuration/batcher.mdx
+++ b/pages/operators/chain-operators/configuration/batcher.mdx
@@ -116,7 +116,7 @@ There are two throttling knobs:
 
 **Feature requirements**
 
-*   This new feature is enabled by default and requires running op-geth version `v1.101411.1` or later. It can be disabled by setting --throttle-interval to 0. The sequencer's op-geth node has to be updated first, before updating the batcher, so that the new required RPC is available at the time of the batcher restart.
+*   This new feature is enabled by default and requires running op-geth version `v1.101411.1` or later. It can be disabled by setting --throttle-threshold to 0. The sequencer's op-geth node has to be updated first, before updating the batcher, so that the new required RPC is available at the time of the batcher restart.
 *   It is required to upgrade to `op-conductor/v0.2.0` if you are using conductor's leader-aware rpc proxy feature. This conductor release includes support for the `miner_setMaxDASize` op-geth rpc proxy.
 
 **Configuration**

--- a/pages/operators/chain-operators/configuration/batcher.mdx
+++ b/pages/operators/chain-operators/configuration/batcher.mdx
@@ -116,7 +116,7 @@ There are two throttling knobs:
 
 **Feature requirements**
 
-*   This new feature is enabled by default and requires running op-geth version `v1.101411.1` or later. It can be disabled by setting --throttle-threshold to 0. The sequencer's op-geth node has to be updated first, before updating the batcher, so that the new required RPC is available at the time of the batcher restart.
+*   This new feature is enabled by default and requires running op-geth version `v1.101411.1` or later. It can be disabled by setting `--throttle-threshold` to 0. The sequencer's op-geth node has to be updated first, before updating the batcher, so that the new required RPC is available at the time of the batcher restart.
 *   It is required to upgrade to `op-conductor/v0.2.0` if you are using conductor's leader-aware rpc proxy feature. This conductor release includes support for the `miner_setMaxDASize` op-geth rpc proxy.
 
 **Configuration**


### PR DESCRIPTION
**Description**

This PR updates the docs to reflect the correct CLI parameter name, `--throttle-threshold`, instead of the incorrect `--throttle-interval`. 

The change aligns the documentation with the actual code, as shown in the following snippet:
https://github.com/ethereum-optimism/optimism/blob/f4264b98709e96ed6b69726be2f3c78dd4979a43/op-batcher/flags/flags.go#L159-L164

