### PR TITLE
Remove op-erigon from docs

### DIFF
--- a/node-operators/guides/management/archive-node.mdx
+++ b/node-operators/guides/management/archive-node.mdx
@@ -64,7 +64,7 @@ Archive sync can be enabled by using the archive configuration for your network 
 
 ## Archive mode with alternative clients
 
-Alternative execution clients such as `reth` and `op-erigon` are designed as archive nodes by default, which means they always maintain the complete history of the chain. When using these clients with execution-layer sync, they will automatically operate in archive mode.
+Alternative execution clients such as `reth` are designed as archive nodes by default, which means they always maintain the complete history of the chain. When using these clients with execution-layer sync, they will automatically operate in archive mode.
 
 ### Configuration for op-node with reth
 
@@ -77,19 +77,6 @@ Set the following flags on `op-node`:
 
 <Info>
   Both flags are not the default setting and must be explicitly configured on `op-node`. `reth` operates as an archive node by default.
-</Info>
-
-### Configuration for op-node with op-erigon
-
-Set the following flags on `op-node`:
-
-```shell
---syncmode=execution-layer
---l2.enginekind=erigon
-```
-
-<Info>
-  Both flags are not the default setting and must be explicitly configured on `op-node`. `op-erigon` operates as an archive node by default.
 </Info>
 
 ## How archive sync works

--- a/node-operators/guides/management/snap-sync.mdx
+++ b/node-operators/guides/management/snap-sync.mdx
@@ -47,7 +47,7 @@ The following flag is the default setting for `op-geth` to enable snap sync, so 
 
 In addition to `op-geth` and `Nethermind`, you can enable execution-layer syncing with alternative execution clients such as `reth` and `op-erigon`.
 
-Unlike `op-geth` and `Nethermind`, `reth` and `op-erigon` are designed as archive nodes, which means they require the complete history of the chain.
+Unlike `op-geth` and `Nethermind` and `reth` are designed as archive nodes, which means they require the complete history of the chain.
 However, these clients can still retrieve block headers and data through the P2P network instead of deriving each individual block, resulting in a faster initial sync.
 
 For OP Mainnet, the [bedrock datadir](/node-operators/guides/management/snapshots) is required. For other OP Stack networks, no datadir is required.
@@ -59,19 +59,6 @@ Set the following flags on `op-node`:
 ```shell
 --syncmode=execution-layer
 --l2.enginekind=reth
-```
-
-<Info>
-  Both flags are not the default setting and must be explicitly configured on `op-node`.
-</Info>
-
-### Configuration for op-node with op-erigon
-
-Set the following flags on `op-node`:
-
-```shell
---syncmode=execution-layer
---l2.enginekind=erigon
 ```
 
 <Info>

--- a/node-operators/reference/features/snap-sync.mdx
+++ b/node-operators/reference/features/snap-sync.mdx
@@ -46,7 +46,6 @@ Snap Sync is supported by the following execution clients:
 *   **op-geth**: Native snap sync support with `--syncmode=snap` (enabled by default)
 *   **Nethermind**: Native snap sync support with `--Sync.SnapSync=true`
 *   **reth**: Execution-layer sync support (archive mode)
-*   **op-erigon**: Execution-layer sync support (archive mode)
 
 ## Network requirements
 

--- a/node-operators/reference/op-node-config.mdx
+++ b/node-operators/reference/op-node-config.mdx
@@ -202,7 +202,7 @@ Path to JWT secret key. Keys are 32 bytes, hex encoded in a file. A new key will
 
 ### l2.enginekind
 
-The kind of engine client, used to control the behavior of optimism in respect to different types of engine clients. Valid options: `geth`, `reth`, `erigon`. The default value is `geth`.
+The kind of engine client, used to control the behavior of optimism in respect to different types of engine clients. Valid options: `geth`, `reth`. The default value is `geth`.
 
 <Tabs>
   <Tab title="Syntax">`--l2.enginekind=<value>`</Tab>


### PR DESCRIPTION

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Sunnyside Labs archived op-erigon as of April 1st as the ecosystem moves towards reth.

This PR removes references of op-erigon in the optimism docs. 
