### PR TITLE
Update get-started.mdx

### DIFF
--- a/pages/interop/get-started.mdx
+++ b/pages/interop/get-started.mdx
@@ -32,7 +32,7 @@ Choose your development environment to build, test, and quickly iterate on your 
 
 | Environment           | Purpose                                   | Getting Started                                            |
 | --------------------- | ----------------------------------------- | ---------------------------------------------------------- |
-| **Local development** | Rapid iteration and testing with Supersim | [Setup supersim guide](/app-developers/tutorials/supersim) |
+| **Local development** | Rapid iteration and testing with Supersim | [Setup Supersim guide](/app-developers/tutorials/supersim) |
 | **Interop devnet**    | Large-scale testing on testnets           | [Network specs](/interop/tools/devnet)                     |
 
 For complete network details including RPC endpoints, chain IDs, contract addresses, and bridging instructions, see the [Superchain Interop Devnet Documentation](/interop/tools/devnet).


### PR DESCRIPTION
The product names such as Superchain and Supersim should always be in the format with the first letter capitalized wherever they appear.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
