### PR TITLE
adding eas redirect

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1496,6 +1496,10 @@
     {
       "source": "/app-developers/tools/testing/devnet",
       "destination": "/app-developers/guides/building-apps"
+    },
+    {
+      "source": "chain/identity/contracts-eas",
+      "destination": "/concepts/stack/smart-contracts#eas-ethereum-attestation-service"
     }
   ],
   "navigation": {


### PR DESCRIPTION
EAS (https://attest.org/ecosystem) has a link to https://docs.optimism.io/chain/identity/contracts-eas, which is broken. It should probably be changed to https://docs.optimism.io/concepts/stack/smart-contracts#eas-ethereum-attestation-service.