### PR TITLE
interop: recorrect the logic between CrossL2Inbox and op-supervisor

### DIFF
--- a/pages/interop/reading-logs.mdx
+++ b/pages/interop/reading-logs.mdx
@@ -107,7 +107,7 @@ sequenceDiagram
 
 3.  The attestation verifier calls `validateMessage()` on the `CrossL2Inbox` contract, passing the attestation identifier and a hash of the event data.
 
-4.  The [`CrossL2Inbox`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol) contract interacts with the [`OP-Supervisor`](/interop/op-supervisor) service to check if the specified log exists on the source chain.
+4.  The [`CrossL2Inbox`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol) contract will be called only after the [`OP-Supervisor`](/interop/op-supervisor) service to check if the specified log exists on the source chain.
 
 5.  The `OP-Supervisor` confirms the validity of the log to the `CrossL2Inbox` contract.
 


### PR DESCRIPTION
The CrossL2Inbox is not directly interact with op-supervisor, the op-supervisor is work together with OP-geth and only allow the valid message transaction(aka the CrossL2Inbox call) to be included to the next block
[content reference](https://discord.com/channels/1244729134312198194/1245066114887585853/1369411848922730617)
