### PR TITLE
Update chain-dev-net.mdx

### DIFF
--- a/pages/operators/chain-operators/tutorials/chain-dev-net.mdx
+++ b/pages/operators/chain-operators/tutorials/chain-dev-net.mdx
@@ -69,7 +69,7 @@ accepts a YAML file which configures how many network participants there are, wh
 the network's topology. An example YAML file is below:
 
 ```yaml
-# Check https://github.com/ethpandaops/optimism-package for more detail.
+# Check https://github.com/ethpandaops/optimism-package for more details.
 
 optimism_package:
   # An array of L2 networks to run.


### PR DESCRIPTION
The doc is outdated.

As a new user of the Optimism platform, I found that I can’t launch the devnet following the tutorial.

So, I checked the latest Optimism package changes.