### PR TITLE
feat: Add JAW.id to account abstraction tools

### DIFF
--- a/app-developers/tools/account-abstraction.mdx
+++ b/app-developers/tools/account-abstraction.mdx
@@ -47,7 +47,9 @@ Ready to enable account abstraction experiences in your app? Here's some helpful
 *   [Stackup](https://docs.stackup.sh/docs): provides smart account tooling for building account abstraction within your apps. They offer Paymaster and Bundler APIs for sponsoring gas and sending account abstraction transactions.
 
 *   [thirdweb](https://portal.thirdweb.com/react/v5/account-abstraction/get-started?utm_source=opdocs&utm_medium=docs):
-    offers the complete tool-kit to leverage account abstraction technology to enable seamless user experiences for your users. This includes Account Factory contracts that lets your users spin up Smart Accounts, Bundler for UserOps support, and Paymaster to enable gas sponsorships. 
+    offers the complete tool-kit to leverage account abstraction technology to enable seamless user experiences for your users. This includes Account Factory contracts that lets your users spin up Smart Accounts, Bundler for UserOps support, and Paymaster to enable gas sponsorships.
+
+*   [JAW.id](https://jaw.id): a drop-in smart account solution for dApps, integrates via a standard EIP-1193 provider and wagmi connector, with no custom bundler or paymaster wiring required. Brings identity-first infrastructure: passkey authentication, ENS-native identity, programmable session keys, and AI agent delegation.
 
 ## Helpful tips
 


### PR DESCRIPTION
 **Description**                                                                                                      
   
  Add JAW.id to the account abstraction tools section. JAW.id is a drop-in smart account solution that integrates via  
  standard EIP-1193 provider and wagmi connector, with identity-first infrastructure including passkey authentication,
  ENS-native identity, programmable session keys, and AI agent delegation.

  **Tests**

  No tests needed, documentation-only change.

  **Additional context**

  None.

  **Metadata**

  None.