### PR TITLE
Update mips.go link to current location in multithreaded directory

### DIFF
--- a/pages/stack/fault-proofs/cannon.mdx
+++ b/pages/stack/fault-proofs/cannon.mdx
@@ -193,7 +193,7 @@ and Pre-image information (if required for the MIPS instruction).
 
 ### `mips.go`
 
-[`mips.go`](https://github.com/ethereum-optimism/optimism/blob/develop/cannon/mipsevm/singlethreaded/mips.go) implements all the required MIPS
+[`mips.go`](https://github.com/ethereum-optimism/optimism/blob/develop/cannon/mipsevm/multithreaded/mips.go) implements all the required MIPS
 instructions, and also tracks additional memory access for the instruction currently being run.
 This is important to make sure that the second memory proof is encoded correctly for instructions that use it, such as loads, stores, and
 certain syscalls. The full list of instructions supported can be found [here](mips#table-of-supported-mips-instructions).


### PR DESCRIPTION
Replaced the outdated link to mips.go in the Cannon documentation with the correct path:
https://github.com/ethereum-optimism/optimism/blob/develop/cannon/mipsevm/multithreaded/mips.go
This ensures the documentation references the actual file in the latest Optimism repository structure and prevents broken links for users.
