### PR TITLE
fix: don't set rollup.sequencerhttp for the example 

### DIFF
--- a/create-l2-rollup-example/docker-compose.yml
+++ b/create-l2-rollup-example/docker-compose.yml
@@ -66,7 +66,7 @@ services:
           geth init --datadir=/workspace/op-geth-data --state.scheme=hash /workspace/genesis.json
         fi
         echo "Starting geth..."
-        exec geth --datadir=/workspace/op-geth-data --http --http.addr=0.0.0.0 --http.port=8545 --ws --ws.addr=0.0.0.0 --ws.port=8546 --authrpc.addr=0.0.0.0 --authrpc.port=8551 --authrpc.jwtsecret=/workspace/jwt.txt --syncmode=full --gcmode=archive --rollup.disabletxpoolgossip=true --rollup.sequencerhttp=http://op-node:8547 --http.vhosts=* --http.corsdomain=* --http.api=eth,net,web3,debug,txpool,admin --ws.origins=* --ws.api=eth,net,web3,debug,txpool,admin --authrpc.vhosts=*
+        exec geth --datadir=/workspace/op-geth-data --http --http.addr=0.0.0.0 --http.port=8545 --ws --ws.addr=0.0.0.0 --ws.port=8546 --authrpc.addr=0.0.0.0 --authrpc.port=8551 --authrpc.jwtsecret=/workspace/jwt.txt --syncmode=full --gcmode=archive --rollup.disabletxpoolgossip=true --http.vhosts=* --http.corsdomain=* --http.api=eth,net,web3,debug,txpool,admin --ws.origins=* --ws.api=eth,net,web3,debug,txpool,admin --authrpc.vhosts=*
 
 
   # Batcher


### PR DESCRIPTION

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Ref https://github.com/ethereum-optimism/developers/discussions/890#discussioncomment-14752183

We should not set the `--rollup.sequencerhttp` for the sequencer node, else it will forward to the op-node, but op-node doesn't enabled the `eth_` namespace, it will cause the below error:

```
the method eth_sendRawTransaction does not exist/is not available
```

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
