### PR TITLE
tutorials: clarify the difference between kurtosis devnets and op-up

### DIFF
--- a/pages/operators/chain-operators/tutorials/chain-dev-net.mdx
+++ b/pages/operators/chain-operators/tutorials/chain-dev-net.mdx
@@ -1,6 +1,6 @@
 ---
 title: Running a Local Development Environment
-description: This tutorial walks you through spinning up an OP Stack devnet chain.
+description: This tutorial walks you through spinning up local OP Stack chain for protocol development.
 lang: en-US
 content_type: tutorial
 topic: running-a-local-development-environment
@@ -22,13 +22,14 @@ import {WipCallout} from '@/components/WipCallout'
 
 # Running a Local Development Environment
 
-<Callout type="info">
-  This guide is currently under active development. If you run into any issues, please open an issue on
-  [Github](https://github.com/ethereum-optimism/optimism).
-</Callout>
+This tutorial is **designed for protocol developers** who want to contribute to the OP Stack
+by spinning up a local OP Stack development environment running with [Kurtosis](https://www.kurtosis.com/).
+You'll perform the full deployment process, and **you'll end up with your very own OP Stack devnet, with smart contracts and components that closely mirror what gets run in production**.
 
-This tutorial is **designed for developers** who want to learn about the OP Stack by spinning up a local OP Stack devnet.
-You'll perform the full deployment process, and **you'll end up with your very own OP Stack devnet**.
+<Callout type="info">
+  This tutorial is intended for protocol developers. If you're looking to try out the OP Stack in a more lightweight way,
+  you can use the []`op-up`](https://localchain.dev) tool to deploy a local network in less than a minute.
+</Callout>
 
 It's useful to understand what each of these components does before
 you start deploying your chain. To learn about the different components please

--- a/pages/operators/chain-operators/tutorials/chain-dev-net.mdx
+++ b/pages/operators/chain-operators/tutorials/chain-dev-net.mdx
@@ -28,7 +28,7 @@ You'll perform the full deployment process, and **you'll end up with your very o
 
 <Callout type="info">
   This tutorial is intended for protocol developers. If you're looking to try out the OP Stack in a more lightweight way,
-  you can use the []`op-up`](https://localchain.dev) tool to deploy a local network in less than a minute.
+  you can use the [`op-up`](https://localchain.dev) tool to deploy a local network in less than a minute.
 </Callout>
 
 It's useful to understand what each of these components does before


### PR DESCRIPTION
We will soon start pushing people who are just "trying out" the OP Stack to use localchain.dev instead of running Kurtosis, which is more of a full-fledged development environment. This PR updates the Kurtosis tutorial to clarity that.