### PR TITLE
fix(setup-rollup): op-program uses genesis-l2.json instead

### DIFF
--- a/create-l2-rollup-example/scripts/setup-rollup.sh
+++ b/create-l2-rollup-example/scripts/setup-rollup.sh
@@ -210,7 +210,7 @@ setup_batcher() {
     # Copy state file
     cp "$DEPLOYER_DIR/.deployer/state.json" .
     INBOX_ADDRESS=$(cat state.json | jq -r '.opChainDeployments[0].SystemConfigProxy')
-    
+
     # Create .env file with OP_BATCHER prefixed variables
     cat > .env << EOF
 OP_BATCHER_L2_ETH_RPC=http://op-geth:8545
@@ -394,7 +394,7 @@ generate_challenger_prestate() {
     log_info "Copying chain configuration files..."
     mkdir -p op-program/chainconfig/configs
     cp "$DEPLOYER_DIR/.deployer/rollup.json" "op-program/chainconfig/configs/${CHAIN_ID}-rollup.json"
-    cp "$DEPLOYER_DIR/.deployer/genesis.json" "op-program/chainconfig/configs/${CHAIN_ID}-genesis.json"
+    cp "$DEPLOYER_DIR/.deployer/genesis.json" "op-program/chainconfig/configs/${CHAIN_ID}-genesis-l2.json"
 
     # Generate prestate
     log_info "Generating reproducible prestate..."


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

op-program uses `<chain-id>-genesis-l2.json` instead, else an error raised:

```
./bin/op-program configs check-custom-chains
t=2025-10-21T08:35:05+0000 lvl=crit msg="Application failed" err="invalid config file name: 16584-genesis.json, Make sure that the only files in the custom config directory are placeholder.json, depsets.json, <chai
n-id>-genesis-l2.json or <chain-id>-rollup.json"
```

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
