### PR TITLE
Update Fault Proofs Explainer

### DIFF
--- a/pages/stack/fault-proofs/explainer.mdx
+++ b/pages/stack/fault-proofs/explainer.mdx
@@ -86,11 +86,17 @@ Due to the permissionless structure where many different actors can participate 
 Users can complete the full withdrawal cycle without depending on any privileged action.
 The Guardian role can override the system by pausing withdrawals, blacklisting games, or reverting to a permissioned system.
 As a result, the trust assumption is reduced to requiring only that the Guardian role does not act to intervene, inline with the stage 1 requirements.
+
 ### Since the roles of proposer and challenger will be open to everyone, are guides available outlining the best practices for running them?
 
 It's not expected that normal users run `op-proposer` to regularly propose output roots.
-Users would generally just propose a single output root if they need to withdraw and the chain operator isn't proposing outputs for them via direct calls to the `DisputeGameFactory` via Etherscan or using the [`create-game`](https://github.com/ethereum-optimism/optimism/tree/develop/op-challenger#create-game) subcommand of `op-challenger`.
-Documentation for `op-challenger` is forthcoming.
+Users would generally just propose a single output root if they need to withdraw and the chain operator isn't proposing outputs for them via direct calls to the `DisputeGameFactory` via Etherscan.
+
+<Callout type="warning">
+The [`create-game`](https://github.com/ethereum-optimism/optimism/tree/develop/op-challenger#create-game) subcommand of `op-challenger` is **for testing purposes only** and should not be used in production environments. It is not intended as a replacement for proper `op-proposer` infrastructure.
+</Callout>
+
+For detailed guidance on running `op-challenger`, see the [OP-Challenger explainer](/stack/fault-proofs/challenger) and [how to configure challenger for your chain](/operators/chain-operators/tools/op-challenger).
 
 ### How much ETH should a chain operator put aside to operate the Fault Proof System?
 


### PR DESCRIPTION
…and and provide guidance for `op-challenger` usage

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates the fault proofs explainer to correct misleading information about the `op-challenger` tool and provide accurate docs links.


**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
