### PR TITLE
Remove dead link in docs

### DIFF
--- a/pages/stack/_meta.json
+++ b/pages/stack/_meta.json
@@ -9,7 +9,6 @@
   "design-principles": "Design philosophy & principles",
   "components": "OP Stack components",
   "public-devnets": "Public devnets",
-  "superchain-ops-guide": "Superchain-ops upgrades",
   "opcm": "OP Contracts Manager",
   "smart-contracts": "Smart contracts",  
   "rollup": "Rollup",


### PR DESCRIPTION
Noticed there was a dead link in the navigation under OP Stack..

**Description**

Simple pull request to remove the dead link to the nonexistent "Superchain-ops upgrades" page.

**Additional context**

It would be good to create the page at some point unless it was previously deleted for some reason.