### PR TITLE
Fix Docker image references on node releases page (issue #1657)

### DIFF
--- a/node-operators/reference/releases.mdx
+++ b/node-operators/reference/releases.mdx
@@ -18,14 +18,16 @@ Chain and node operators should always run the latest production releases of the
 
 ### Docker images
 
-To make it easier to find and use our Docker images, each release entry below provides links to the corresponding Docker images:
+Docker images for OP Stack components are published alongside each release and component.
 
-*   **op-node**: Docker images can be found [here](https://hub.docker.com/r/ethereumoptimism/op-node/tags).
-*   **op-geth**: Docker images can be found [here](https://hub.docker.com/r/ethereumoptimism/op-geth/tags).
+- **op-node**: Refer to the images and tags referenced in the [`op-node` releases](https://github.com/ethereum-optimism/optimism/releases) and the component’s README.
+- **op-geth**: Refer to the images and tags referenced in the [`op-geth` releases](https://github.com/ethereum-optimism/op-geth/releases) and the component’s README.
 
 ### Example Docker image tags
 
-We follow a consistent tagging convention to make it easier to find the right image. Here are some examples:
+The exact image name and registry can vary over time and between deployments. In general, image tags follow the component name and release version, for example:
 
-*   `optimism/op-node:<version>`
-*   `optimism/op-geth:<version>`
+- `<registry>/<namespace>/op-node:<version>`
+- `<registry>/<namespace>/op-geth:<version>`
+
+Always refer to the release notes or README for the precise image reference.


### PR DESCRIPTION
- Removed outdated Docker Hub image links for `op-node` and `op-geth`.
- Updated the Docker images section to point to the component release pages and READMEs instead of hard-coded image names.
- Replaced specific image examples with generic, registry-agnostic examples so the docs stay correct even if image locations change.
- Addresses the confusion reported in issue #1657.
