### PR TITLE
Tutorial/precompiles

### DIFF
--- a/pages/operators/chain-operators/tutorials/adding-precompiles.mdx
+++ b/pages/operators/chain-operators/tutorials/adding-precompiles.mdx
@@ -38,7 +38,7 @@ To create a new precompile, the file to modify is [`op-geth/core/vm/contracts.go
   *   use an address that is unlikely to ever clash with a standard precompile and avoids the [EIP-7587](https://eips.ethereum.org/EIPS/eip-7587) reserved range (0x1337, for example):
 
       ```go
-      common.BytesToAddress([]byte{0x13,37}): &retConstant{},
+      common.BytesToAddress([]byte{0x13,0x37}): &retConstant{},
       ```
 
   ### Add the lines for the precompile


### PR DESCRIPTION
**Description**
Fix the precompile address conflict in the "Adding a precompile" tutorial to ensure [EIP-7587](https://eips.ethereum.org/EIPS/eip-7587) compliance.
This PR addresses a critical inconsistency in the precompile tutorial where:

The documentation text suggests using address like `0x100`
However, the code example uses `[]byte{1,0}` which creates address `0x0100`. This address falls within the EIP-7587 reserved range (`0x0100`-`0x01FF`) and `0x100` is now use by [RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md)

<img width="901" height="851" alt="image" src="https://github.com/user-attachments/assets/44be94cc-aa47-42d1-b9fb-86af04de17f1" />


Changes made
- Fixed the byte array from `[]byte{1,0}` to `[]byte{0x13, 0x37}` to properly create address `0x1337`
- Updated all corresponding cast command examples to use the correct address `0x1337`

**Tests**

- Verified that  `common.BytesToAddress([]byte{0x13, 0x37})` correctly produces  `0x1337 `
- Confirmed that `0x1337` is outside all reserved ranges

<img width="648" height="705" alt="image" src="https://github.com/user-attachments/assets/a8c08db0-5453-417a-a6be-96426ecb30de" />

Metadata
[RIP-7212: Precompile for secp256r1 Curve Support](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md)
[EIP-7587: Reserve precompile address range for RIP process](https://eips.ethereum.org/EIPS/eip-7587)