### PR TITLE
Fix broken Optimism contract link in custom token bridging tutorial

### DIFF
--- a/pages/app-developers/tutorials/bridging/standard-bridge-custom-token.mdx
+++ b/pages/app-developers/tutorials/bridging/standard-bridge-custom-token.mdx
@@ -23,7 +23,7 @@ import { WipCallout } from '@/components/WipCallout'
 In this tutorial, you'll learn how to bridge a custom ERC-20 token from Ethereum to an OP Stack chain using the Standard Bridge system.
 This tutorial is meant for developers who already have an existing ERC-20 token on Ethereum and want to create a bridged representation of that token on OP Mainnet.
 
-This tutorial explains how you can create a custom token that conforms to the [`IOptimismMintableERC20`](https://github.com/ethereum-optimism/optimism/blob/v1.12.2/packages/contracts-bedrock/src/universal/IOptimismMintableERC20.sol) interface so that it can be used with the Standard Bridge system.
+This tutorial explains how you can create a custom token that conforms to the [`IOptimismMintableERC20`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/universal/OptimismMintableERC20Factory.sol) interface so that it can be used with the Standard Bridge system.
 A custom token allows you to do things like trigger extra logic whenever a token is deposited.
 If you don't need extra functionality like this, consider following the tutorial on [Bridging Your Standard ERC-20 Token Using the Standard Bridge](./standard-bridge-standard-token) instead.
 
@@ -33,7 +33,7 @@ If you don't need extra functionality like this, consider following the tutorial
 
 ## About OptimismMintableERC20s
 
-The Standard Bridge system requires that L2 representations of L1 tokens implement the [`IOptimismMintableERC20`](https://github.com/ethereum-optimism/optimism/blob/v1.12.2/packages/contracts-bedrock/src/universal/IOptimismMintableERC20.sol) interface.
+The Standard Bridge system requires that L2 representations of L1 tokens implement the [`IOptimismMintableERC20`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/universal/OptimismMintableERC20Factory.sol) interface.
 This interface is a superset of the standard ERC-20 interface and includes functions that allow the bridge to properly verify deposits/withdrawals and mint/burn tokens as needed.
 Your L2 token contract must implement this interface in order to be bridged using the Standard Bridge system.
 This tutorial will show you how to create a custom token that implements this interface.


### PR DESCRIPTION
Replaced outdated link to IOptimismMintableERC20.sol (which returned 404) with the current, working link to OptimismMintableERC20Factory.sol in the "Bridging your custom ERC-20 token using the Standard Bridge" tutorial. This ensures that readers are directed to the correct contract interface in the official Optimism repository.