### PR TITLE
 Fix deposit flow tutorial

### DIFF
--- a/pages/stack/transactions/deposit-flow.mdx
+++ b/pages/stack/transactions/deposit-flow.mdx
@@ -95,7 +95,7 @@ It is possible to replay a failed deposit, possibly with more gas.
 ### Replays in action
 
 <Callout type="info">
-  **L1 vs L2 Network Clarification**
+  **L1 vs L2 network clarification**
 
   This tutorial involves **two different networks**:
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

### Problem
The deposit flow tutorial had critical issues preventing users from completing it:

- **Wrong L1 RPC**: `L1_RPC` pointed to OP Sepolia (L2) instead of Ethereum Sepolia (L1)  
- **Network confusion**: Both L1 and L2 RPCs pointed to the same chain
- **Unreliable transaction finding**: Only method relied on Etherscan internal transactions that aren't always visible

### Solution

- **Correct L1 RPC**: Now points to Ethereum Sepolia (`sepolia.infura.io`)
- **Clear L1/L2 distinction**: Added prominent callout explaining the two networks involved
- **Multiple fallback methods**: Added 3 ways to find failed relay transactions (Etherscan, events, cast queries)
- **Better timing guidance**: Added wait instructions and timing expectations
- **Setup instructions**: Included how to get Infura API key

### Impact
Users can now successfully complete the cross-chain deposit replay tutorial without getting stuck on network configuration or missing transaction data.

Fixes reported issue where users couldn't find internal transactions and were confused about L1/L2 network setup.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

- Fixes: https://github.com/ethereum-optimism/docs/issues/1226