### PR TITLE
fix typo superchain-withdrawal-pause-test.mdx

### DIFF
--- a/pages/notices/superchain-withdrawal-pause-test.mdx
+++ b/pages/notices/superchain-withdrawal-pause-test.mdx
@@ -28,7 +28,7 @@ The Optimism Collective will be testing improved incident response features on t
 
 ## What's happening
 
-1.  During this excercise, the privileged [`GUARDIAN`](/superchain/privileged-roles#guardian) address will call the `pause` function on the `SuperchainConfig`.
+1.  During this exercise, the privileged [`GUARDIAN`](/superchain/privileged-roles#guardian) address will call the `pause` function on the `SuperchainConfig`.
 2.  Members of the Optimism Collective's security team will ensure that the pause is executed correctly and the incident response improvements worked as intended.
 3.  Then the `unpause` function will be called to resume normal operations.
 


### PR DESCRIPTION
**Description**

Hey devs, fixed typo

pages/notices/superchain-withdrawal-pause-test.mdx
excercise - exercise