### PR TITLE
added operator_fee_vault_recipient chain_fees_fee_recipient to role addresses

### DIFF
--- a/create-l2-rollup-example/scripts/setup-rollup.sh
+++ b/create-l2-rollup-example/scripts/setup-rollup.sh
@@ -73,7 +73,7 @@ generate_addresses() {
     log_info "Changed to directory: $(pwd)"
 
     # Generate addresses for different roles using openssl
-    for role in admin base_fee_vault_recipient l1_fee_vault_recipient sequencer_fee_vault_recipient system_config unsafe_block_signer batcher proposer challenger; do
+    for role in admin base_fee_vault_recipient l1_fee_vault_recipient sequencer_fee_vault_recipient system_config unsafe_block_signer operator_fee_vault_recipient chain_fees_fee_recipient batcher proposer challenger ; do
         # Generate a random 32-byte private key, ensuring it's not zero
         private_key=""
         while [ -z "$private_key" ] || [ "$private_key" = "0000000000000000000000000000000000000000000000000000000000000000" ]; do


### PR DESCRIPTION
**Description**
**Tested on:** `op-deployer version 0.6.0-rc.3-28a63ff7-2026-01-15T19:40:35Z`

In the `setup-rollup.sh` script,
When creating wallet addresses for roles using this piece of code

```
for role in admin base_fee_vault_recipient l1_fee_vault_recipient sequencer_fee_vault_recipient system_config unsafe_block_signer batcher proposer challenger; do
        # Generate a random 32-byte private key, ensuring it's not zero
        private_key=""
        while [ -z "$private_key" ] || [ "$private_key" = "0000000000000000000000000000000000000000000000000000000000000000" ]; do
            private_key=$(openssl rand -hex 32)
        done  
```

No addresses were created for **operatorFeeVaultRecipient** and **chainFeesRecipient**, which means when the `intent.toml` files were created, operatorFeeVaultRecipient and chainFeesRecipient had zero addresses.


**Tests**

When deploying the L1 contracts with
```
op-deployer apply \
  --workdir .deployer \
  --l1-rpc-url $L1_RPC_URL \
  --private-key $PRIVATE_KEY
```

Would give you the below error
`Application failed: failed to validate intent-type=standard-overrides: chain has a fee vault set to zero address: chainId=0x00000000000000000000000000000000000000000000000000000000000007e9`

**Solution**

Add  `operator_fee_vault_recipient chain_fees_fee_recipient` to the wallet address creation forloop`


`for role in admin base_fee_vault_recipient l1_fee_vault_recipient sequencer_fee_vault_recipient system_config unsafe_block_signer operator_fee_vault_recipient chain_fees_fee_recipient batcher proposer challenger`

**Result**

```
op-deployer apply \
  --workdir .deployer \
  --l1-rpc-url $L1_RPC_URL \
  --private-key $PRIVATE_KEY
INFO [01-28|13:20:52.399] Load database journal from disk
INFO [01-28|13:20:52.399] State snapshot generator is not found
INFO [01-28|13:20:52.399] Initialized path database                readonly=true triecache=16.00MiB statecache=16.00MiB buffer=0.00B state-history="entire chain"
INFO [01-28|13:20:52.457] initializing pipeline                    stage=init strategy=live
INFO [01-28|13:20:53.214] superchain deployment not needed         stage=deploy-superchain
INFO [01-28|13:20:53.215] implementations deployment not needed    stage=deploy-implementations
INFO [01-28|13:20:53.216] deploying OP chain using local allocs    stage=deploy-opchain id=0x00000000000000000000000000000000000000000000000000000000000007e9
INFO [01-28|13:20:55.789] Running chain assertions on the DisputeGameFactory proxy at 0x7388BD5AA641e0216c992c8d72e480250Ab32d00 sender=0xf6304C2d6Bb2d94b12343E89283742b7bd6ad14B
INFO [01-28|13:20:55.799] Running chain assertions on the L1CrossDomainMessenger proxy at 0x4e8243FF0908F7E8F202C0D6017B8364F456d059 sender=0xf6304C2d6Bb2d94b12343E89283742b7bd6ad14B
```