### PR TITLE
feat: split json-rpc into geth and node's

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1141,7 +1141,11 @@
     },
     {
       "source": "/operators/node-operators/json-rpc",
-      "destination": "/node-operators/reference/json-rpc"
+      "destination": "/node-operators/reference/op-node-json-rpc"
+    },
+    {
+      "source": "/node-operators/reference/json-rpc",
+      "destination": "/node-operators/reference/op-node-json-rpc"
     },
     {
       "source": "/operators/node-operators/management",
@@ -2193,7 +2197,13 @@
                   "node-operators/reference/features/snap-sync"
                 ]
               },
-              "node-operators/reference/json-rpc",
+              {
+                "group": "JSON-RPC API",
+                "pages": [
+                  "node-operators/reference/op-node-json-rpc",
+                  "node-operators/reference/op-geth-json-rpc"
+                ]
+              },
               "node-operators/reference/consensus-layer-sync",
               "node-operators/reference/releases"
             ]

--- a/node-operators/reference/op-geth-json-rpc.mdx
+++ b/node-operators/reference/op-geth-json-rpc.mdx
@@ -1,0 +1,679 @@
+---
+title: op-geth JSON-RPC API
+description: Complete reference for op-geth execution client RPC methods with OP Stack enhancements.
+---
+
+`op-geth` is the execution client for the OP Stack, based on Go Ethereum (Geth). It provides the execution layer with Ethereum-equivalent functionality plus OP Stack-specific enhancements for L2 gas accounting and receipts.
+
+## Overview
+
+The `op-geth` execution client implements the standard Ethereum JSON-RPC API with minimal modifications. This means you can use familiar Ethereum tools and libraries with OP Stack chains.
+
+<Info>
+  The execution engine's RPC interface is identical to [the upstream Geth RPC interface](https://geth.ethereum.org/docs/interacting-with-geth/rpc). The key difference is that transaction receipts include additional L1 gas usage and pricing information specific to L2 operations.
+</Info>
+
+## Key Differences from Ethereum
+
+While `op-geth` maintains compatibility with Ethereum's JSON-RPC API, there are important differences:
+
+### Transaction Receipts
+
+Transaction receipts in `op-geth` include additional L1 data fee information:
+
+- **`l1GasUsed`**: Amount of L1 gas used for L1 data availability
+- **`l1GasPrice`**: L1 gas price at the time of transaction execution
+- **`l1Fee`**: Total L1 data fee charged (in wei)
+- **`l1FeeScalar`**: Scalar value used in L1 fee calculation
+
+This additional information helps you understand the full cost of L2 transactions, which include both L2 execution costs and L1 data availability costs.
+
+### Gas Price Calculation
+
+For L2 gas prices, use the standard [`eth_gasPrice`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_gasprice) method.
+
+For L1 gas prices and fee estimation, use the [`GasPriceOracle`](https://explorer.optimism.io/address/0x420000000000000000000000000000000000000F) predeployed contract or [the Optimism SDK](/app-developers/tutorials/transactions/sdk-estimate-costs).
+
+## Standard JSON-RPC Methods
+
+`op-geth` supports all standard Ethereum JSON-RPC methods. Below are commonly used methods with examples.
+
+### eth_blockNumber
+
+Returns the number of the most recent block.
+
+<Tabs>
+  <Tab title="curl">
+    ```sh
+    curl -X POST -H "Content-Type: application/json" --data \
+      '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+      http://localhost:8545
+    ```
+  </Tab>
+  <Tab title="cast">
+    ```sh
+    cast block-number --rpc-url http://localhost:8545
+    ```
+  </Tab>
+</Tabs>
+
+Sample success output:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "0x4b7"
+}
+```
+
+### eth_getBalance
+
+Returns the balance of the account at the given address.
+
+<Tabs>
+  <Tab title="curl">
+    ```sh
+    curl -X POST -H "Content-Type: application/json" --data \
+      '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb","latest"],"id":1}' \
+      http://localhost:8545
+    ```
+  </Tab>
+  <Tab title="cast">
+    ```sh
+    cast balance 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb --rpc-url http://localhost:8545
+    ```
+  </Tab>
+</Tabs>
+
+Sample success output:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "0x0234c8a3397aab58"
+}
+```
+
+### eth_getTransactionByHash
+
+Returns information about a transaction by transaction hash.
+
+<Tabs>
+  <Tab title="curl">
+    ```sh
+    curl -X POST -H "Content-Type: application/json" --data \
+      '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b"],"id":1}' \
+      http://localhost:8545
+    ```
+  </Tab>
+  <Tab title="cast">
+    ```sh
+    cast tx 0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b --rpc-url http://localhost:8545
+    ```
+  </Tab>
+</Tabs>
+
+Sample success output:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "blockHash": "0x1d59ff54b1eb26b013ce3cb5fc9dab3705b415a67127a003c3e61eb445bb8df2",
+    "blockNumber": "0x5daf3b",
+    "from": "0xa7d9ddbe1f17865597fbd27ec712455208b6b76d",
+    "gas": "0xc350",
+    "gasPrice": "0x4a817c800",
+    "hash": "0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b",
+    "input": "0x68656c6c6f21",
+    "nonce": "0x15",
+    "to": "0xf02c1c8e6114b1dbe8937a39260b5b0a374432bb",
+    "transactionIndex": "0x41",
+    "value": "0xf3dbb76162000",
+    "type": "0x0",
+    "chainId": "0xa4b1",
+    "v": "0x1546d71",
+    "r": "0x8a8eafb3cf4c5c4c5c5e5c5e5c5e5c5e5c5e5c5e5c5e5c5e5c5e5c5e5c5e5c5e",
+    "s": "0x8a8eafb3cf4c5c4c5c5e5c5e5c5e5c5e5c5e5c5e5c5e5c5e5c5e5c5e5c5e5c5e"
+  }
+}
+```
+
+### eth_getTransactionReceipt
+
+Returns the receipt of a transaction by transaction hash. This method includes OP Stack-specific L1 fee fields.
+
+<Tabs>
+  <Tab title="curl">
+    ```sh
+    curl -X POST -H "Content-Type: application/json" --data \
+      '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b"],"id":1}' \
+      http://localhost:8545
+    ```
+  </Tab>
+  <Tab title="cast">
+    ```sh
+    cast receipt 0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b --rpc-url http://localhost:8545
+    ```
+  </Tab>
+</Tabs>
+
+Sample success output:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "blockHash": "0x1d59ff54b1eb26b013ce3cb5fc9dab3705b415a67127a003c3e61eb445bb8df2",
+    "blockNumber": "0x5daf3b",
+    "contractAddress": null,
+    "cumulativeGasUsed": "0x33bc",
+    "effectiveGasPrice": "0x4a817c800",
+    "from": "0xa7d9ddbe1f17865597fbd27ec712455208b6b76d",
+    "gasUsed": "0x4dc",
+    "logs": [],
+    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "status": "0x1",
+    "to": "0xf02c1c8e6114b1dbe8937a39260b5b0a374432bb",
+    "transactionHash": "0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b",
+    "transactionIndex": "0x41",
+    "type": "0x0",
+    "l1GasUsed": "0x5e0",
+    "l1GasPrice": "0x3b9aca00",
+    "l1Fee": "0x16a3f5b9c0",
+    "l1FeeScalar": "1.0"
+  }
+}
+```
+
+<Info>
+  Notice the additional fields at the end of the receipt: `l1GasUsed`, `l1GasPrice`, `l1Fee`, and `l1FeeScalar`. These fields are specific to OP Stack chains and provide information about L1 data availability costs.
+</Info>
+
+### eth_call
+
+Executes a new message call immediately without creating a transaction on the blockchain.
+
+<Tabs>
+  <Tab title="curl">
+    ```sh
+    curl -X POST -H "Content-Type: application/json" --data \
+      '{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"0x420000000000000000000000000000000000000F","data":"0x519b4bd3"},"latest"],"id":1}' \
+      http://localhost:8545
+    ```
+  </Tab>
+  <Tab title="cast">
+    ```sh
+    cast call 0x420000000000000000000000000000000000000F "l1BaseFee()" --rpc-url http://localhost:8545
+    ```
+  </Tab>
+</Tabs>
+
+Sample success output:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "0x00000000000000000000000000000000000000000000000000000003b9aca00"
+}
+```
+
+### eth_estimateGas
+
+Generates and returns an estimate of gas needed for a transaction to complete.
+
+<Tabs>
+  <Tab title="curl">
+    ```sh
+    curl -X POST -H "Content-Type: application/json" --data \
+      '{"jsonrpc":"2.0","method":"eth_estimateGas","params":[{"from":"0x8D97689C9818892B700e27F316cc3E41e17fBeb9","to":"0xd3CdA913deB6f67967B99D67aCDFa1712C293601","value":"0xde0b6b3a7640000"}],"id":1}' \
+      http://localhost:8545
+    ```
+  </Tab>
+  <Tab title="cast">
+    ```sh
+    cast estimate 0xd3CdA913deB6f67967B99D67aCDFa1712C293601 --value 1ether --from 0x8D97689C9818892B700e27F316cc3E41e17fBeb9 --rpc-url http://localhost:8545
+    ```
+  </Tab>
+</Tabs>
+
+Sample success output:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "0x5208"
+}
+```
+
+<Warning>
+  `eth_estimateGas` only estimates L2 execution gas. To calculate the total transaction cost including L1 data fees, use the [Optimism SDK](/app-developers/tutorials/transactions/sdk-estimate-costs) or query the [`GasPriceOracle` predeployed contract](https://explorer.optimism.io/address/0x420000000000000000000000000000000000000F).
+</Warning>
+
+### eth_sendRawTransaction
+
+Submits a signed transaction to the network.
+
+<Tabs>
+  <Tab title="curl">
+    ```sh
+    curl -X POST -H "Content-Type: application/json" --data \
+      '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"],"id":1}' \
+      http://localhost:8545
+    ```
+  </Tab>
+  <Tab title="cast">
+    ```sh
+    cast publish 0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675 --rpc-url http://localhost:8545
+    ```
+  </Tab>
+</Tabs>
+
+Sample success output:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331"
+}
+```
+
+### eth_getBlockByNumber
+
+Returns information about a block by block number.
+
+<Tabs>
+  <Tab title="curl">
+    ```sh
+    curl -X POST -H "Content-Type: application/json" --data \
+      '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x1b4",true],"id":1}' \
+      http://localhost:8545
+    ```
+  </Tab>
+  <Tab title="cast">
+    ```sh
+    cast block 0x1b4 --rpc-url http://localhost:8545
+    ```
+  </Tab>
+</Tabs>
+
+Sample success output:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "difficulty": "0x0",
+    "extraData": "0x",
+    "gasLimit": "0x1c9c380",
+    "gasUsed": "0x5208",
+    "hash": "0x1d59ff54b1eb26b013ce3cb5fc9dab3705b415a67127a003c3e61eb445bb8df2",
+    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "miner": "0x4200000000000000000000000000000000000011",
+    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "nonce": "0x0000000000000000",
+    "number": "0x1b4",
+    "parentHash": "0x9b83c12c69edb74f6c8dd5d052765c1adf940e320bd1291696e6fa07829eee71",
+    "receiptsRoot": "0x056b23fbba480696b65fe5a59b8f2148a1299103c4f57df839233af2cf4ca2d2",
+    "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+    "size": "0x27f",
+    "stateRoot": "0xd5855eb08b3387c0af375e9cdb6acfc05eb8f519e419b874b6ff2ffda7ed1dff",
+    "timestamp": "0x54e34e8e",
+    "totalDifficulty": "0x0",
+    "transactions": [],
+    "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+    "uncles": []
+  }
+}
+```
+
+### eth_getLogs
+
+Returns an array of all logs matching a given filter object.
+
+<Tabs>
+  <Tab title="curl">
+    ```sh
+    curl -X POST -H "Content-Type: application/json" --data \
+      '{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"0x1","toBlock":"0x2","address":"0x8320fe7702b96808f7bbc0d4a888ed1468216cfd"}],"id":1}' \
+      http://localhost:8545
+    ```
+  </Tab>
+  <Tab title="cast">
+    ```sh
+    cast logs --from-block 1 --to-block 2 --address 0x8320fe7702b96808f7bbc0d4a888ed1468216cfd --rpc-url http://localhost:8545
+    ```
+  </Tab>
+</Tabs>
+
+Sample success output:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": [{
+    "address": "0x8320fe7702b96808f7bbc0d4a888ed1468216cfd",
+    "topics": [
+      "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+      "0x00000000000000000000000000000000000000000000000000000000000000fe",
+      "0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+    ],
+    "data": "0x0000000000000000000000000000000000000000000000000000000000000001",
+    "blockNumber": "0x1",
+    "transactionHash": "0xab059a62e22e230fe0f56d8555340a29b2e9532360368f810595453f6fdd213b",
+    "transactionIndex": "0x0",
+    "blockHash": "0x8243343df08b9751f5ca0c5f8c9c0460d8a9b6351066fae0acbd4d3e776de8bb",
+    "logIndex": "0x0",
+    "removed": false
+  }]
+}
+```
+
+### eth_chainId
+
+Returns the currently configured chain ID, used for signing replay-protected transactions.
+
+<Tabs>
+  <Tab title="curl">
+    ```sh
+    curl -X POST -H "Content-Type: application/json" --data \
+      '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
+      http://localhost:8545
+    ```
+  </Tab>
+  <Tab title="cast">
+    ```sh
+    cast chain-id --rpc-url http://localhost:8545
+    ```
+  </Tab>
+</Tabs>
+
+Sample success output:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "0xa"
+}
+```
+
+## Gas Price Methods
+
+### eth_gasPrice
+
+Returns the current gas price in wei for L2 execution.
+
+<Tabs>
+  <Tab title="curl">
+    ```sh
+    curl -X POST -H "Content-Type: application/json" --data \
+      '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}' \
+      http://localhost:8545
+    ```
+  </Tab>
+  <Tab title="cast">
+    ```sh
+    cast gas-price --rpc-url http://localhost:8545
+    ```
+  </Tab>
+</Tabs>
+
+Sample success output:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "0x4a817c800"
+}
+```
+
+<Info>
+  This only returns the L2 gas price. For comprehensive transaction cost estimation including L1 data fees, use the [`GasPriceOracle` predeployed contract](https://explorer.optimism.io/address/0x420000000000000000000000000000000000000F) or [the Optimism SDK](/app-developers/tutorials/transactions/sdk-estimate-costs).
+</Info>
+
+### eth_maxPriorityFeePerGas
+
+Returns the current maximum priority fee per gas (EIP-1559).
+
+<Tabs>
+  <Tab title="curl">
+    ```sh
+    curl -X POST -H "Content-Type: application/json" --data \
+      '{"jsonrpc":"2.0","method":"eth_maxPriorityFeePerGas","params":[],"id":1}' \
+      http://localhost:8545
+    ```
+  </Tab>
+  <Tab title="cast">
+    ```sh
+    cast --priority-gas-price --rpc-url http://localhost:8545
+    ```
+  </Tab>
+</Tabs>
+
+Sample success output:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "0x3b9aca00"
+}
+```
+
+## Account and State Methods
+
+### eth_getCode
+
+Returns code at a given address.
+
+<Tabs>
+  <Tab title="curl">
+    ```sh
+    curl -X POST -H "Content-Type: application/json" --data \
+      '{"jsonrpc":"2.0","method":"eth_getCode","params":["0x420000000000000000000000000000000000000F","latest"],"id":1}' \
+      http://localhost:8545
+    ```
+  </Tab>
+  <Tab title="cast">
+    ```sh
+    cast code 0x420000000000000000000000000000000000000F --rpc-url http://localhost:8545
+    ```
+  </Tab>
+</Tabs>
+
+Sample success output:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "0x608060405234801561001057600080fd5b50600436106100365760003560e01c806354fd4d501461003b578063..."
+}
+```
+
+### eth_getStorageAt
+
+Returns the value from a storage position at a given address.
+
+<Tabs>
+  <Tab title="curl">
+    ```sh
+    curl -X POST -H "Content-Type: application/json" --data \
+      '{"jsonrpc":"2.0","method":"eth_getStorageAt","params":["0x420000000000000000000000000000000000000F","0x0","latest"],"id":1}' \
+      http://localhost:8545
+    ```
+  </Tab>
+  <Tab title="cast">
+    ```sh
+    cast storage 0x420000000000000000000000000000000000000F 0x0 --rpc-url http://localhost:8545
+    ```
+  </Tab>
+</Tabs>
+
+Sample success output:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "0x0000000000000000000000000000000000000000000000000000000000000001"
+}
+```
+
+### eth_getTransactionCount
+
+Returns the number of transactions sent from an address (the nonce).
+
+<Tabs>
+  <Tab title="curl">
+    ```sh
+    curl -X POST -H "Content-Type: application/json" --data \
+      '{"jsonrpc":"2.0","method":"eth_getTransactionCount","params":["0x8D97689C9818892B700e27F316cc3E41e17fBeb9","latest"],"id":1}' \
+      http://localhost:8545
+    ```
+  </Tab>
+  <Tab title="cast">
+    ```sh
+    cast nonce 0x8D97689C9818892B700e27F316cc3E41e17fBeb9 --rpc-url http://localhost:8545
+    ```
+  </Tab>
+</Tabs>
+
+Sample success output:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "0x1a"
+}
+```
+
+## Debug and Trace Methods
+
+`op-geth` supports the same debug and trace methods as upstream Geth, allowing detailed transaction analysis and debugging.
+
+<Warning>
+  Debug and trace methods can be resource-intensive. Most public RPC providers disable these methods. You'll need to run your own node with `--http.api debug,trace` to access them.
+</Warning>
+
+### debug_traceTransaction
+
+Returns the trace of a transaction, showing all internal calls and state changes.
+
+<Tabs>
+  <Tab title="curl">
+    ```sh
+    curl -X POST -H "Content-Type: application/json" --data \
+      '{"jsonrpc":"2.0","method":"debug_traceTransaction","params":["0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b"],"id":1}' \
+      http://localhost:8545
+    ```
+  </Tab>
+  <Tab title="cast">
+    ```sh
+    cast run 0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b --rpc-url http://localhost:8545 --trace
+    ```
+  </Tab>
+</Tabs>
+
+### debug_traceCall
+
+Traces a call without executing it on-chain.
+
+<Tabs>
+  <Tab title="curl">
+    ```sh
+    curl -X POST -H "Content-Type: application/json" --data \
+      '{"jsonrpc":"2.0","method":"debug_traceCall","params":[{"to":"0x420000000000000000000000000000000000000F","data":"0x519b4bd3"},"latest"],"id":1}' \
+      http://localhost:8545
+    ```
+  </Tab>
+</Tabs>
+
+## WebSocket Support
+
+`op-geth` supports WebSocket connections for real-time event subscriptions using the `eth_subscribe` method.
+
+### eth_subscribe
+
+Creates a subscription for specific events.
+
+```javascript
+// Connect to WebSocket
+const ws = new WebSocket('ws://localhost:8546');
+
+// Subscribe to new block headers
+ws.send(JSON.stringify({
+  "jsonrpc": "2.0",
+  "method": "eth_subscribe",
+  "params": ["newHeads"],
+  "id": 1
+}));
+
+// Subscribe to logs
+ws.send(JSON.stringify({
+  "jsonrpc": "2.0",
+  "method": "eth_subscribe",
+  "params": [
+    "logs",
+    {
+      "address": "0x8320fe7702b96808f7bbc0d4a888ed1468216cfd",
+      "topics": ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"]
+    }
+  ],
+  "id": 2
+}));
+```
+
+### eth_unsubscribe
+
+Cancels an active subscription.
+
+```javascript
+ws.send(JSON.stringify({
+  "jsonrpc": "2.0",
+  "method": "eth_unsubscribe",
+  "params": ["0x9cef478923ff08bf67fde6c64013158d"],
+  "id": 1
+}));
+```
+
+## Additional Resources
+
+For a complete list of all supported JSON-RPC methods, refer to:
+
+- [Geth JSON-RPC Documentation](https://geth.ethereum.org/docs/interacting-with-geth/rpc)
+- [Ethereum JSON-RPC Specification](https://ethereum.org/en/developers/docs/apis/json-rpc/)
+- [OP Stack Transaction Cost Estimation](/app-developers/tutorials/transactions/sdk-estimate-costs)
+
+## Running a Node with RPC Access
+
+To run your own `op-geth` node with full RPC access:
+
+```sh
+op-geth \
+  --http \
+  --http.addr 0.0.0.0 \
+  --http.port 8545 \
+  --http.api eth,net,web3,debug,trace \
+  --ws \
+  --ws.addr 0.0.0.0 \
+  --ws.port 8546 \
+  --ws.api eth,net,web3 \
+  ... # additional flags
+```
+
+<Warning>
+  Be cautious when exposing RPC endpoints publicly. Use authentication, rate limiting, and firewall rules to prevent abuse. Debug and trace APIs should only be enabled for trusted clients.
+</Warning>

--- a/node-operators/reference/op-node-json-rpc.mdx
+++ b/node-operators/reference/op-node-json-rpc.mdx
@@ -1,9 +1,9 @@
 ---
-title: JSON-RPC API
-description: Learn about the different OP Mainnet components with an RPC API.
+title: op-node JSON-RPC API
+description: Complete reference for op-node RPC methods including rollup-specific functionality.
 ---
 
-There are several OP Mainnet components with an RPC API, which are reviewed in this guide.
+`op-node` implements rollup-specific functionality as the Consensus Layer, similar to an L1 beacon node. It provides RPC methods for querying rollup state, managing peers, and controlling sequencer operations.
 
 <Info>
   Use [`eth_gasPrice`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_gasprice) instead of `rollup_gasPrices` for the L2 gas price.
@@ -11,29 +11,23 @@ There are several OP Mainnet components with an RPC API, which are reviewed in t
   If you want to estimate the cost of a transaction, you can [use the SDK](/app-developers/tutorials/transactions/sdk-estimate-costs).
 </Info>
 
-## op-node
-
-`op-node` implements most rollup-specific functionality as Consensus-Layer, similar to a L1 beacon-node. The following RPC methods are broken down by namespace.
-
+## Making RPC Requests
 
 The following examples show you how to make requests with [`curl`](https://curl.se/) and [`cast`](https://book.getfoundry.sh/cast/).
 
 <Info>
-  Protip: piping these commands in to [`jq`](https://jqlang.github.io/jq/) will give you nicely formatted JSON responses.
-  
+  Protip: piping these commands into [`jq`](https://jqlang.github.io/jq/) will give you nicely formatted JSON responses.
+
   `$ cast rpc optimism_syncStatus --rpc-url http://localhost:9545 | jq`
 </Info>
 
-### optimism
+## optimism Namespace
 
+Optimism-specific rollup methods for querying chain state and configuration.
 
-Optimism specific rollup methods.
+### optimism_outputAtBlock
 
-
-#### `optimism_outputAtBlock`
-
-Get the output root at a specific block.
-This method is documented in [the specifications](https://specs.optimism.io/protocol/rollup-node.html?utm_source=op-docs&utm_medium=docs#output-method-api).
+Get the output root at a specific block. This method is documented in [the specifications](https://specs.optimism.io/protocol/rollup-node.html?utm_source=op-docs&utm_medium=docs#output-method-api).
 
 <Tabs>
   <Tab title="curl">
@@ -50,8 +44,6 @@ This method is documented in [the specifications](https://specs.optimism.io/prot
   </Tab>
 </Tabs>
 
-
-
 Sample success output:
 
 ```json
@@ -65,9 +57,9 @@ Sample success output:
 }
 ```
 
-#### `optimism_syncStatus`
+### optimism_syncStatus
 
-Get the synchronization status.
+Get the synchronization status of the rollup node. This method provides detailed information about L1 and L2 block processing states.
 
 <Tabs>
   <Tab title="curl">
@@ -187,7 +179,7 @@ Sample success output:
 }
 ```
 
-#### `optimism_rollupConfig`
+### optimism_rollupConfig
 
 Get the rollup configuration parameters.
 
@@ -205,7 +197,6 @@ Get the rollup configuration parameters.
     ```
   </Tab>
 </Tabs>
-
 
 Sample success output:
 
@@ -243,9 +234,9 @@ Sample success output:
 }
 ```
 
-#### `optimism_version`
+### optimism_version
 
-Get the software version.
+Get the software version of the op-node.
 
 <Info>
 At the moment, building from source will not give you the correct version, but our docker images will.
@@ -266,8 +257,6 @@ At the moment, building from source will not give you the correct version, but o
   </Tab>
 </Tabs>
 
-
-
 Sample success output:
 
 ```json
@@ -278,13 +267,13 @@ Sample success output:
 }
 ```
 
-### opp2p 
+## opp2p Namespace
 
-The `opp2p` namespace handles peer interactions.
+The `opp2p` namespace handles peer-to-peer networking interactions, allowing you to manage peer connections, discovery, and network policies.
 
-#### `opp2p_self`
+### opp2p_self
 
-Returns your node's information.
+Returns your node's peer information including peer ID, addresses, and network configuration.
 
 <Tabs>
   <Tab title="curl">
@@ -347,9 +336,9 @@ Sample success output:
 }
 ```
 
-#### `opp2p_peers`
+### opp2p_peers
 
-Returns a list of your node's peers.
+Returns a list of your node's peers with detailed connection information.
 
 <Tabs>
   <Tab title="curl">
@@ -417,8 +406,8 @@ Sample success output:
             "rejectedPayloads": 0
           }
         }
-      },
-    ...
+      }
+    },
     "bannedPeers": [],
     "bannedIPS": [],
     "bannedSubnets": []
@@ -426,9 +415,9 @@ Sample success output:
 }
 ```
 
-#### `opp2p_peerStats`
+### opp2p_peerStats
 
-Returns your peer stats.
+Returns aggregate statistics about your peer connections.
 
 <Tabs>
   <Tab title="curl">
@@ -462,9 +451,9 @@ Sample success output:
 }
 ```
 
-#### `opp2p_discoveryTable`
+### opp2p_discoveryTable
 
-Returns your peer discovery table.
+Returns your peer discovery table containing node records (ENRs) of discovered peers.
 
 <Tabs>
   <Tab title="curl">
@@ -489,23 +478,20 @@ Sample success output:
   "id": 1,
   "result": [
   "enr:-J24QGC_SzoGG4EqyvO_082paQOwhvECeWGT-kaenrHdE2_iLTLeGmH-IOVpqEjC0L-yWmkI-c7598VaCjHQRNWn1CyGAYsqDgrFgmlkgnY0gmlwhNgp3WeHb3BzdGFja4OFQgCJc2VjcDI1NmsxoQPiq20PNZYzyvpEifcGVrOXHfM94JeWSgDL07I2hSl0d4N0Y3CCJAaDdWRwgiQG",
-  "enr:-J24QKvt2ThBM8-FPeHfAmpoaVLdfVD2cw1cRpNuwmvH_bQtQ1dqrrZw9FqiMbXbFRQf9IvjrlKSFLodbsRALIFATICGAYuQClJigmlkgnY0gmlwhKI3ZuaHb3BzdGFja4O6BACJc2VjcDI1NmsxoQLQRz2CH95qQd6vmF5saV-WOoTZobNfSt-FUdVa7R35nYN0Y3CCIyuDdWRwgiMr",
-  "enr:-J24QEMvLGmRBbDw48cHq9GzHSDiPlJ3eUpZiOMMXwvxN0JLQMZsS3-J6DKP2Uu--65BC5lAQF3zv7ukQDbEjuZpr5iGAYs0a4segmlkgnY0gmlwhEEVRWmHb3BzdGFja4OFQgCJc2VjcDI1NmsxoQJI0VT2eysk6v3t63pOZlGgJReDnNqh30roStkURIpGCoN0Y3CCJAaDdWRwgiQG",
-  ...
-  "enr:-J24QOdxnjbP7MkCFBuEjWe50NGdtAECj8tyrDBmXm8Y-JydVeoNF_IXNqodIUqeAfuAe3gcLceju96NVf8as78Eaq-GAYlu7qN_gmlkgnY0gmlwhAUJaBCHb3BzdGFja4OFQgCJc2VjcDI1NmsxoQKTb2oTlnUf5v-jP7YXZXI1wcfeSuPvsVd2niNV3BXHBYN0Y3CCJAaDdWRwgiQG"
+  "enr:-J24QKvt2ThBM8-FPeHfAmpoaVLdfVD2cw1cRpNuwmvH_bQtQ1dqrrZw9FqiMbXbFRQf9IvjrlKSFLodbsRALIFATICGAYuQClJigmlkgnY0gmlwhKI3ZuaHb3BzdGFja4O6BACJc2VjcDI1NmsxoQLQRz2CH95qQd6vmF5saV-WOoTZobNfSt-FUdVa7R35nYN0Y3CCIyuDdWRwgiMr"
   ]
 }
 ```
 
-#### `opp2p_blockPeer`
+### opp2p_blockPeer
 
-Blocks a peer.
+Blocks a peer by peer ID, preventing future connections.
 
 <Tabs>
   <Tab title="curl">
     ```sh
     curl -X POST -H "Content-Type: application/json" --data \
-        '{"jsonrpc":"2.0","method":"opp2p_blockPeer","params":[<peerID>],"id":1}'  \
+        '{"jsonrpc":"2.0","method":"opp2p_blockPeer","params":["<peerID>"],"id":1}'  \
         http://localhost:9545
     ```
   </Tab>
@@ -515,8 +501,6 @@ Blocks a peer.
     ```
   </Tab>
 </Tabs>
-
-
 
 Sample success output:
 
@@ -528,15 +512,15 @@ Sample success output:
 }
 ```
 
-#### `opp2p_unblockPeer`
+### opp2p_unblockPeer
 
-Unblocks a peer.
+Unblocks a previously blocked peer.
 
 <Tabs>
   <Tab title="curl">
     ```sh
     curl -X POST -H "Content-Type: application/json" --data \
-        '{"jsonrpc":"2.0","method":"opp2p_unblockPeer","params":[<peerID>],"id":1}'  \
+        '{"jsonrpc":"2.0","method":"opp2p_unblockPeer","params":["<peerID>"],"id":1}'  \
         http://localhost:9545
     ```
   </Tab>
@@ -557,9 +541,9 @@ Sample success output:
 }
 ```
 
-#### `opp2p_listBlockedPeers`
+### opp2p_listBlockedPeers
 
-Returns a list of your blocked peers.
+Returns a list of blocked peer IDs.
 
 <Tabs>
   <Tab title="curl">
@@ -578,7 +562,7 @@ Returns a list of your blocked peers.
 
 Sample success output:
 
-```
+```json
 {
   "jsonrpc": "2.0",
   "id": 1,
@@ -588,9 +572,9 @@ Sample success output:
 }
 ```
 
-#### `opp2p_blockAddr`
+### opp2p_blockAddr
 
-Blocks ip address.
+Blocks connections from a specific IP address.
 
 <Tabs>
   <Tab title="curl">
@@ -617,9 +601,9 @@ Sample success output:
 }
 ```
 
-#### `opp2p_unblockAddr`
+### opp2p_unblockAddr
 
-Unblocks ip address.
+Unblocks a previously blocked IP address.
 
 <Tabs>
   <Tab title="curl">
@@ -646,9 +630,9 @@ Sample success output:
 }
 ```
 
-#### `opp2p_listBlockedAddrs`
+### opp2p_listBlockedAddrs
 
-Returns a list of blocked ip addresses.
+Returns a list of blocked IP addresses.
 
 <Tabs>
   <Tab title="curl">
@@ -667,7 +651,7 @@ Returns a list of blocked ip addresses.
 
 Sample success output:
 
-```
+```json
 {
   "jsonrpc": "2.0",
   "id": 1,
@@ -677,9 +661,9 @@ Sample success output:
 }
 ```
 
-#### `opp2p_blockSubnet`
+### opp2p_blockSubnet
 
-Blocks subnet.
+Blocks connections from a specific subnet (CIDR notation).
 
 <Tabs>
   <Tab title="curl">
@@ -706,9 +690,9 @@ Sample success output:
 }
 ```
 
-#### `opp2p_unblockSubnet`
+### opp2p_unblockSubnet
 
-Unblocks subnet.
+Unblocks a previously blocked subnet.
 
 <Tabs>
   <Tab title="curl">
@@ -735,9 +719,9 @@ Sample success output:
 }
 ```
 
-#### `opp2p_listBlockedSubnets`
+### opp2p_listBlockedSubnets
 
-Returns list of blocked subnets.
+Returns a list of blocked subnets.
 
 <Tabs>
   <Tab title="curl">
@@ -764,9 +748,9 @@ Sample success output:
 }
 ```
 
-#### `opp2p_protectPeer`
+### opp2p_protectPeer
 
-Protect peer.
+Protects a peer from being pruned from the connection pool.
 
 <Tabs>
   <Tab title="curl">
@@ -793,9 +777,9 @@ Sample success output:
 }
 ```
 
-#### `opp2p_unprotectPeer`
+### opp2p_unprotectPeer
 
-Unprotect peer.
+Removes protection from a peer, allowing it to be pruned if necessary.
 
 <Tabs>
   <Tab title="curl">
@@ -822,15 +806,15 @@ Sample success output:
 }
 ```
 
-#### `opp2p_connectPeer`
+### opp2p_connectPeer
 
-Connect peer.
+Initiates a connection to a peer using its multiaddress.
 
 <Tabs>
   <Tab title="curl">
     ```sh
     curl -X POST -H "Content-Type: application/json" --data \
-        '{"jsonrpc":"2.0","method":"opp2p_connectPeer","params":[<peer multiaddr>],"id":1}'  \
+        '{"jsonrpc":"2.0","method":"opp2p_connectPeer","params":["<peer multiaddr>"],"id":1}'  \
         http://localhost:9545
     ```
   </Tab>
@@ -851,9 +835,9 @@ Sample success output:
 }
 ```
 
-#### `opp2p_disconnectPeer`
+### opp2p_disconnectPeer
 
-Disconnect peer.
+Disconnects from a specific peer.
 
 <Tabs>
   <Tab title="curl">
@@ -872,7 +856,7 @@ Disconnect peer.
 
 Sample success output:
 
-```json 
+```json
 {
   "jsonrpc": "2.0",
   "id": 1,
@@ -880,13 +864,13 @@ Sample success output:
 }
 ```
 
-### admin
+## admin Namespace
 
-todo: add admin namespace description
+Administrative methods for controlling sequencer operations and the derivation pipeline.
 
-#### `admin_resetDerivationPipeline`
+### admin_resetDerivationPipeline
 
-Resets the derivation pipeline.
+Resets the derivation pipeline, forcing it to re-derive L2 blocks from L1 data.
 
 <Tabs>
   <Tab title="curl">
@@ -905,13 +889,17 @@ Resets the derivation pipeline.
 
 Sample success output:
 
-```
-todo: add Sample success output
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": null
+}
 ```
 
-#### `admin_startSequencer`
+### admin_startSequencer
 
-Starts the sequencer.
+Starts the sequencer if it was previously stopped. This allows the node to begin producing new blocks.
 
 <Tabs>
   <Tab title="curl">
@@ -930,13 +918,17 @@ Starts the sequencer.
 
 Sample success output:
 
-```
-todo: add Sample success output
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": null
+}
 ```
 
-#### `admin_stopSequencer`
+### admin_stopSequencer
 
-Stops sequencer.
+Stops the sequencer, preventing it from producing new blocks. The node will continue to sync from other sequencers.
 
 <Tabs>
   <Tab title="curl">
@@ -955,13 +947,17 @@ Stops sequencer.
 
 Sample success output:
 
-```
-todo: add Sample success output
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": null
+}
 ```
 
-#### `admin_sequencerActive`
+### admin_sequencerActive
 
-Returns the status of the sequencer. This endpoint provides real-time information about whether the sequencer is actively processing transactions.
+Returns whether the sequencer is currently active and producing blocks.
 
 <Tabs>
   <Tab title="curl">
@@ -973,35 +969,17 @@ Returns the status of the sequencer. This endpoint provides real-time informatio
   </Tab>
   <Tab title="cast">
     ```sh
-    cast rpc admin_sequencerActive [] --rpc-url http://localhost:9545
+    cast rpc admin_sequencerActive --rpc-url http://localhost:9545
     ```
   </Tab>
 </Tabs>
 
 Sample success output:
 
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": true
+}
 ```
-todo: add Sample success output
-```
-
-## Execution clients
-
-The OP Stack supports multiple execution client implementations. Each client implements the execution layer with minimal changes for a secure Ethereum-equivalent application environment.
-
-<Tabs>
-  <Tab title="op-geth">
-    ### op-geth
-
-    `op-geth` is the original execution client for the OP Stack, based on the Go Ethereum (Geth) implementation.
-    
-    The execution engine's RPC interface is identical to [the upstream Geth RPC interface](https://geth.ethereum.org/docs/interacting-with-geth/rpc). The responses are nearly identical too, except we also include the L1 gas usage and price information.
-  </Tab>
-  <Tab title="Nethermind">
-    ### Nethermind
-
-    `Nethermind` is a high-performance execution client implementation written in C#. The `Nethermind` client has been adapted to support OP Stack chains, providing an alternative execution client option for node operators.
-    
-    The execution engine's RPC interface is identical to [the upstream `Nethermind` RPC interface](https://docs.nethermind.io/interacting/json-rpc-server/). The responses are nearly identical too, except we also include the L1 gas usage and price information.
-  </Tab>
-</Tabs>
-


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->


1. Rename the old JSON-RPC to op-node JSON-RPC(as is most for the op-node's RPC)
2. Add Geth's JSON-RPC into op-geth JSON-RPC, and declare the key difference between Optimism and Ethereum


**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

Now the tab looks like below:

<img width="278" height="125" alt="image" src="https://github.com/user-attachments/assets/eaf38a32-e407-441a-86b0-b6a17182a7f8" />


**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
