### PR TITLE
Update op-challenger version for upgrade 16 to 1.5.1

### DIFF
--- a/pages/notices/upgrade-16.mdx
+++ b/pages/notices/upgrade-16.mdx
@@ -37,7 +37,7 @@ Upgrade 16 is an L1 smart contracts upgrade for the OP Stack. We do not expect a
 Chain operators must complete two tasks:
 
 *   Deploy new dispute game contracts with new absolute prestates
-*   Update `op-challenger` to [op-challenger/v1.5.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-challenger%2Fv1.5.0)
+*   Update `op-challenger` to [op-challenger/v1.5.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-challenger%2Fv1.5.1)
 
 Chain operators should be aware that Upgrade 16 involves a one-time invalidation of all existing withdrawal proofs. Users who have proven withdrawals can either finalize withdrawals prior to the activation of Upgrade 16 or will be required to re-prove these withdrawals after the upgrade activates.
 


### PR DESCRIPTION
op-challenger/v1.5.1 is a bug fix update that will be the required version for upgrade 16.

https://github.com/ethereum-optimism/optimism/releases/tag/op-challenger%2Fv1.5.1