### PR TITLE
Fix missing fee vault recipients in rollup setup

### DIFF
--- a/create-l2-rollup-example/scripts/setup-rollup.sh
+++ b/create-l2-rollup-example/scripts/setup-rollup.sh
@@ -130,6 +130,8 @@ update_intent() {
     BATCHER_ADDR=$(cat addresses/batcher_address.txt)
     PROPOSER_ADDR=$(cat addresses/proposer_address.txt)
     CHALLENGER_ADDR=$(cat addresses/challenger_address.txt)
+    OPERATOR_FEE_VAULT_ADDR=$(cat addresses/operator_fee_vault_recipient_address.txt)
+    CHAIN_FEES_RECIPIENT_ADDR=$(cat addresses/chain_fees_fee_recipient_address.txt)
 
     # Keep the default contract locators and opcmAddress from op-deployer init
 
@@ -145,7 +147,8 @@ update_intent() {
     sed -i.bak "s|proposer = .*|proposer = \"$PROPOSER_ADDR\"|" .deployer/intent.toml
     sed -i.bak "s|challenger = .*|challenger = \"$CHALLENGER_ADDR\"|" .deployer/intent.toml
     sed -i.bak "s|fundDevAccounts = .*|fundDevAccounts = true|" .deployer/intent.toml
-
+    sed -i.bak "s|operatorFeeVaultRecipient = .*|operatorFeeVaultRecipient = \"$OPERATOR_FEE_VAULT_ADDR\"|" .deployer/intent.toml
+    sed -i.bak "s|chainFeesRecipient = .*|chainFeesRecipient = \"$CHAIN_FEES_RECIPIENT_ADDR\"|" .deployer/intent.toml
     log_success "Intent configuration updated"
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Fix create-l2-rollup-example/scripts/setup-rollup.sh to populate operatorFeeVaultRecipient and chainFeesRecipient in intent.toml.
This prevents op-deployer from failing with “chain has a fee vault set to zero address” during make setup.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
