### PR TITLE
Fix op-geth tag name in upgrade-17.mdx

### DIFF
--- a/notices/upgrade-17.mdx
+++ b/notices/upgrade-17.mdx
@@ -54,9 +54,9 @@ These following steps are necessary for every node operator:
   <Step title="Update to the latest release">
   The releases contain both the Jovian Mainnet and Sepolia Superchain activation timestamps.
   
-    *   [op-node/v1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-node%2Fv1.16.2)
-    *   [op-geth/v1.101603.5](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.5)
-    *   [op-reth/v1.9.2](https://github.com/paradigmxyz/reth/releases/tag/v1.9.2)
+    *   op-node: [op-node/v1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-node%2Fv1.16.2)
+    *   op-geth: [v1.101603.5](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.5)
+    *   op-reth: [op-reth/v1.9.2](https://github.com/paradigmxyz/reth/releases/tag/v1.9.2)
   </Step>
 
   <Step title="Configure the Jovian activation date">


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The op-geth tag is incorrect. 

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
