### PR TITLE
Improve Actions SDK Config sample code

### DIFF
--- a/app-developers/guides/configuring-actions.mdx
+++ b/app-developers/guides/configuring-actions.mdx
@@ -24,6 +24,8 @@ Actions SDK lets you choose which assets, markets, chains, protocols, and provid
 
     <Tabs>
       <Tab title="Frontend">
+        Select a wallet provider:
+
         <Tabs>
           <Tab title="Privy">
             ```typescript title="actions.ts"
@@ -80,6 +82,8 @@ Actions SDK lets you choose which assets, markets, chains, protocols, and provid
       </Tab>
 
       <Tab title="Backend">
+        Select a wallet provider:
+
         <Tabs>
           <Tab title="Privy">
             ```typescript title="actions.ts"

--- a/app-developers/guides/configuring-actions.mdx
+++ b/app-developers/guides/configuring-actions.mdx
@@ -23,62 +23,121 @@ Actions SDK lets you choose which assets, markets, chains, protocols, and provid
     Let Actions SDK know which Wallet Provider you've chosen:
 
     <Tabs>
-      <Tab title="Privy">
-        ```typescript title="actions.ts"
-        import type { WalletConfig } from "@eth-optimism/actions-sdk";
-
-        const walletConfig: WalletConfig = {
-          hostedWalletConfig: {
-            provider: {
-              type: "privy",
-            },
-          },
-          smartWalletConfig: {
-            provider: {
-              type: "default",
-              attributionSuffix: "actions",
-            },
-          },
-        };
-        ```
+      <Tab title="Frontend">
+        <Tabs>
+          <Tab title="Privy">
+            ```typescript title="actions.ts"
+            const walletConfig = {
+              hostedWalletConfig: {
+                provider: {
+                  type: "privy" as const,
+                },
+              },
+              smartWalletConfig: {
+                provider: {
+                  type: "default" as const,
+                  attributionSuffix: "actions",
+                },
+              },
+            };
+            ```
+          </Tab>
+          <Tab title="Turnkey">
+            ```typescript title="actions.ts"
+            const walletConfig = {
+              hostedWalletConfig: {
+                provider: {
+                  type: "turnkey" as const,
+                },
+              },
+              smartWalletConfig: {
+                provider: {
+                  type: "default" as const,
+                  attributionSuffix: "actions",
+                },
+              },
+            };
+            ```
+          </Tab>
+          <Tab title="Dynamic">
+            ```typescript title="actions.ts"
+            const walletConfig = {
+              hostedWalletConfig: {
+                provider: {
+                  type: "dynamic" as const,
+                },
+              },
+              smartWalletConfig: {
+                provider: {
+                  type: "default" as const,
+                  attributionSuffix: "actions",
+                },
+              },
+            };
+            ```
+          </Tab>
+        </Tabs>
       </Tab>
-      <Tab title="Turnkey">
-        ```typescript title="actions.ts"
-        import type { WalletConfig } from "@eth-optimism/actions-sdk";
 
-        const walletConfig: WalletConfig = {
-          hostedWalletConfig: {
-            provider: {
-              type: "turnkey",
-            },
-          },
-          smartWalletConfig: {
-            provider: {
-              type: "default",
-              attributionSuffix: "actions",
-            },
-          },
-        };
-        ```
-      </Tab>
-      <Tab title="Dynamic">
-        ```typescript title="actions.ts"
-        import type { WalletConfig } from "@eth-optimism/actions-sdk";
+      <Tab title="Backend">
+        <Tabs>
+          <Tab title="Privy">
+            ```typescript title="actions.ts"
+            import { PrivyClient } from '@privy-io/node'
 
-        const walletConfig: WalletConfig = {
-          hostedWalletConfig: {
-            provider: {
-              type: "dynamic",
-            },
-          },
-          smartWalletConfig: {
-            provider: {
-              type: "default",
-              attributionSuffix: "actions",
-            },
-          },
-        };
-        ```
+            const privyClient = new PrivyClient(
+              process.env.PRIVY_APP_ID,
+              process.env.PRIVY_APP_SECRET,
+            )
+
+            const walletConfig = {
+              hostedWalletConfig: {
+                provider: {
+                  type: "privy" as const,
+                  config: {
+                    privyClient,
+                  },
+                },
+              },
+              smartWalletConfig: {
+                provider: {
+                  type: "default" as const,
+                  attributionSuffix: "actions",
+                },
+              },
+            };
+            ```
+          </Tab>
+          <Tab title="Turnkey">
+            ```typescript title="actions.ts"
+            import { Turnkey } from '@turnkey/sdk-server'
+
+            const turnkeyClient = new Turnkey({
+              apiBaseUrl: 'https://api.turnkey.com',
+              apiPublicKey: process.env.TURNKEY_API_KEY,
+              apiPrivateKey: process.env.TURNKEY_API_SECRET,
+              defaultOrganizationId: process.env.TURNKEY_ORGANIZATION_ID,
+            })
+
+            const walletConfig = {
+              hostedWalletConfig: {
+                provider: {
+                  type: "turnkey" as const,
+                  config: {
+                    client: turnkeyClient.apiClient(),
+                  },
+                },
+              },
+              smartWalletConfig: {
+                provider: {
+                  type: "default" as const,
+                  attributionSuffix: "actions",
+                },
+              },
+            };
+            ```
+          </Tab>
+        </Tabs>
       </Tab>
     </Tabs>
 

--- a/app-developers/quickstarts/actions.mdx
+++ b/app-developers/quickstarts/actions.mdx
@@ -59,11 +59,13 @@ Actions works with both frontend and backend wallets depending on your needs:
 
     <Tabs>
       <Tab title="Privy">
-        Install and setup [Privy](https://docs.privy.io/basics/react/installation).
+        **Set Up Privy**
+
+        Sign up for Privy and follow the full Privy installation [guide](https://docs.privy.io/basics/react/installation).
 
         **Configure Wallet Provider**
 
-        Give your embedded wallets the ability to take Action:
+        Once you have set up Privy embedded wallets, pass them to Actions SDK:
 
         ```typescript
         import { actions } from './config'
@@ -108,11 +110,13 @@ Actions works with both frontend and backend wallets depending on your needs:
       </Tab>
 
       <Tab title="Turnkey">
-        Install and setup [Turnkey](https://docs.turnkey.com/sdks/react/getting-started).
+        **Set Up Turnkey**
+
+        Sign up for Turnkey and follow the full Turnkey installation [guide](https://docs.turnkey.com/sdks/react/getting-started).
 
         **Configure Wallet Provider**
 
-        Give your embedded wallets the ability to take Action:
+        Once you have set up Turnkey embedded wallets, pass them to Actions SDK:
 
         ```typescript
         import { useTurnkey, WalletSource } from "@turnkey/react-wallet-kit"
@@ -177,11 +181,13 @@ Actions works with both frontend and backend wallets depending on your needs:
       </Tab>
 
       <Tab title="Dynamic">
-        Install and setup [Dynamic](https://www.dynamic.xyz/docs/wallets/embedded-wallets/mpc/setup).
+        **Set Up Dynamic**
+
+        Sign up for Dynamic and follow the full Dynamic installation [guide](https://www.dynamic.xyz/docs/wallets/embedded-wallets/mpc/setup).
 
         **Configure Wallet Provider**
 
-        Give your embedded wallets the ability to take Action:
+        Once you have set up Dynamic embedded wallets, pass them to Actions SDK:
 
         ```typescript
         import { useDynamicContext } from "@dynamic-labs/sdk-react-core"
@@ -234,11 +240,13 @@ Actions works with both frontend and backend wallets depending on your needs:
 
     <Tabs>
       <Tab title="Privy">
-        Install and setup [Privy](https://docs.privy.io/basics/nodeJS/installation).
+        **Set Up Privy**
+
+        Sign up for Privy and follow the full Privy installation [guide](https://docs.privy.io/basics/nodeJS/installation).
 
         **Configure Wallet Provider**
 
-        Give your embedded wallets the ability to take Action:
+        Once you have set up Privy embedded wallets, pass them to Actions SDK:
 
         ```typescript
         import { actions } from './config'
@@ -290,11 +298,13 @@ Actions works with both frontend and backend wallets depending on your needs:
       </Tab>
 
       <Tab title="Turnkey">
-        Install and setup [Turnkey](https://docs.turnkey.com/sdks/javascript-server).
+        **Set Up Turnkey**
+
+        Sign up for Turnkey and follow the full Turnkey installation [guide](https://docs.turnkey.com/sdks/javascript-server).
 
         **Configure Wallet Provider**
 
-        Give your embedded wallets the ability to take Action:
+        Once you have set up Turnkey embedded wallets, pass them to Actions SDK:
 
         ```typescript
         import { Turnkey } from '@turnkey/sdk-server'


### PR DESCRIPTION
## Problem

The `ActionsConfig` wallet provider set up example is not currently accurate.

## Solution

- [x] Add backend WalletProvider client to ActionsConfig step for Privy and Turnkey
- [x] Improve wording for provider sign up step