### PR TITLE
Update op-geth/op-node for U15

### DIFF
--- a/pages/interop/tutorials/message-passing.mdx
+++ b/pages/interop/tutorials/message-passing.mdx
@@ -238,7 +238,7 @@ For development purposes, we'll first use autorelay mode to handle message execu
 
   6.  Create `src/GreetingSender.sol`.
 
-      ```solidity file=<rootDir>/public/tutorials/GreetingSender.sol#L1-L28 hash=75d197d1e1da112421785c2160f6a55a
+      ```solidity file=<rootDir>/public/tutorials/GreetingSender.sol#L1-L28 hash=9ed77001810caf52bbaa94da8b0dc5c6
       ```
 
   <details>

--- a/pages/notices/upgrade-15.mdx
+++ b/pages/notices/upgrade-15.mdx
@@ -99,10 +99,6 @@ The new op-program release that contains the Mainnet activation timestamps will 
 
 ## For node operators
 
-<Callout type="info">
-  The Mainnet node binaries will be available soon. The following versions are for the Sepolia Superchain activation.
-</Callout>
-
 Node operators will need to upgrade to the respective Isthmus releases before the activation dates.
 
 These following steps are necessary for every node operator:
@@ -110,10 +106,10 @@ These following steps are necessary for every node operator:
 <Steps>
   ### Update to the latest release
 
-  The releases are for the Isthmus Sepolia Superchain activation. Mainnet releases will be cut when the activation timestamp has been determined.
+  The releases are for the Isthmus Mainnet Superchain activation.
 
-  *   [`op-node` at `v1.13.0`](https://github.com/ethereum-optimism/optimism/releases/tag/op-node%2Fv1.13.0)
-  *   [`op-geth` at `v1.101503.2`](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101503.2)
+  *   [`op-node` at `v1.13.2`](https://github.com/ethereum-optimism/optimism/releases/tag/op-node%2Fv1.13.2)
+  *   [`op-geth` at `v1.101503.4`](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101503.4)
 
   ### Configure the Isthmus activation date
 
@@ -124,10 +120,6 @@ These following steps are necessary for every node operator:
   </Callout>
 
   For node operators of not using the [hardfork activation inheritance behavior](https://github.com/ethereum-optimism/superchain-registry/blob/main/docs/hardfork-activation-inheritance.md), you will need to manually configure the activation. This can be done one of two ways:
-
-  <Callout type="info">
-    The override flag for op-node was missed and will be added in the mainnet release. If you utilize the override flags, please just set the activation time in the rollup configuration file. 
-  </Callout>
 
   <Callout type="warning">
     If you use custom genesis chain configuration, you need to set the `pragueTime` to the same value as the `isthmusTime`. It is not automatically set, this happens by default for chains using the network flags and also when using the override flags.

--- a/pages/notices/upgrade-15.mdx
+++ b/pages/notices/upgrade-15.mdx
@@ -106,7 +106,7 @@ These following steps are necessary for every node operator:
 <Steps>
   ### Update to the latest release
 
-  The releases are for the Isthmus Mainnet Superchain activation.
+  The releases contain both the Isthmus Mainnet and Sepolia Superchain activation timestamps.
 
   *   [`op-node` at `v1.13.2`](https://github.com/ethereum-optimism/optimism/releases/tag/op-node%2Fv1.13.2)
   *   [`op-geth` at `v1.101503.4`](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101503.4)


### PR DESCRIPTION
* Updated the release versions for `op-node` and `op-geth` to `v1.13.2` and `v1.101503.4`, respectively, to reflect the Mainnet Superchain activation.
* Revised text to clarify that the releases are for the Isthmus Mainnet Superchain activation, replacing references to Sepolia.

### Removal of Outdated Callouts:

* Removed an informational callout about the availability of Mainnet node binaries, as it is no longer relevant.
* Removed an informational callout regarding the override flag for `op-node`, which was missed earlier but is addressed in the Mainnet release.