### PR TITLE
fix(node-trobleshooting): the unclean shutdown is invisible

### DIFF
--- a/node-operators/guides/troubleshooting.mdx
+++ b/node-operators/guides/troubleshooting.mdx
@@ -95,9 +95,20 @@ being written to the LevelDB database which can take several minutes.
 
 **Solution**
 
-If an unexpected shutdown does occur, the `removedb` subcommand can be used to
-delete the state database and resync it from the ancient database. This should
-get the database back up and running.
+In most cases, `op-geth` can recover automatically from an unclean shutdown when you restart it. The warning message is informational and doesn't necessarily indicate a problem.
+
+However, if `op-geth` fails to restart properly after an unclean shutdown, you can use the `removedb` subcommand as a last resort:
+
+```bash
+geth removedb --datadir=<path to data directory>
+```
+
+<Warning>
+  This command will delete all state database data. After running `removedb`,
+  you must manually restart the node to begin the resync process from the ancient database,
+  which can take significant time. Only use this when the node actually fails to restart,
+  not for every unclean shutdown warning.
+</Warning>
 
 ### For Nethermind
 
@@ -112,6 +123,7 @@ Unclean shutdowns in `Nethermind` can lead to database corruption. This typicall
 1.  **Lock File Issues**
 
     If `Nethermind` complains about lock files after an unclean shutdown, run:
+
     ```bash
     find /path/to/nethermind_db -type f -name 'LOCK' -delete
     ```
@@ -119,6 +131,7 @@ Unclean shutdowns in `Nethermind` can lead to database corruption. This typicall
 2.  **Block Checksum Mismatch**
 
     If you encounter block checksum mismatch errors, you can enable direct I/O:
+
     ```bash
     --Db.UseDirectIoForFlushAndCompactions true
     ```
@@ -127,6 +140,7 @@ Unclean shutdowns in `Nethermind` can lead to database corruption. This typicall
 3.  **Complete Resync**
 
     In cases of severe corruption, a full resync is recommended:
+
     ```bash
     sudo systemctl stop nethermind
     sudo rm -rf /path/to/nethermind_db/mainnet

--- a/node-operators/guides/troubleshooting.mdx
+++ b/node-operators/guides/troubleshooting.mdx
@@ -80,54 +80,55 @@ say if Geth stops unexpectedly, the database can be corrupted. This is known as 
 "unclean shutdown" and it can lead to a variety of problems for the node when
 it is restarted.
 
-<Tabs items={['op-geth', 'Nethermind']}>
-  <Tabs.Tab>
-    It is always best to shut down Geth gracefully, i.e. using a
-    shutdown command such as `ctrl-c`, `docker stop -t 300 <container ID>` or
-    `systemctl stop` (although please note that `systemctl stop` has a default timeout
-    of 90s - if Geth takes longer than this to gracefully shut down it will quit
-    forcefully. Update the `TimeoutSecs` variable in `systemd.service` to override this
-    value to something larger, at least 300s).
+### For op-geth
 
-    This way, Geth knows to write all relevant information into the database to
-    allow the node to restart properly later. This can involve >1GB of information
-    being written to the LevelDB database which can take several minutes.
+It is always best to shut down Geth gracefully, i.e. using a
+shutdown command such as `ctrl-c`, `docker stop -t 300 <container ID>` or
+`systemctl stop` (although please note that `systemctl stop` has a default timeout
+of 90s - if Geth takes longer than this to gracefully shut down it will quit
+forcefully. Update the `TimeoutSecs` variable in `systemd.service` to override this
+value to something larger, at least 300s).
 
-    ### Solution
+This way, Geth knows to write all relevant information into the database to
+allow the node to restart properly later. This can involve >1GB of information
+being written to the LevelDB database which can take several minutes.
 
-    If an unexpected shutdown does occur, the `removedb` subcommand can be used to
-    delete the state database and resync it from the ancient database. This should
-    get the database back up and running.
-  </Tabs.Tab>
+**Solution**
 
-  <Tabs.Tab>
-    Unclean shutdowns in `Nethermind` can lead to database corruption. This typically happens when:
+If an unexpected shutdown does occur, the `removedb` subcommand can be used to
+delete the state database and resync it from the ancient database. This should
+get the database back up and running.
 
-    *   The node experiences hardware failures (disk failures, memory errors, overheating)
-    *   Power cuts cause abrupt shutdowns
-    *   The process is terminated without proper cleanup
+### For Nethermind
 
-    ### Solutions
+Unclean shutdowns in `Nethermind` can lead to database corruption. This typically happens when:
 
-    1.  **Lock File Issues**
-        If `Nethermind` complains about lock files after an unclean shutdown, run:
-        ```bash
-        find /path/to/nethermind_db -type f -name 'LOCK' -delete
-        ```
+*   The node experiences hardware failures (disk failures, memory errors, overheating)
+*   Power cuts cause abrupt shutdowns
+*   The process is terminated without proper cleanup
 
-    2.  **Block Checksum Mismatch**
-        If you encounter block checksum mismatch errors, you can enable direct I/O:
-        ```bash
-        --Db.UseDirectIoForFlushAndCompactions true
-        ```
-        Note: This may impact performance.
+**Solutions**
 
-    3.  **Complete Resync**
-        In cases of severe corruption, a full resync is recommended:
-        ```bash
-        sudo systemctl stop nethermind
-        sudo rm -rf /path/to/nethermind_db/mainnet
-        sudo systemctl start nethermind
-        ```
-  </Tabs.Tab>
-</Tabs>
+1.  **Lock File Issues**
+
+    If `Nethermind` complains about lock files after an unclean shutdown, run:
+    ```bash
+    find /path/to/nethermind_db -type f -name 'LOCK' -delete
+    ```
+
+2.  **Block Checksum Mismatch**
+
+    If you encounter block checksum mismatch errors, you can enable direct I/O:
+    ```bash
+    --Db.UseDirectIoForFlushAndCompactions true
+    ```
+    Note: This may impact performance.
+
+3.  **Complete Resync**
+
+    In cases of severe corruption, a full resync is recommended:
+    ```bash
+    sudo systemctl stop nethermind
+    sudo rm -rf /path/to/nethermind_db/mainnet
+    sudo systemctl start nethermind
+    ```


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

The solutions in https://docs.optimism.io/node-operators/guides/troubleshooting#unclean-shutdowns is hidden, fix it and add more warnings of op-geth's removedb.

<img width="1546" height="686" alt="image" src="https://github.com/user-attachments/assets/a916a421-eb87-4f9e-b531-6ca92c79c839" />


**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
