### PR TITLE
docs: add note about L2 vs L1 finality on Optimism

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ Follow these [mintlify docs](https://www.mintlify.com/docs/installation) to prev
 ## License
 
 This project is licensed under the [MIT License](https://github.com/ethereum-optimism/optimism/blob/develop/LICENSE).
+> Note: On Optimism, L2 transactions are considered final for UX purposes
+> once they are included in an L2 block, but economic finality is only
+> achieved after the corresponding state root is posted and finalized on L1.


### PR DESCRIPTION
This PR adds a short note to the README clarifying the distinction between
UX-level finality on L2 and economic finality on L1.

While transactions can be treated as final for user experience once they are
included in an L2 block, economic finality is only achieved after the
corresponding state root has been posted and finalized on L1.

This helps developers set correct expectations when building on Optimism.
Documentation-only change, no code modifications.


<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
