### PR TITLE
Fix paths for chain configuration file copying

### DIFF
--- a/chain-operators/tutorials/create-l2-rollup/op-challenger-setup.mdx
+++ b/chain-operators/tutorials/create-l2-rollup/op-challenger-setup.mdx
@@ -52,8 +52,9 @@ The challenger needs the absolute prestate to participate in dispute games. Here
     ```bash
     # Assuming you're in rollup/challenger/optimism directory
     # Replace <YOUR-CHAIN-ID> with your actual L2 chain ID
-    cp ../deployer/.deployer/rollup.json op-program/chainconfig/configs/<YOUR-CHAIN-ID>-rollup.json
-    cp ../deployer/.deployer/genesis.json op-program/chainconfig/configs/<YOUR-CHAIN-ID>-genesis.json
+    cp ../../deployer/.deployer/rollup.json op-program/chainconfig/configs/<YOUR-CHAIN-ID>-rollup.json
+    # For op-challanger/v1.7.0 use ../../deployer/.deployer/genesis.json op-program/chainconfig/configs/<YOUR-CHAIN-ID>-genesis-l2.json
+    cp ../../deployer/.deployer/genesis.json op-program/chainconfig/configs/<YOUR-CHAIN-ID>-genesis.json
 
     # Your directory structure should look like:
     # rollup/


### PR DESCRIPTION
# Fix paths for chain configuration file copying

## Description

Updated file paths for copying chain configuration files from `../deployer/` to `../../deployer/` to reflect the correct relative path from the current working directory.

### Changes

- Fixed `rollup.json` copy path: `../deployer/.deployer/rollup.json` → `../../deployer/.deployer/rollup.json`
- Fixed `genesis.json` copy path: `../deployer/.deployer/genesis.json` → `../../deployer/.deployer/genesis.json`
- Added comment noting alternative path for op-challenger/v1.7.0 (`genesis-l2.json`)

## Tests

Manual verification that the updated paths correctly reference the deployer configuration files from the expected directory structure.

## Additional context

The previous paths assumed a different directory structure. This fix ensures the copy commands work correctly when executed from the appropriate location in the project hierarchy.

## Metadata

N/A