### PR TITLE
fix(docs): Correct Standard Rollup Charter link path

### DIFF
--- a/superchain/superchain-registry.mdx
+++ b/superchain/superchain-registry.mdx
@@ -15,10 +15,10 @@ An OP Stack Standard Rollup follows the Standard Rollup Charter.
 
 This configuration targets the Optimism Collective's highest bar for security, uptime, and decentralization.
 
-You can find more details in the [Standard Rollup Charter documentation](/superchain/concepts/blockspace-charter).
+You can find more details in the [Standard Rollup Charter documentation](/superchain/concepts/standard-rollup-charter).
 
 <Info>
-  We **strongly** recommend using the [op-deployer](/operators/chain-operators/tools/op-deployer) to deploy L1 contracts and generate the L2 genesis file that meets the configuration requirements outlined in the [Standard Rollup Charter](/superchain/concepts/blockspace-charter).
+  We **strongly** recommend using the [op-deployer](/operators/chain-operators/tools/op-deployer) to deploy L1 contracts and generate the L2 genesis file that meets the configuration requirements outlined in the [Standard Rollup Charter](/superchain/concepts/standard-rollup-charter).
 </Info>
 
 ## Joining the Registry


### PR DESCRIPTION
The original link pointed to '/superchain/concepts/blockspace-charter' but should reference '/superchain/concepts/standard-rollup-charter' to match the actual Standard Rollup Charter document. This fix ensures developers can access the correct documentation when following links in the Superchain Registry guide.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
