### PR TITLE
fix: correct max-blocks-per-span-batch description and syntax examples

### DIFF
--- a/chain-operators/guides/configuration/batcher.mdx
+++ b/chain-operators/guides/configuration/batcher.mdx
@@ -172,15 +172,12 @@ See the [span batch feature page](/op-stack/features/span-batches) to learn more
 
 #### max-blocks-per-span-batch
 
-Indicates how many blocks back the batcher should look during startup for a
-recent batch tx on L1. This can speed up waiting for node sync. It should be
-set to the verifier confirmation depth of the sequencer (e.g. 4). The default
-value is `0`.
+Maximum number of blocks to add to a span batch. The default value is `0` (no maximum).
 
 <Tabs>
-  <Tab title="Syntax">`--check-recent-txs-depth=<value>`</Tab>
-  <Tab title="Example">`--check-recent-txs-depth=0`</Tab>
-  <Tab title="Environment Variable">`OP_BATCHER_CHECK_RECENT_TXS_DEPTH=0`</Tab>
+  <Tab title="Syntax">`--max-blocks-per-span-batch=<value>`</Tab>
+  <Tab title="Example">`--max-blocks-per-span-batch=0`</Tab>
+  <Tab title="Environment Variable">`OP_BATCHER_MAX_BLOCKS_PER_SPAN_BATCH=0`</Tab>
 </Tabs>
 
 #### compression-algo


### PR DESCRIPTION
Fixes #1933

The `max-blocks-per-span-batch` section had the description and syntax examples 
of `check-recent-txs-depth`. Replaced with the correct description and examples 
from the source code.
