### PR TITLE
Add missing commands and help text to supersim docs

### DIFF
--- a/pages/app-developers/tutorials/supersim/reference/fork.mdx
+++ b/pages/app-developers/tutorials/supersim/reference/fork.mdx
@@ -15,7 +15,7 @@ categories:
 is_imported_content: "false"
 ---
 
-import { Callout, Steps } from "nextra/components";
+import { Callout, Steps } from "nextra/components"
 
 # Fork mode
 
@@ -156,5 +156,5 @@ supersim fork --chains=op,base,zora --interop.enabled
 
 ## Next steps
 
-- Explore the Supersim [included contracts](/app-developers/tutorials/supersim/chain-env/included-contracts) being used to help replicate the Superchain environment.
-- Learn how to [deposit transactions](/app-developers/tutorials/supersim/deposit-transactions) with Supersim, using a much simpler approach that bypasses the derivation pipeline.
+*   Explore the Supersim [included contracts](/app-developers/tutorials/supersim/chain-env/included-contracts) being used to help replicate the Superchain environment.
+*   Learn how to [deposit transactions](/app-developers/tutorials/supersim/deposit-transactions) with Supersim, using a much simpler approach that bypasses the derivation pipeline.

--- a/pages/app-developers/tutorials/supersim/reference/fork.mdx
+++ b/pages/app-developers/tutorials/supersim/reference/fork.mdx
@@ -12,10 +12,10 @@ categories:
   - mainnet
   - testnet
   - cli
-is_imported_content: 'false'
+is_imported_content: "false"
 ---
 
-import { Callout, Steps } from 'nextra/components'
+import { Callout, Steps } from "nextra/components";
 
 # Fork mode
 
@@ -68,9 +68,11 @@ OPTIONS:
                 L1 height to fork the superchain (bounds L2 time). `0` for latest
 
           --chains value                                                         ($SUPERSIM_CHAINS)
-                chains to fork in the superchain, mainnet options: [base, lyra, metal, mode, op,
-                orderly, race, tbn, zora]. In order to replace the public rpc endpoint for a
-                chain, specify the ($SUPERSIM_RPC_URL_<CHAIN>) env variable. i.e
+                chains to fork in the superchain, mainnet options: [arena-z, automata, base,
+                bob, cyber, ethernity, funki, hashkeychain, ink, lisk, lyra, metal, mint, mode,
+                op, orderly, polynomial, race, redstone, shape, soneium, sseed, swan, swell, tbn,
+                unichain, worldchain, xterio-eth, zora]. In order to replace the public rpc endpoint
+                for a chain, specify the ($SUPERSIM_RPC_URL_<CHAIN>) env variable. i.e
                 SUPERSIM_RPC_URL_OP=http://optimism-mainnet.infura.io/v3/<API-KEY>
 
           --network value                     (default: "mainnet")               ($SUPERSIM_NETWORK)
@@ -82,8 +84,18 @@ OPTIONS:
           --interop.enabled                   (default: true)                    ($SUPERSIM_INTEROP_ENABLED)
                 enable interop predeploy and functionality
 
+          --admin.port value                  (default: 8420)                    ($SUPERSIM_ADMIN_PORT)
+                Listening port for the admin server
+
+          --interop.l2tol2cdm.override value                                     ($SUPERSIM_INTEROP_L2TO2CDM_OVERRIDE)
+                Path to the L2ToL2CrossDomainMessenger build artifact that overrides
+                the default implementation
+
           --l1.port value                     (default: 8545)                    ($SUPERSIM_L1_PORT)
                 Listening port for the L1 instance. `0` binds to any available port
+
+          --l2.count value                    (default: 2)                       ($SUPERSIM_L2_COUNT)
+                Number of L2s. Max of 5
 
           --l2.starting.port value            (default: 9545)                    ($SUPERSIM_L2_STARTING_PORT)
                 Starting port to increment from for L2 chains. `0` binds each chain to any
@@ -92,12 +104,24 @@ OPTIONS:
           --interop.autorelay                 (default: false)                   ($SUPERSIM_INTEROP_AUTORELAY)
                 Automatically relay messages sent to the L2ToL2CrossDomainMessenger using
                 account 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720
-          
+
           --interop.delay value               (default: 0)                       ($SUPERSIM_INTEROP_DELAY)
                 Delay before relaying messages sent to the L2ToL2CrossDomainMessenger
 
           --logs.directory value                                                 ($SUPERSIM_LOGS_DIRECTORY)
                 Directory to store logs
+
+          --l1.host value                     (default: "127.0.0.1")             ($SUPERSIM_L1_HOST)
+                Host address for the L1 instance
+
+          --l2.host value                     (default: "127.0.0.1")             ($SUPERSIM_L2_HOST)
+                Host address for L2 instances
+
+          --odyssey.enabled                   (default: false)                   ($SUPERSIM_ODYSSEY_ENABLED)
+                Enable odyssey experimental features
+
+          --dependency.set value                                                 ($SUPERSIM_DEPENDENCY_SET)
+                Override local chain IDs in the dependency set.(format: '[901,902]' or '[]')
 
           --log.level value                   (default: INFO)                    ($SUPERSIM_LOG_LEVEL)
                 The lowest log level that will be output
@@ -111,9 +135,6 @@ OPTIONS:
 
           --log.pid                           (default: false)                   ($SUPERSIM_LOG_PID)
                 Show pid in the log
-
-          --odyssey.enabled                   (default: false)                   ($SUPERSIM_ODYSSEY_ENABLED)
-                Enable odyssey experimental features
 
           --help, -h                          (default: false)
                 show help
@@ -135,5 +156,5 @@ supersim fork --chains=op,base,zora --interop.enabled
 
 ## Next steps
 
-*   Explore the Supersim [included contracts](/app-developers/tutorials/supersim/chain-env/included-contracts) being used to help replicate the Superchain environment.
-*   Learn how to [deposit transactions](/app-developers/tutorials/supersim/deposit-transactions) with Supersim, using a much simpler approach that bypasses the derivation pipeline.
+- Explore the Supersim [included contracts](/app-developers/tutorials/supersim/chain-env/included-contracts) being used to help replicate the Superchain environment.
+- Learn how to [deposit transactions](/app-developers/tutorials/supersim/deposit-transactions) with Supersim, using a much simpler approach that bypasses the derivation pipeline.

--- a/pages/app-developers/tutorials/supersim/reference/vanilla.mdx
+++ b/pages/app-developers/tutorials/supersim/reference/vanilla.mdx
@@ -91,9 +91,27 @@ DESCRIPTION:
 
 COMMANDS:
    fork     Locally fork a network in the superchain registry
+   docs     Display available docs links
    help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
+
+    --admin.port value                  (default: 8420)                    ($SUPERSIM_ADMIN_PORT)
+          Listening port for the admin server
+
+    --interop.l2tol2cdm.override value                                     ($SUPERSIM_INTEROP_L2TO2CDM_OVERRIDE)
+          Path to the L2ToL2CrossDomainMessenger build artifact that overrides
+          the default implementation
+
+    --l1.port value                     (default: 8545)                    ($SUPERSIM_L1_PORT)
+          Listening port for the L1 instance. `0` binds to any available port
+
+    --l2.count value                    (default: 2)                       ($SUPERSIM_L2_COUNT)
+          Number of L2s. Max of 5
+
+    --l2.starting.port value            (default: 9545)                    ($SUPERSIM_L2_STARTING_PORT)
+          Starting port to increment from for L2 chains. `0` binds each chain to any
+          available port
 
     --interop.autorelay                 (default: false)                   ($SUPERSIM_INTEROP_AUTORELAY)
           Automatically relay messages sent to the L2ToL2CrossDomainMessenger using
@@ -102,12 +120,20 @@ GLOBAL OPTIONS:
     --interop.delay value               (default: 0)                       ($SUPERSIM_INTEROP_DELAY)
           Delay before relaying messages sent to the L2ToL2CrossDomainMessenger
 
-    --l1.port value                     (default: 8545)                    ($SUPERSIM_L1_PORT)
-          Listening port for the L1 instance. `0` binds to any available port
+    --logs.directory value                                                 ($SUPERSIM_LOGS_DIRECTORY)
+          Directory to store logs
 
-    --l2.starting.port value            (default: 9545)                    ($SUPERSIM_L2_STARTING_PORT)
-          Starting port to increment from for L2 chains. `0` binds each chain to any
-          available port
+    --l1.host value                     (default: "127.0.0.1")             ($SUPERSIM_L1_HOST)
+          Host address for the L1 instance
+
+    --l2.host value                     (default: "127.0.0.1")             ($SUPERSIM_L2_HOST)
+          Host address for L2 instances
+
+    --odyssey.enabled                   (default: false)                   ($SUPERSIM_ODYSSEY_ENABLED)
+          Enable odyssey experimental features
+
+    --dependency.set value                                                 ($SUPERSIM_DEPENDENCY_SET)
+          Override local chain IDs in the dependency set.(format: '[901,902]' or '[]')
 
     --log.color                         (default: false)                   ($SUPERSIM_LOG_COLOR)
           Color the log output if in terminal mode
@@ -122,14 +148,7 @@ GLOBAL OPTIONS:
     --log.pid                           (default: false)                   ($SUPERSIM_LOG_PID)
           Show pid in the log
 
-    --logs.directory value                                                 ($SUPERSIM_LOGS_DIRECTORY)
-          Directory to store logs
-
-    --odyssey.enabled                   (default: false)                   ($SUPERSIM_ODYSSEY_ENABLED)
-          Enable odyssey experimental features
-
    MISC
-
 
     --help, -h                          (default: false)
           show help
@@ -140,6 +159,6 @@ GLOBAL OPTIONS:
 
 ## Next steps
 
-*   Explore the Supersim [included contracts](/app-developers/tutorials/supersim/chain-env/included-contracts) being used to help replicate the Superchain environment.
-*   Get network details about the two OP Stack systems spun up in vanilla mode: [OPChainA (chainID 901)](/app-developers/tutorials/supersim/chain-env/chain-a) and [OPChainB (chainID 902)](/app-developers/tutorials/supersim/chain-env/chain-b).
-*   Learn how to [deposit transactions](/app-developers/tutorials/supersim/deposit-transactions) with Supersim, using a much simpler approach that bypasses the derivation pipeline.
+- Explore the Supersim [included contracts](/app-developers/tutorials/supersim/chain-env/included-contracts) being used to help replicate the Superchain environment.
+- Get network details about the two OP Stack systems spun up in vanilla mode: [OPChainA (chainID 901)](/app-developers/tutorials/supersim/chain-env/chain-a) and [OPChainB (chainID 902)](/app-developers/tutorials/supersim/chain-env/chain-b).
+- Learn how to [deposit transactions](/app-developers/tutorials/supersim/deposit-transactions) with Supersim, using a much simpler approach that bypasses the derivation pipeline.

--- a/pages/app-developers/tutorials/supersim/reference/vanilla.mdx
+++ b/pages/app-developers/tutorials/supersim/reference/vanilla.mdx
@@ -10,10 +10,10 @@ categories:
   - supersim
   - devnets
   - cli
-is_imported_content: 'false'
+is_imported_content: "false"
 ---
 
-import { Callout, Steps } from 'nextra/components'
+import { Callout, Steps } from "nextra/components"
 
 # Vanilla mode
 
@@ -159,6 +159,6 @@ GLOBAL OPTIONS:
 
 ## Next steps
 
-- Explore the Supersim [included contracts](/app-developers/tutorials/supersim/chain-env/included-contracts) being used to help replicate the Superchain environment.
-- Get network details about the two OP Stack systems spun up in vanilla mode: [OPChainA (chainID 901)](/app-developers/tutorials/supersim/chain-env/chain-a) and [OPChainB (chainID 902)](/app-developers/tutorials/supersim/chain-env/chain-b).
-- Learn how to [deposit transactions](/app-developers/tutorials/supersim/deposit-transactions) with Supersim, using a much simpler approach that bypasses the derivation pipeline.
+*   Explore the Supersim [included contracts](/app-developers/tutorials/supersim/chain-env/included-contracts) being used to help replicate the Superchain environment.
+*   Get network details about the two OP Stack systems spun up in vanilla mode: [OPChainA (chainID 901)](/app-developers/tutorials/supersim/chain-env/chain-a) and [OPChainB (chainID 902)](/app-developers/tutorials/supersim/chain-env/chain-b).
+*   Learn how to [deposit transactions](/app-developers/tutorials/supersim/deposit-transactions) with Supersim, using a much simpler approach that bypasses the derivation pipeline.


### PR DESCRIPTION
## Problem
The supersim docs include two sets of `--help` menu text. Both have outdated text and are missing commands.

## Solution
Add all missing commands from `supersim --help` and `supersim fork --help` text.