### PR TITLE
Quick start tutorial - genesis config file naming fix

### DIFF
--- a/create-l2-rollup-example/scripts/setup-rollup.sh
+++ b/create-l2-rollup-example/scripts/setup-rollup.sh
@@ -394,7 +394,7 @@ generate_challenger_prestate() {
     log_info "Copying chain configuration files..."
     mkdir -p op-program/chainconfig/configs
     cp "$DEPLOYER_DIR/.deployer/rollup.json" "op-program/chainconfig/configs/${CHAIN_ID}-rollup.json"
-    cp "$DEPLOYER_DIR/.deployer/genesis.json" "op-program/chainconfig/configs/${CHAIN_ID}-genesis.json"
+    cp "$DEPLOYER_DIR/.deployer/genesis.json" "op-program/chainconfig/configs/${CHAIN_ID}-genesis-l2.json"
 
     # Generate prestate
     log_info "Generating reproducible prestate..."


### PR DESCRIPTION
setup fix

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This is a simple fix for the Quick Start tutorial found [here](https://docs.optimism.io/operators/chain-operators/tutorials/create-l2-rollup#quick-setup-recommended).

Without this fix, the user will experience this error: 

```
  github.com/ethereum-optimism/optimism/op-program/host/config
  ./bin/op-program configs check-custom-chains
  t=2025-10-12T21:01:07+0100 lvl=crit msg="Application failed" err="invalid config file name: 16584-genesis.json, Make sure that the only files in the custom config directory are placeholder.json, depsets.json, <chain-id>-genesis-l2.json or <chain-id>-rollup.json"
  make[2]: *** [check-custom-chains] Error 1
  make[1]: *** [reproducible-prestate] Error 2
  make: *** [setup] Error 2
```

This is because the ./op-program configs check-custom-chains expects the genesis file to follow the `<chain-id>-genesis-l2.json` pattern.
**Tests**

No tests, this is a script fix.



